### PR TITLE
Enable production source maps and fix formatting in config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
         source: '/irl',
         destination: 'events/irl',
         permanent: true,
-      }
+      },
     ];
   },
   env: {
@@ -49,9 +49,10 @@ const nextConfig = {
       },
     ],
   },
-  experimental:{
-    serverSourceMaps:false
+  experimental: {
+    serverSourceMaps: false,
   },
+  productionBrowserSourceMaps: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
Enabled `productionBrowserSourceMaps` to support debugging in production builds. Also corrected inconsistent formatting in the redirects and experimental sections for better code readability. No functional changes to redirection logic were made.