### PR TITLE
Replace `useApplicationSearch` with `useFullApplicationSearch`

### DIFF
--- a/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
+++ b/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
@@ -5,9 +5,7 @@ import Image from 'next/image';
 import s from './AppSearchDesktop.module.scss';
 import { useQueryClient } from '@tanstack/react-query';
 import { SearchQueryKeys } from '@/services/search/constants';
-import { useApplicationSearch } from '@/services/search/hooks/useApplicationSearch';
 import { TryAiSearch } from '@/components/core/application-search/components/TryAiSearch';
-import { TryToSearch } from '@/components/core/application-search/components/TryToSearch';
 import { RecentSearch } from '@/components/core/application-search/components/RecentSearch';
 import { ContentLoader } from '@/components/core/application-search/components/ContentLoader';
 import { NothingFound } from '@/components/core/application-search/components/NothingFound';
@@ -18,8 +16,8 @@ import clsx from 'clsx';
 import { IUserInfo } from '@/types/shared.types';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import { AiConversationHistory } from '@/components/core/application-search/components/AiConversationHistory/AiConversationHistory';
-import { ChatHistory } from '@/components/core/application-search/components/AiChatPanel/components/ChatHistory';
 import { useRouter } from 'next/navigation';
+import { useFullApplicationSearch } from '@/services/search/hooks/useFullApplicationSearch';
 
 interface Props {
   userInfo: IUserInfo;
@@ -98,7 +96,7 @@ export const AppSearchDesktop = ({ isLoggedIn, userInfo, authToken }: Props) => 
   useOnClickOutside([inputRef], handleInputClickOutside);
   useOnClickOutside([fullSearchDialogRef], handleFullSearchClickOutside);
 
-  const { data, isLoading } = useApplicationSearch(searchTerm);
+  const { data, isLoading } = useFullApplicationSearch(searchTerm);
 
   const isOpen = isFocused; //  || !!data;
 

--- a/components/core/application-search/components/AppSearchMobile/AppSearchMobile.tsx
+++ b/components/core/application-search/components/AppSearchMobile/AppSearchMobile.tsx
@@ -4,18 +4,16 @@ import Image from 'next/image';
 import s from './AppSearchMobile.module.scss';
 import { SearchModeToggle } from '@/components/core/application-search/components/SearchModeToggle';
 import { DebouncedInput } from '@/components/core/application-search/components/DebouncedInput';
-import { useApplicationSearch } from '@/services/search/hooks/useApplicationSearch';
 import { TryAiSearch } from '@/components/core/application-search/components/TryAiSearch';
-import { TryToSearch } from '@/components/core/application-search/components/TryToSearch';
 import { RecentSearch } from '@/components/core/application-search/components/RecentSearch';
 import { ContentLoader } from '@/components/core/application-search/components/ContentLoader';
 import { NothingFound } from '@/components/core/application-search/components/NothingFound';
-import { clsx } from 'clsx';
 import { SearchResultsSection } from '@/components/core/application-search/components/SearchResultsSection';
 import { FullSearchResults } from '@/components/core/application-search/components/FullSearchResults';
 import { AiChatPanel } from '@/components/core/application-search/components/AiChatPanel';
 import { IUserInfo } from '@/types/shared.types';
 import { AiConversationHistory } from '@/components/core/application-search/components/AiConversationHistory/AiConversationHistory';
+import { useFullApplicationSearch } from '@/services/search/hooks/useFullApplicationSearch';
 
 interface Props {
   userInfo: IUserInfo;
@@ -28,7 +26,7 @@ export const AppSearchMobile = ({ isLoggedIn, userInfo, authToken }: Props) => {
   const [mode, setMode] = useState<'regular' | 'ai'>('regular');
   const [searchTerm, setSearchTerm] = useState('');
   const [isFocused, setFocused] = useState(true);
-  const { data, isLoading } = useApplicationSearch(searchTerm);
+  const { data, isLoading } = useFullApplicationSearch(searchTerm);
   const [initialAiPrompt, setInitialAiPrompt] = useState('');
 
   const handleClose = useCallback(() => {

--- a/components/core/application-search/components/FullSearchPanel/FullSearchPanel.tsx
+++ b/components/core/application-search/components/FullSearchPanel/FullSearchPanel.tsx
@@ -6,10 +6,10 @@ import { ContentLoader } from '@/components/core/application-search/components/C
 import { NothingFound } from '@/components/core/application-search/components/NothingFound';
 import { SearchResultsSection } from '@/components/core/application-search/components/SearchResultsSection';
 import { FullSearchResults } from '@/components/core/application-search/components/FullSearchResults';
-import { useApplicationSearch } from '@/services/search/hooks/useApplicationSearch';
 
 import s from './FullSearchPanel.module.scss';
 import { useUnifiedSearchAnalytics } from '@/analytics/unified-search.analytics';
+import { useFullApplicationSearch } from '@/services/search/hooks/useFullApplicationSearch';
 
 interface Props {
   initialSearchTerm: string;
@@ -20,7 +20,7 @@ interface Props {
 export const FullSearchPanel = ({ initialSearchTerm, onTryAiSearch, onClose }: Props) => {
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const [isFocused, setFocused] = useState(!initialSearchTerm);
-  const { data, isLoading } = useApplicationSearch(searchTerm);
+  const { data, isLoading } = useFullApplicationSearch(searchTerm);
   const analyticsRef = useRef<boolean>(false);
 
   const analytics = useUnifiedSearchAnalytics();


### PR DESCRIPTION
Updated components to utilize `useFullApplicationSearch` instead of `useApplicationSearch` for search functionality. This improves consistency across desktop, mobile, and full search implementations.