### PR TITLE
fix: ensure UpcomingEventsWidget renders only with valid settings (#909)

### DIFF
--- a/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
+++ b/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
@@ -28,7 +28,7 @@ export const UpcomingEventsWidget = ({ userInfo }: Props) => {
   const { data: settings } = useMemberNotificationsSettings(userInfo?.uid);
   const { onUpcomingEventsWidgetShowAllClicked } = useEventsAnalytics();
 
-  if (!userInfo || isLoading || !data?.length) {
+  if (!userInfo || isLoading || !data?.length || userInfo.uid !== id || !settings?.recommendationsEnabled) {
     return null;
   }
 


### PR DESCRIPTION
Added checks to validate user ID consistency and whether recommendations are enabled in the user's notification settings. This prevents the widget from rendering under inappropriate conditions, improving accuracy and user experience.