### PR TITLE
Fix incorrect condition in member preferences logic

### DIFF
--- a/services/members.service.ts
+++ b/services/members.service.ts
@@ -151,14 +151,16 @@ export const getMember = async (id: string, query: any, isLoggedIn?: boolean, us
     member = { ...member, repositories: respositorymemberResponse };
   }
 
-  if (isLoggedIn && (!userInfo?.roles?.includes(ADMIN_ROLE) || userInfo?.uid === member?.id)) {
+  if (isLoggedIn && (!userInfo?.roles?.includes(ADMIN_ROLE) || userInfo?.uid !== member?.id)) {
     let memberPreferences = member?.preferences;
     let preferences;
+
     if (!memberPreferences) {
       preferences = JSON.parse(JSON.stringify(PRIVACY_CONSTANTS.DEFAULT_SETTINGS));
     } else {
       preferences = memberPreferences;
     }
+
     if (isHidePref) {
       hidePreferences(preferences, member);
     }


### PR DESCRIPTION
Adjusted the conditional check to ensure the proper handling of user roles and member IDs. This resolves a logic error where preferences could be incorrectly processed for the logged-in user.