### PR TITLE
fix: make edit button conditional on `isEditable` (#911)

### DIFF
--- a/components/page/member-details/ContributionsDetails/components/ContributionsList/ContributionsList.tsx
+++ b/components/page/member-details/ContributionsDetails/components/ContributionsList/ContributionsList.tsx
@@ -41,9 +41,11 @@ export const ContributionsList = ({ isEditable, onAdd, onEdit, member }: Props) 
                   <div className={s.secondaryLabel}>{item.role}</div>
                 </div>
               </div>
-              <button className={s.editBtn} onClick={() => onEdit(item)}>
-                <EditIcon />
-              </button>
+              {isEditable && (
+                <button className={s.editBtn} onClick={() => onEdit(item)}>
+                  <EditIcon />
+                </button>
+              )}
             </li>
           ))}
         </ul>

--- a/components/page/member-details/ExperienceDetails/components/ExperiencesList/ExperiencesList.tsx
+++ b/components/page/member-details/ExperienceDetails/components/ExperiencesList/ExperiencesList.tsx
@@ -46,9 +46,11 @@ export const ExperiencesList = ({ isEditable, onAdd, onEdit, member }: Props) =>
                   </div>
                 </div>
               </div>
-              <button className={s.editBtn} onClick={() => onEdit(item)}>
-                <EditIcon />
-              </button>
+              {isEditable && (
+                <button className={s.editBtn} onClick={() => onEdit(item)}>
+                  <EditIcon />
+                </button>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Wrap the edit button in a conditional check based on the `isEditable` prop in both `ContributionsList` and `ExperiencesList` components. This ensures the button is only rendered when edits are allowed.