### PR TITLE
fix: set default label for PARTIALLY_ADDRESSED close status

### DIFF
--- a/components/core/update-ask-status-dialog/helpers.ts
+++ b/components/core/update-ask-status-dialog/helpers.ts
@@ -61,10 +61,10 @@ export const REASON_OPTIONS = [
 
 export function getDependantLabel(reason: string) {
   switch (reason) {
-    case AskCloseReasons.FULLY_ADDRESSED:
     case AskCloseReasons.PARTIALLY_ADDRESSED: {
       return "What's left unresolved?*";
     }
+    case AskCloseReasons.FULLY_ADDRESSED:
     case AskCloseReasons.NO_LONGER_NEEDED:
     case AskCloseReasons.UNADRESSABLE:
     case AskCloseReasons.DUPLICATE: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bf80a475-8b09-445a-9704-c77e64637147)
