### PR TITLE
Enable profile completion and subscription widgets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,8 @@ import { getCookiesFromHeaders } from '@/utils/next-helpers';
 import dynamic from 'next/dynamic';
 import { SOCIAL_IMAGE_URL } from '@/utils/constants';
 import QueryProvider from '@/providers/QueryProvider';
+import { SubscribeToRecoomendations } from '@/components/core/navbar/components/SubscribeToRecoomendations';
+import { CompleteYourProfile } from '@/components/core/navbar/components/CompleteYourProfile';
 
 // dynamic components:
 const Loader = dynamic(() => import('../components/core/loader'), { ssr: false });
@@ -59,8 +61,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <StyledJsxRegistry>
           <QueryProvider>
             <header className="layout__header">
-              {/*<SubscribeToRecoomendations userInfo={userInfo} />*/}
-              {/*<CompleteYourProfile userInfo={userInfo} />*/}
+              <SubscribeToRecoomendations userInfo={userInfo} />
+              <CompleteYourProfile userInfo={userInfo} />
               <Navbar isLoggedIn={isLoggedIn} userInfo={userInfo} authToken={authToken} />
             </header>
             <main className="layout__main">{children}</main>

--- a/app/members/[id]/page.tsx
+++ b/app/members/[id]/page.tsx
@@ -15,6 +15,8 @@ import MemberProjectContribution from '@/components/page/member-details/member-p
 import Bio from '@/components/page/member-details/bio';
 import IrlMemberContribution from '@/components/page/member-details/member-irl-contributions';
 import ExperienceList from '@/components/page/member-details/experience/experience-list-card';
+import { SubscribeToRecommendationsWidget } from '@/components/page/member-info/components/SubscribeToRecommendationsWidget';
+import { UpcomingEventsWidget } from '@/components/page/member-info/components/UpcomingEventsWidget';
 // import { SubscribeToRecommendationsWidget } from '@/components/page/member-info/components/SubscribeToRecommendationsWidget';
 // import { UpcomingEventsWidget } from '@/components/page/member-info/components/UpcomingEventsWidget';
 
@@ -69,8 +71,8 @@ const MemberDetails = async ({ params }: { params: any }) => {
           </div>
         )}
       </div>
-      {/*<SubscribeToRecommendationsWidget userInfo={userInfo} />*/}
-      {/*<UpcomingEventsWidget userInfo={userInfo} />*/}
+      <SubscribeToRecommendationsWidget userInfo={userInfo} />
+      <UpcomingEventsWidget userInfo={userInfo} />
     </div>
   );
 };

--- a/components/core/navbar/components/AccountMenu/AccountMenu.tsx
+++ b/components/core/navbar/components/AccountMenu/AccountMenu.tsx
@@ -19,6 +19,8 @@ import { NotificationsMenu } from '@/components/core/navbar/components/Notificat
 import { clsx } from 'clsx';
 import { useRouter } from 'next/navigation';
 import { isNumber } from 'lodash';
