### PR TITLE
Reset focus state on search close

### DIFF
--- a/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
+++ b/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
@@ -41,6 +41,7 @@ export const AppSearchDesktop = ({ isLoggedIn, userInfo, authToken }: Props) => 
     setInitialAiPrompt('');
     setSearchTerm('');
     setShowFullSearch(false);
+    setFocused(false);
   }, []);
 
   const handleInputClickOutside = useCallback(

--- a/services/search/hooks/useApplicationSearch.ts
+++ b/services/search/hooks/useApplicationSearch.ts
@@ -3,6 +3,7 @@ import { SearchQueryKeys } from '@/services/search/constants';
 import { SearchResult } from '@/services/search/types';
 import { getCookiesFromClient } from '@/utils/third-party.helper';
 import { useUnifiedSearchAnalytics } from '@/analytics/unified-search.analytics';
+import { saveRecentSearch } from '@/services/search/hooks/useRecentSearch';
 
 async function fetcher(searchTerm: string) {
   const { authToken } = getCookiesFromClient();
@@ -16,6 +17,7 @@ async function fetcher(searchTerm: string) {
 
   if (response?.ok) {
     const result: SearchResult = await response.json();
+    saveRecentSearch(searchTerm);
 
     return result;
   }


### PR DESCRIPTION
Added `setFocused(false)` to ensure the focus state is cleared when the search is closed. This prevents unintended behavior caused by residual focus.