### PR TITLE
fix: dir-176 search dropdown empty state (#856)

### DIFF
--- a/components/core/application-search/components/AiConversationHistory/AiConversationHistory.tsx
+++ b/components/core/application-search/components/AiConversationHistory/AiConversationHistory.tsx
@@ -31,7 +31,7 @@ export const AiConversationHistory = ({ onClick, isLoggedIn }: Props) => {
     const oneMonthAgo = subMonths(now, 1);
     const currentYear = getYear(now);
 
-    return (chats ?? []).slice(0, 5).reduce(
+    return (chats ?? []).slice(0, 3).reduce(
       (
         groups: {
           today: IThread[];
@@ -86,56 +86,63 @@ export const AiConversationHistory = ({ onClick, isLoggedIn }: Props) => {
     return [...fixedKeys, ...yearKeys];
   }, [groupedChats]);
 
+  if (!history?.length) {
+    return null;
+  }
+
   return (
     <>
-      <button
-        className={s.root}
-        onClick={() => {
-          router.push(`/husky/chat`);
-        }}
-        id="application-search-try-ai"
-      >
-        <Image src="/icons/ai-search.svg" alt="Search" width={24} height={24} />
-        Conversation History
-      </button>
-      {!!orderedKeys.length && (
-        <div className={s.list}>
-          {orderedKeys.map((key) =>
-            groupedChats[key as keyof typeof groupedChats]?.length > 0 ? (
-              <React.Fragment key={key}>
-                <div className={s.label}>{key === 'lastWeek' ? 'Last 7 days' : key === 'lastMonth' ? 'Last 30 days' : key === 'today' ? 'Today' : key === 'yesterday' ? 'Yesterday' : key}</div>
-                {groupedChats[key as keyof typeof groupedChats]
-                  .sort((a: IThread, b: IThread) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) // Sort by createdAt (newest first)
-                  .map((chat: IThread) => (
-                    <div
-                      key={chat.threadId}
-                      className={s.query}
-                      onClick={async () => {
-                        const { authToken } = await getUserCredentials(isLoggedIn);
+      <div className={s.root}>
+        <div className={s.label}>AI conversations</div>
+        {!!orderedKeys.length && (
+          <div className={s.list}>
+            {orderedKeys.map((key) =>
+              groupedChats[key as keyof typeof groupedChats]?.length > 0 ? (
+                <React.Fragment key={key}>
+                  {/*<div className={s.label}>{key === 'lastWeek' ? 'Last 7 days' : key === 'lastMonth' ? 'Last 30 days' : key === 'today' ? 'Today' : key === 'yesterday' ? 'Yesterday' : key}</div>*/}
+                  {groupedChats[key as keyof typeof groupedChats]
+                    .sort((a: IThread, b: IThread) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) // Sort by createdAt (newest first)
+                    .map((chat: IThread) => (
+                      <div
+                        key={chat.threadId}
+                        className={s.query}
+                        onClick={async () => {
+                          const { authToken } = await getUserCredentials(isLoggedIn);
 
-                        if (!authToken) {
-                          return;
-                        }
+                          if (!authToken) {
+                            return;
+                          }
 
-                        const thread = await getHuskyThreadById(chat.threadId, authToken);
+                          const thread = await getHuskyThreadById(chat.threadId, authToken);
 
-                        analytics.onAiConversationHistoryClick(thread.title);
+                          analytics.onAiConversationHistoryClick(thread.title);
 
-                        if (!thread) {
-                          return;
-                        }
+                          if (!thread) {
+                            return;
+                          }
 
-                        router.push(`/husky/chat/${thread.threadId}`);
-                      }}
-                    >
-                      {chat.title}
-                    </div>
-                  ))}
-              </React.Fragment>
-            ) : null,
-          )}
-        </div>
-      )}
+                          router.push(`/husky/chat/${thread.threadId}`);
+                        }}
+                      >
+                        {chat.title}
+                      </div>
+                    ))}
+                </React.Fragment>
+              ) : null,
+            )}
+          </div>
+        )}
+        <button
+          className={s.btnText}
+          onClick={() => {
+            router.push(`/husky/chat`);
+            onClick();
+          }}
+          id="application-search-try-ai"
+        >
+          AI Chat History
+        </button>
+      </div>
     </>
   );
 };

--- a/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.module.scss
+++ b/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.module.scss
@@ -23,7 +23,7 @@ $padding-inline: 16px;
   background: #FFF;
   box-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.16), 0 0 1px 0 rgba(15, 23, 42, 0.12), 0 4px 4px 0 rgba(15, 23, 42, 0.04);
 
-  padding: 12px $padding-inline;
+  //padding: 12px $padding-inline;
 }
 
 .divider {

--- a/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
+++ b/components/core/application-search/components/AppSearchDesktop/AppSearchDesktop.tsx
@@ -127,8 +127,8 @@ export const AppSearchDesktop = ({ isLoggedIn, userInfo, authToken }: Props) => 
     if (!searchTerm) {
       return (
         <>
-          {isLoggedIn && <AiConversationHistory onClick={handleTryAiSearch} isLoggedIn={isLoggedIn} />}
-          <RecentSearch onSelect={handleChange} />
+          {isLoggedIn && <RecentSearch onSelect={handleChange} />}
+          {isLoggedIn && <AiConversationHistory onClick={handleFullSearchClose} isLoggedIn={isLoggedIn} />}
         </>
       );
     }
@@ -142,13 +142,13 @@ export const AppSearchDesktop = ({ isLoggedIn, userInfo, authToken }: Props) => 
     }
 
     return (
-      <>
+      <div style={{ padding: '8px 16px' }}>
         <TryAiSearch onClick={handleTryAiSearch} disabled={searchTerm.trim().length === 0} />
         {!!data.teams?.length && <SearchResultsSection title="Teams" items={data.teams} query={searchTerm} onSelect={handleFullSearchClose} />}
         {!!data.members?.length && <SearchResultsSection title="Members" items={data.members} query={searchTerm} onSelect={handleFullSearchClose} />}
         {!!data.projects?.length && <SearchResultsSection title="Projects" items={data.projects} query={searchTerm} onSelect={handleFullSearchClose} />}
         {!!data.events?.length && <SearchResultsSection title="Events" items={data.events} query={searchTerm} onSelect={handleFullSearchClose} />}
-      </>
+      </div>
     );
   }
 

--- a/components/core/application-search/components/AppSearchMobile/AppSearchMobile.tsx
+++ b/components/core/application-search/components/AppSearchMobile/AppSearchMobile.tsx
@@ -63,8 +63,8 @@ export const AppSearchMobile = ({ isLoggedIn, userInfo, authToken }: Props) => {
       if (!searchTerm) {
         return (
           <>
-            {isLoggedIn && <AiConversationHistory onClick={handleTryAiSearch} isLoggedIn={isLoggedIn} />}
-            <RecentSearch onSelect={handleChange} />
+            {isLoggedIn && <RecentSearch onSelect={handleChange} />}
+            {isLoggedIn && <AiConversationHistory onClick={handleClose} isLoggedIn={isLoggedIn} />}
           </>
         );
       }

--- a/components/core/application-search/components/NothingFound/NothingFound.tsx
+++ b/components/core/application-search/components/NothingFound/NothingFound.tsx
@@ -9,12 +9,14 @@ interface Props {
 
 export const NothingFound = ({ onClick }: Props) => {
   return (
-    <button className={s.root} onClick={() => onClick()} id="application-search-nothing-found">
-      <div className={s.content}>
-        <div className={s.title}>Nothing found</div>
-        <div className={s.subtitle}>Try AI Search for more results</div>
-      </div>
-      <Image src="/icons/ai-search.svg" alt="Search" width={24} height={24} />
-    </button>
+    <div style={{ padding: '8px 16px' }}>
+      <button className={s.root} onClick={() => onClick()} id="application-search-nothing-found">
+        <div className={s.content}>
+          <div className={s.title}>Nothing found</div>
+          <div className={s.subtitle}>Try AI Search for more results</div>
+        </div>
+        <Image src="/icons/ai-search.svg" alt="Search" width={24} height={24} />
+      </button>
+    </div>
   );
 };

--- a/components/core/application-search/components/RecentSearch/RecentSearch.module.scss
+++ b/components/core/application-search/components/RecentSearch/RecentSearch.module.scss
@@ -6,8 +6,8 @@ $padding-inline: 16px;
 .root {
   display: flex;
   flex-direction: column;
-  margin-top: 12px;
   gap: 8px;
+  padding: 8px 16px;
 
   .label {
     color: #64748B;
@@ -58,8 +58,8 @@ $padding-inline: 16px;
 
 .divider {
   height: 1px;
-  width: calc(100% + $padding-inline * 2);
-  margin-inline: -$padding-inline;
+  width: 100%;
+  //margin-inline: -$padding-inline;
   margin-block: 8px;
   background: #E2E8F0;
 }

--- a/components/core/application-search/components/RecentSearch/RecentSearch.tsx
+++ b/components/core/application-search/components/RecentSearch/RecentSearch.tsx
@@ -22,7 +22,6 @@ export const RecentSearch = ({ onSelect }: Props) => {
 
   return (
     <>
-      <div className={s.divider} />
       <div className={s.root}>
         <div className={s.label}>Recent</div>
         <ul className={s.list}>
@@ -50,6 +49,7 @@ export const RecentSearch = ({ onSelect }: Props) => {
           ))}
         </ul>
       </div>
+      <div className={s.divider} />
     </>
   );
 };

--- a/components/core/application-search/components/TryAiSearch/TryAiSearch.module.scss
+++ b/components/core/application-search/components/TryAiSearch/TryAiSearch.module.scss
@@ -1,7 +1,25 @@
 @use "styles/mixins";
 @use 'styles/media';
 
+$padding-inline: 16px;
+
 .root {
+  display: flex;
+  flex-direction: column;
+  //margin-top: 12px;
+  gap: 8px;
+  padding: 8px 16px;
+}
+
+.divider {
+  height: 1px;
+  width: calc(100% + $padding-inline * 2);
+  margin-inline: -$padding-inline;
+  margin-block: 8px;
+  background: #E2E8F0;
+}
+
+.btn {
   @include mixins.centralize;
   gap: 8px;
 
@@ -22,12 +40,30 @@
   }
 }
 
+.btnText {
+  @include mixins.centralize;
+  gap: 8px;
+
+  border-radius: 8px;
+  background: #FFF;
+  padding: 10px 8px;
+  height: 40px;
+  width: 100%;
+  color: #427DFF;
+
+  &:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    user-select: none;
+  }
+}
+
 .list {
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding-block: 16px;
+  //padding-block: 16px;
 }
 
 .label {

--- a/components/core/application-search/components/TryAiSearch/TryAiSearch.tsx
+++ b/components/core/application-search/components/TryAiSearch/TryAiSearch.tsx
@@ -5,7 +5,7 @@ import s from './TryAiSearch.module.scss';
 
 export const TryAiSearch = ({ onClick, disabled }: { onClick: () => void; disabled: boolean }) => {
   return (
-    <button className={s.root} onClick={() => onClick()} disabled={disabled} id="application-search-try-ai">
+    <button className={s.btn} onClick={() => onClick()} disabled={disabled} id="application-search-try-ai">
       <Image src="/icons/ai-search.svg" alt="Search" width={24} height={24} />
       Try AI Search for more results
     </button>

--- a/services/search/hooks/useRecentSearch.ts
+++ b/services/search/hooks/useRecentSearch.ts
@@ -5,7 +5,7 @@ export function saveRecentSearch(term: string) {
   try {
     const key = 'recentSearches';
     const existing = JSON.parse(localStorage.getItem(key) || '[]');
-    const updated = [term, ...existing.filter((t: string) => t !== term)].slice(0, 10);
+    const updated = [term, ...existing.filter((t: string) => t !== term)].slice(0, 3);
     localStorage.setItem(key, JSON.stringify(updated));
     window.dispatchEvent(new Event('recent-search-updated'));
   } catch (e) {


### PR DESCRIPTION
* Refactor UI components and update recent search logic

Refactored styles and structure across multiple components for enhanced clarity and consistency. Limited recent searches and conversation history to display a maximum of three entries. Improved padding, alignment, and functionality in buttons and section layouts.

* Reorder components in AppSearchMobile render logic

Adjusted the order of <RecentSearch> and <AiConversationHistory> components to ensure proper rendering flow. Updated the onClick prop of <AiConversationHistory> to use handleClose for improved behavior.