+import { useMember } from '@/services/members/hooks/useMember';
+import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 
 interface Props {
   userInfo: IUserInfo;
@@ -34,6 +36,10 @@ export const AccountMenu = ({ userInfo, authToken, isLoggedIn, profileFilledPerc
   const postHogProps = usePostHog();
   const router = useRouter();
   const [showNotifications, setShowNotifications] = useState(false);
+  const { data: member, isLoading } = useMember(userInfo.uid);
+  const [hideCompleteProfile] = useLocalStorageParam('complete_profile_bar', false);
+  const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours && member?.memberInfo.skills.length > 0;
+  const hideProfileStatus = !userInfo || isProfileFilled || hideCompleteProfile || isLoading;
 
   const handleLogout = useCallback(() => {
     clearAllAuthCookies();
@@ -80,7 +86,7 @@ export const AccountMenu = ({ userInfo, authToken, isLoggedIn, profileFilledPerc
                 }}
               >
                 <UserIcon /> {userInfo.name ?? userInfo.email}{' '}
-                {isNumber(profileFilledPercent) && (
+                {!hideProfileStatus && isNumber(profileFilledPercent) && (
                   <span className={s.itemSub}>
                     Filled <div className={s.notificationsCount}>{profileFilledPercent}%</div>
                   </span>

--- a/components/core/navbar/components/MobileNavDrawer/MobileNavDrawer.tsx
+++ b/components/core/navbar/components/MobileNavDrawer/MobileNavDrawer.tsx
@@ -18,6 +18,8 @@ import { useDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import s from './MobileNavDrawer.module.scss';
 import { isNumber } from 'lodash';
 import { Signup } from '@/components/core/navbar/components/Signup';
+import { useMember } from '@/services/members/hooks/useMember';
+import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 
 interface IMobileNavDrawer {
   userInfo: IUserInfo;
@@ -39,8 +41,11 @@ export const MobileNavDrawer = (props: Readonly<IMobileNavDrawer>) => {
   const postHogProps = usePostHog();
   const drawerRef = useRef(null);
   const router = useRouter();
-
+  const { data: member, isLoading } = useMember(userInfo.uid);
+  const [hideCompleteProfile] = useLocalStorageParam('complete_profile_bar', false);
   const defaultAvatarImage = useDefaultAvatar(userInfo?.name);
+  const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours && member?.memberInfo.skills.length > 0;
+  const hideProfileStatus = !userInfo || isProfileFilled || hideCompleteProfile || isLoading;
 
   useClickedOutside({ callback: () => onNavMenuClick(), ref: drawerRef });
 
@@ -128,7 +133,7 @@ export const MobileNavDrawer = (props: Readonly<IMobileNavDrawer>) => {
                   <li className="md__container__bdy__supandset__optn">
                     <UserIcon />
                     <div className="nb__right__helpc__opts__optn__name">{userInfo.name ?? userInfo.email}</div>
-                    {isNumber(props.profileFilledPercent) && (
+                    {!hideProfileStatus && isNumber(props.profileFilledPercent) && (
                       <span className="nb__right_sub">
                         Filled <div className="nb__right_notifications_count">{props.profileFilledPercent}%</div>
                       </span>

--- a/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
+++ b/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
@@ -11,6 +11,7 @@ import { MembersQueryKeys } from '@/services/members/constants';
 import { usePathname, useRouter } from 'next/navigation';
 import { HighlightsBar } from '@/components/core/navbar/components/HighlightsBar';
 import { clsx } from 'clsx';
+import { useMember } from '@/services/members/hooks/useMember';
 
 interface Props {
   userInfo: IUserInfo;
@@ -19,8 +20,9 @@ interface Props {
 export const SubscribeToRecoomendations = ({ userInfo }: Props) => {
   const [view, setView] = useState<'initial' | 'confirmation'>('initial');
   const [open, setOpen] = useState(false);
+  const { data: member, isLoading } = useMember(userInfo.uid);
   const { data } = useMemberNotificationsSettings(userInfo?.uid);
-  const { mutateAsync, isPending } = useUpdateMemberNotificationsSettings();
+  const { mutateAsync } = useUpdateMemberNotificationsSettings();
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const router = useRouter();
@@ -63,7 +65,9 @@ export const SubscribeToRecoomendations = ({ userInfo }: Props) => {
     }
   }, [mutateAsync, queryClient, userInfo]);
 
-  if (!userInfo || pathname.includes('/members') || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog) {
+  const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours && member?.memberInfo.skills.length > 0;
+
+  if (!userInfo || pathname.includes(`/members/${userInfo.uid}`) || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog || !isProfileFilled || isLoading) {
     return null;
   }
 

--- a/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
+++ b/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
@@ -11,6 +11,7 @@ import { useUpdateMemberNotificationsSettings } from '@/services/members/hooks/u
 import { useQueryClient } from '@tanstack/react-query';
 import { MembersQueryKeys } from '@/services/members/constants';
 import { FloatingWidgets } from '@/components/page/member-info/components/FloatingWidgets';
+import { useMember } from '@/services/members/hooks/useMember';
 
 interface Props {
   userInfo: IUserInfo;
@@ -20,6 +21,7 @@ export const SubscribeToRecommendationsWidget = ({ userInfo }: Props) => {
   const [view, setView] = useState<'initial' | 'confirmation'>('initial');
   const { data } = useMemberNotificationsSettings(userInfo?.uid);
   const { id } = useParams();
+  const { data: member } = useMember(userInfo.uid);
   const { mutateAsync, isPending } = useUpdateMemberNotificationsSettings();
   const queryClient = useQueryClient();
 
@@ -61,12 +63,14 @@ export const SubscribeToRecommendationsWidget = ({ userInfo }: Props) => {
     }
   }, [mutateAsync, queryClient, userInfo]);
 
+  const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours && member?.memberInfo.skills.length > 0;
+
   // I am authenticated user
   // 1. this is mine profile
   // 2. I have not subscribed to recommendations yet
   // 3. I am a specific user with recommendations enabled
   // 4. if i did not press not now
-  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog) {
+  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog || !isProfileFilled) {
     return null;
   }
 

--- a/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
+++ b/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
@@ -11,6 +11,7 @@ import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 import { format } from 'date-fns-tz';
 import { useUpcomingEvents } from '@/services/events/hooks/useUpcomingEvents';
 import Link from 'next/link';
+import { useMemberNotificationsSettings } from '@/services/members/hooks/useMemberNotificationsSettings';
 
 interface Props {
   userInfo: IUserInfo;
@@ -20,8 +21,9 @@ export const UpcomingEventsWidget = ({ userInfo }: Props) => {
   const [open, setOpen] = useLocalStorageParam('upcoming-events-widget', true);
 
   const { data, isLoading } = useUpcomingEvents();
+  const { data: settings } = useMemberNotificationsSettings(userInfo?.uid);
 
-  if (isLoading || !data?.length) {
+  if (!userInfo || isLoading || !data?.length || !settings?.subscribed) {
     return null;
   }
 


### PR DESCRIPTION
Reinstated profile completion and recommendation subscription widgets for better user engagement. Introduced checks for completed profiles and stored preferences to conditionally display widgets. Simplified related logic by leveraging new hooks and member data.