### PR TITLE
fix: URL validation on the social handle fields for settings page of TEAMS 

### DIFF
--- a/components/form/url-field-error/index.tsx
+++ b/components/form/url-field-error/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface URLFieldErrorProps {
+  message: string;
+  show: boolean;
+}
+
+const URLFieldError = ({ message, show }: URLFieldErrorProps): React.ReactElement | null => {
+  if (!show) return null;
+  
+  return (
+    <div className="url-error">
+      {message}
+      
+      <style jsx>{`
+        .url-error {
+          position: absolute;
+          bottom: -18px;
+          right: 0;
+          font-size: 12px;
+          color: #ef4444;
+          font-weight: 400;
+          text-align: right;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default URLFieldError;

--- a/components/form/url-text-field/index.tsx
+++ b/components/form/url-text-field/index.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import TextField from '../text-field';
+import URLFieldError from '../url-field-error';
+import { isValidURL, getURLErrorMessage, URLType } from '../../../utils/url-validation';
+
+interface URLTextFieldProps {
+  id: string;
+  name: string;
+  label?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  maxLength?: number;
+  type?: string;
+  isMandatory?: boolean;
+  urlType: URLType;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const URLTextField = ({
+  id,
+  name,
+  label,
+  placeholder,
+  defaultValue = '',
+  maxLength,
+  type = 'text',
+  isMandatory = false,
+  urlType,
+  onChange,
+}: URLTextFieldProps) => {
+  const [value, setValue] = useState(defaultValue);
+  const [touched, setTouched] = useState(false);
+  const isInvalid = touched && value !== '' && !isValidURL(value, urlType);
+  
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  return (
+    <div className="url-field-container">
+      <TextField
+        id={id}
+        name={name}
+        label={label}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        maxLength={maxLength}
+        type={type}
+        isMandatory={isMandatory}
+        onChange={handleChange}
+        onBlur={() => setTouched(true)}
+      />
+      <URLFieldError 
+        message={getURLErrorMessage(urlType)} 
+        show={isInvalid} 
+      />
+      
+      <style jsx>{`
+        .url-field-container {
+          position: relative;
+          width: 100%;
+          margin-bottom: 8px;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default URLTextField;

--- a/components/page/settings/manage-teams.tsx
+++ b/components/page/settings/manage-teams.tsx
@@ -21,6 +21,8 @@ import { ENROLLMENT_TYPE } from '@/utils/constants';
 import { useSettingsAnalytics } from '@/analytics/settings.analytics';
 import AlertMessage from './alert-message';
 import TeamsMemberInfo from './teams-member-info';
+import URLTextField from '../../form/url-text-field';
+import { isValidURL, URLType } from '../../../utils/url-validation';
 
 function ManageTeamsSettings(props: any) {
   //props
@@ -144,10 +146,32 @@ function ManageTeamsSettings(props: any) {
 
   const validateSocial = async (formattedData: any) => {
     let errors = [];
-    const validationResponse = validateForm(socialSchema, formattedData);
-    if (!validationResponse?.success) {
-      errors.push(...validationResponse.errors);
+    
+    // Check individual fields for URL validity
+    const fieldsToValidate: Array<{field: string, type: URLType, required: boolean}> = [
+      { field: 'contactMethod', type: 'contactMethod', required: true },
+      { field: 'website', type: 'website', required: true },
+      { field: 'linkedinHandler', type: 'linkedin', required: false },
+      { field: 'twitterHandler', type: 'twitter', required: false },
+      { field: 'telegramHandler', type: 'telegram', required: false },
+      { field: 'blog', type: 'blog', required: false },
+    ];
+    
+    fieldsToValidate.forEach(({ field, type, required }) => {
+      const value = formattedData[field];
+      if ((required && !value) || (value && !isValidURL(value, type))) {
+        errors.push(`Invalid ${field} format`);
+      }
+    });
+    
+    // Use schema validation as backup
+    if (errors.length === 0) {
+      const validationResponse = validateForm(socialSchema, formattedData);
+      if (!validationResponse?.success) {
+        errors.push(...validationResponse.errors);
+      }
     }
+    
     return errors;
   };
 

--- a/components/page/team-form-info/team-social-info.tsx
+++ b/components/page/team-form-info/team-social-info.tsx
@@ -1,5 +1,6 @@
 'use client'
 import TextField from '@/components/form/text-field';
+import URLTextField from '@/components/form/url-text-field';
 
 interface ITeamSocialInfo {
   errors: string[];
@@ -25,24 +26,24 @@ function TeamSocialInfo(props: ITeamSocialInfo) {
           </ul>
         )}
         <div className="teamSocialInfo__form__item">
-          <TextField isMandatory defaultValue={initialValues?.contactMethod ?? ''} maxLength={200} id="register-team-contactMethod" label="Preferred method of contact*" name="contactMethod" type="text" placeholder="Enter contact method" />
+          <URLTextField isMandatory defaultValue={initialValues?.contactMethod ?? ''} maxLength={200} id="register-team-contactMethod" label="Preferred method of contact*" name="contactMethod" type="text" placeholder="Enter contact method" urlType="contactMethod" />
           <p className="info">
             <img src="/icons/info.svg" alt="name info" width="16" height="16px" />{' '}
             <span className="info__text">What is the best way for people to connect with your team? (e.g., team Slack channel, team email address, team Discord server/channel, etc.)</span>
           </p>
         </div>
         <div className="teamSocialInfo__form__item">
-          <TextField isMandatory maxLength={1000} id="register-team-website" label="Website address*" defaultValue={initialValues?.website ?? ''} name="website" type="text" placeholder="Enter address here" />
+          <URLTextField isMandatory maxLength={1000} id="register-team-website" label="Website address*" defaultValue={initialValues?.website ?? ''} name="website" type="text" placeholder="Enter address here" urlType="website" />
           <p className="info">
             <img src="/icons/info.svg" alt="name info" width="16" height="16px" />{' '}
             <span className="info__text">Let us check out what you and your team do! If you have more than one primary website (i.e a docs site), list one per line.</span>
           </p>
         </div>
-        <TextField id="register-team-linkedinHandler" maxLength={200} label="LinkedIn" defaultValue={initialValues?.linkedinHandler ?? ''} name="linkedinHandler" type="text" placeholder="eg., https://www.linkedin.com/in/jbenetcs/" />
-        <TextField id="register-team-twitterHandler" maxLength={200} label="Twitter" defaultValue={initialValues?.twitterHandler ?? ''} name="twitterHandler" type="text" placeholder="e.g., @protocollabs" />
-        <TextField id="register-team-telegramHandler" maxLength={200} label="Telegram" defaultValue={initialValues?.telegramHandler ?? ''} name="telegramHandler" type="text" placeholder="Telegram" />
+        <URLTextField id="register-team-linkedinHandler" maxLength={200} label="LinkedIn" defaultValue={initialValues?.linkedinHandler ?? ''} name="linkedinHandler" type="text" placeholder="eg., https://www.linkedin.com/in/jbenetcs/" urlType="linkedin" />
+        <URLTextField id="register-team-twitterHandler" maxLength={200} label="Twitter" defaultValue={initialValues?.twitterHandler ?? ''} name="twitterHandler" type="text" placeholder="e.g., @protocollabs" urlType="twitter" />
+        <URLTextField id="register-team-telegramHandler" maxLength={200} label="Telegram" defaultValue={initialValues?.telegramHandler ?? ''} name="telegramHandler" type="text" placeholder="Telegram" urlType="telegram" />
         <div className="teamSocialInfo__form__item">
-          <TextField id="register-team-blog" maxLength={1000} label="Blog address" defaultValue={initialValues?.blog ?? ''} name="blog" type="text" placeholder="Enter address here" />
+          <URLTextField id="register-team-blog" maxLength={1000} label="Blog address" defaultValue={initialValues?.blog ?? ''} name="blog" type="text" placeholder="Enter address here" urlType="blog" />
           <p className="info">
             <img src="/icons/info.svg" alt="name info" width="16" height="16px" />{' '}
             <span className="info__text">Sharing your blog link allows us to stay up to date with you, your team, and the direction you are going!</span>

--- a/schema/team-forms.ts
+++ b/schema/team-forms.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isValidURL, getURLErrorMessage, URLType } from '../utils/url-validation';
 
 export const basicInfoSchema = z.object({
   requestorEmail: z
@@ -43,10 +44,44 @@ export const socialSchema = z.object({
     .string({ errorMap: () => ({ message: 'Please add Preferred method of contact' }) })
     .trim()
     .min(1)
-    .max(200),
+    .max(200)
+    .refine((value): value is string => isValidURL(value, 'contactMethod'), {
+      message: getURLErrorMessage('contactMethod'),
+    }),
   website: z
     .string({ errorMap: () => ({ message: 'Please add website' }) })
     .trim()
     .min(1)
-    .max(1000),
+    .max(1000)
+    .refine((value): value is string => isValidURL(value, 'website'), {
+      message: getURLErrorMessage('website'),
+    }),
+  linkedinHandler: z
+    .string()
+    .trim()
+    .max(200)
+    .refine((value): value is string => !value || isValidURL(value, 'linkedin'), {
+      message: getURLErrorMessage('linkedin'),
+    }),
+  twitterHandler: z
+    .string()
+    .trim()
+    .max(200)
+    .refine((value): value is string => !value || isValidURL(value, 'twitter'), {
+      message: getURLErrorMessage('twitter'),
+    }),
+  telegramHandler: z
+    .string()
+    .trim()
+    .max(200)
+    .refine((value): value is string => !value || isValidURL(value, 'telegram'), {
+      message: getURLErrorMessage('telegram'),
+    }),
+  blog: z
+    .string()
+    .trim()
+    .max(1000)
+    .refine((value): value is string => !value || isValidURL(value, 'blog'), {
+      message: getURLErrorMessage('blog'),
+    }),
 });

--- a/utils/url-validation.ts
+++ b/utils/url-validation.ts
@@ -1,0 +1,55 @@
+/**
+ * URL validation utilities for social media platforms
+ */
+
+// Regular expressions for validating different platform URLs
+const URL_PATTERNS = {
+  website: /^https?:\/\/([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\/.*)?$/,
+  linkedin: /^(https?:\/\/)?(www\.)?linkedin\.com\/(in|company)\/[a-zA-Z0-9_-]+\/?$/,
+  twitter: /^(https?:\/\/)?(www\.)?twitter\.com\/[a-zA-Z0-9_]{1,15}\/?$|^@[a-zA-Z0-9_]{1,15}$/,
+  telegram: /^(https?:\/\/)?(www\.)?t\.me\/[a-zA-Z0-9_]{5,32}\/?$|^@[a-zA-Z0-9_]{5,32}$/,
+  blog: /^https?:\/\/([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\/.*)?$/,
+  email: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+  contactMethod: /^$/, // Placeholder - actual validation happens in isValidURL
+};
+
+export type URLType = keyof typeof URL_PATTERNS;
+
+/**
+ * Validates a URL based on platform type
+ * @param url URL to validate
+ * @param type Platform type
+ * @returns Boolean indicating if URL is valid
+ */
+export const isValidURL = (url: string, type: URLType): boolean => {
+  if (!url) return true; // Empty URLs are valid (not required)
+  
+  // For contact method, check if it's either a valid email or website URL
+  if (type === 'contactMethod') {
+    return URL_PATTERNS.email.test(url) || URL_PATTERNS.website.test(url);
+  }
+  
+  const pattern = URL_PATTERNS[type];
+  if (!pattern) return URL_PATTERNS.website.test(url); // Default to website validation
+  
+  return pattern.test(url);
+};
+
+/**
+ * Get error message for an invalid URL
+ * @param type Platform type
+ * @returns Error message string
+ */
+export const getURLErrorMessage = (type: URLType): string => {
+  const messages: Record<URLType, string> = {
+    website: 'Please enter a valid website URL (e.g., https://example.com)',
+    linkedin: 'Please enter a valid LinkedIn URL (e.g., https://linkedin.com/in/username)',
+    twitter: 'Please enter a valid Twitter URL (e.g., https://twitter.com/username or @username)',
+    telegram: 'Please enter a valid Telegram handle (e.g., https://t.me/username or @username)',
+    blog: 'Please enter a valid blog URL (e.g., https://blog.example.com)',
+    email: 'Please enter a valid email address',
+    contactMethod: 'Please enter a valid URL or email address',
+  };
+  
+  return messages[type] || 'Please enter a valid URL';
+};


### PR DESCRIPTION
fixes memser-spaceport/protocol-labs-directory#27

Implements URL validation for team members in the settings page for the form entries - Preferred method of contact, Website address, LinkedIn, Twitter, Telegram, and Blog address.
URLs are checked on the basis of their format for the respective platform.
When a user enters incorrect URL, a warning is given to the user.