### PR TITLE
fix: update search container height to use unset (#869)

### DIFF
--- a/components/page/projects/FiltersSearch/FiltersSearch.tsx
+++ b/components/page/projects/FiltersSearch/FiltersSearch.tsx
@@ -129,7 +129,7 @@ export const FiltersSearch = (props: Props) => {
           }
 
           .toolbar__left__search-container {
-            height: inherit;
+            height: unset;
             border-radius: 4px;
             //box-shadow: 0px 1px 2px 0px rgba(15, 23, 42, 0.16);
             background: #fff;


### PR DESCRIPTION
Changed the height property from "inherit" to "unset" in the search container's styles. This ensures more predictable behavior and resolves potential styling conflicts.