### PR TITLE
Add analytics tracking for recommendation email profile links

### DIFF
--- a/analytics/members.analytics.ts
+++ b/analytics/members.analytics.ts
@@ -273,63 +273,61 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_LIST_CLOSE_FILTER_PANEL_CLICKED, params);
   }
 
-  function onMemberEditBySelf(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null,) {
+  function onMemberEditBySelf(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null) {
     const params = {
       user,
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_EDIT_BY_SELF, params);
   }
 
-  function onMemberEditByAdmin(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null,) {
+  function onMemberEditByAdmin(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null) {
     const params = {
       user,
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_EDIT_BY_ADMIN, params);
   }
 
-  
-  function onMemberDetailsBioReadMoreClicked(member: IAnalyticsMemberInfo | null,) {
+  function onMemberDetailsBioReadMoreClicked(member: IAnalyticsMemberInfo | null) {
     const params = {
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_READ_MORE_CLICKED, params);
   }
 
-  
-  function onMemberDetailsBioReadLessClicked(member: IAnalyticsMemberInfo | null,) {
+  function onMemberDetailsBioReadLessClicked(member: IAnalyticsMemberInfo | null) {
     const params = {
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_READ_LESS_CLICKED, params);
   }
 
-  function onMemberDetailsBioEditClicked(member: IAnalyticsMemberInfo | null,user: IAnalyticsUserInfo | null) {
+  function onMemberDetailsBioEditClicked(member: IAnalyticsMemberInfo | null, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_EDIT_CLICKED, params);
   }
 
-  function onMemberDetailsBioEditCancelClicked(member: IAnalyticsMemberInfo | null,user: IAnalyticsUserInfo | null) {
+  function onMemberDetailsBioEditCancelClicked(member: IAnalyticsMemberInfo | null, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_EDIT_CANCEL_CLICKED, params);
   }
 
-  function onMemberDetailsBioEditSaveClicked(member: IAnalyticsMemberInfo | null,user: IAnalyticsUserInfo | null) {
+  function onMemberDetailsBioEditSaveClicked(member: IAnalyticsMemberInfo | null, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      ...member
+      ...member,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_EDIT_SAVE_CLICKED, params);
   }
 
-  function recordBioSave(type: string,member: IAnalyticsMemberInfo | null, user: IAnalyticsUserInfo | null, payload?: any){
+  function recordBioSave(type: string, member: IAnalyticsMemberInfo | null, user: IAnalyticsUserInfo | null, payload?: any) {
     const params = {
       type,
       user,
@@ -339,21 +337,21 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BIO_EDIT_RECORD_SAVE, params);
   }
 
-  function onClickSeeMoreIrlContribution(user: IAnalyticsUserInfo | null){
+  function onClickSeeMoreIrlContribution(user: IAnalyticsUserInfo | null) {
     const params = {
       user,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.ON_CLICK_SEE_MORE_BUTTON_IRL_CONTRIBUTIONS, params);
   }
 
-  function onClickEventIrlContribution(user: IAnalyticsUserInfo | null){
+  function onClickEventIrlContribution(user: IAnalyticsUserInfo | null) {
     const params = {
       user,
     };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAILS_ON_CLICK_IRL_CONTRIBUTIONS, params);
   }
 
-  function onEditExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null,experience: any,status: string) {
+  function onEditExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null, experience: any, status: string) {
     const params = {
       user,
       ...member,
@@ -363,7 +361,7 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_EDIT_EXPERIENCE_SAVE_CLICKED, params);
   }
 
-  function onAddExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null,experience: any,status: string) {
+  function onAddExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null, experience: any, status: string) {
     const params = {
       user,
       ...member,
@@ -373,14 +371,23 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_ADD_EXPERIENCE_SAVE_CLICKED, params);
   }
 
-  function onDeleteExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null,experience: any,status: string) {
+  function onDeleteExperienceSaveClicked(user: IAnalyticsUserInfo | null, member: IAnalyticsMemberInfo | null, experience: any, status: string) {
     const params = {
       user,
       ...member,
       experience,
       status,
-    };  
+    };
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_DELETE_EXPERIENCE_SAVE_CLICKED, params);
+  }
+
+  function onOpenProfileByRecommendationEmailLink(utmSource: string, utmMedium: string, utmCode: string, targetId: string) {
+    captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAILS_BY_RECOMMENDATION_EMAIL_LINK, {
+      utmSource,
+      utmMedium,
+      utmCode,
+      targetId,
+    });
   }
 
   return {
@@ -425,6 +432,7 @@ export const useMemberAnalytics = () => {
     onAddExperienceClicked,
     onEditExperienceSaveClicked,
     onAddExperienceSaveClicked,
-    onDeleteExperienceSaveClicked
+    onDeleteExperienceSaveClicked,
+    onOpenProfileByRecommendationEmailLink,
   };
 };

--- a/components/page/member-details/member-detail-header.tsx
+++ b/components/page/member-details/member-detail-header.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Fragment, useEffect } from 'react';
 import { useDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import { useRecommendationLinkAnalyticsReport } from '@/services/members/hooks/useRecommendationLinkAnalyticsReport';
 
 interface IMemberDetailHeader {
   member: IMember;
@@ -42,6 +43,8 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
   const defaultAvatarImage = useDefaultAvatar(member?.name);
   const profile = member?.profile ?? defaultAvatarImage;
   const analytics = useMemberAnalytics();
+
+  useRecommendationLinkAnalyticsReport();
 
   const onEditProfileClick = () => {
     if (isOwner) {

--- a/services/members/hooks/useRecommendationLinkAnalyticsReport.ts
+++ b/services/members/hooks/useRecommendationLinkAnalyticsReport.ts
@@ -1,0 +1,25 @@
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { useMemberAnalytics } from '@/analytics/members.analytics';
+
+export function useRecommendationLinkAnalyticsReport() {
+  const reportRef = useRef<boolean>(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const utmSource = searchParams.get('utm_source');
+  const utmMedium = searchParams.get('utm_medium') ?? '';
+  const utmCode = searchParams.get('utm_code') ?? '';
+  const targetId = searchParams.get('target_uid') ?? '';
+
+  const analytics = useMemberAnalytics();
+
+  useEffect(() => {
+    if (!reportRef.current && utmSource === 'recommendations') {
+      reportRef.current = true;
+      analytics.onOpenProfileByRecommendationEmailLink(utmSource, utmMedium, utmCode, targetId);
+
+      router.replace(pathname);
+    }
+  }, [analytics, pathname, router, targetId, utmCode, utmMedium, utmSource]);
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -376,6 +376,8 @@ export const MEMBER_ANALYTICS_EVENTS = {
   MEMBER_DETAIL_EDIT_EXPERIENCE_SAVE_CLICKED: 'member_detail_edit_experience_save_clicked',
   MEMBER_DETAIL_ADD_EXPERIENCE_SAVE_CLICKED: 'member_detail_add_experience_save_clicked',
   MEMBER_DETAIL_DELETE_EXPERIENCE_SAVE_CLICKED: 'member_detail_delete_experience_save_clicked',
+
+  MEMBER_DETAILS_BY_RECOMMENDATION_EMAIL_LINK: 'member-details-by-recommendation-email-link',
 };
 
 export const UNIFIED_SEARCH_ANALYTICS_EVENTS = {


### PR DESCRIPTION
This commit introduces a new hook, `useRecommendationLinkAnalyticsReport`, to track user interactions when accessing a member's profile via recommendation email links. The related analytics event and constants were also added to ensure accurate reporting. Additionally, minor code formatting improvements were made.