### PR TITLE
Enable AI-generated bio button for editable profiles

### DIFF
--- a/components/page/member-details/ProfileDetails/components/ProfileBio/ProfileBio.tsx
+++ b/components/page/member-details/ProfileDetails/components/ProfileBio/ProfileBio.tsx
@@ -24,11 +24,11 @@ export const ProfileBio = ({ bio, isEditable, hasMissingData, onEdit }: Props) =
         ) : (
           <div className={s.row}>
             <p>Tell others who you are, what you’re working on, and what you’re looking to connect around.</p>
-            {/*{isEditable && (*/}
-            {/*  <button className={s.btn} onClick={onEdit}>*/}
-            {/*    Gen Bio <span className={s.desktopOnly}>with AI</span>*/}
-            {/*  </button>*/}
-            {/*)}*/}
+            {isEditable && (
+              <button className={s.btn} onClick={onEdit}>
+                Gen Bio <span className={s.desktopOnly}>with AI</span>
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/components/page/member-details/ProfileDetails/components/ProfileBioInput/ProfileBioInput.module.scss
+++ b/components/page/member-details/ProfileDetails/components/ProfileBioInput/ProfileBioInput.module.scss
@@ -30,7 +30,6 @@
   //display: flex;
   align-items: center;
   gap: 8px;
-  display: none;
 
   &.loading {
     animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;


### PR DESCRIPTION
Restores the AI-generated bio button visibility for editable profiles by uncommenting the button logic. Also removes the unnecessary "display: none" rule from the related SCSS file to ensure proper layout rendering.