### PR TITLE
Add analytics events for recommendations settings actions

### DIFF
--- a/analytics/settings.analytics.ts
+++ b/analytics/settings.analytics.ts
@@ -30,7 +30,7 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_SIDE_MENU_CLICK, params);
   }
 
-  function recordManageTeamsTeamChange(team: any , user: IAnalyticsUserInfo | null){
+  function recordManageTeamsTeamChange(team: any, user: IAnalyticsUserInfo | null) {
     const params = {
       ...team,
       user,
@@ -38,8 +38,7 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MANAGE_TEAMS_TEAM_CHANGE, params);
   }
 
-
-  function recordManageTeamSave(type: string, user: IAnalyticsUserInfo | null, payload?: any){
+  function recordManageTeamSave(type: string, user: IAnalyticsUserInfo | null, payload?: any) {
     const params = {
       type,
       user,
@@ -48,7 +47,7 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MANAGE_TEAMS_SAVE, params);
   }
 
-  function recordManageMembersMemberChange(member: any , user: IAnalyticsUserInfo | null){
+  function recordManageMembersMemberChange(member: any, user: IAnalyticsUserInfo | null) {
     const params = {
       ...member,
       user,
@@ -56,7 +55,7 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MANAGE_MEMBERS_MEMBER_CHANGE, params);
   }
 
-  function recordManageMemberSave(type: string, user: IAnalyticsUserInfo | null, payload?: any){
+  function recordManageMemberSave(type: string, user: IAnalyticsUserInfo | null, payload?: any) {
     const params = {
       type,
       user,
@@ -65,7 +64,7 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MANAGE_MEMBERS_SAVE, params);
   }
 
-  function recordMemberProfileSave(type: string, user: IAnalyticsUserInfo | null, payload?: any){
+  function recordMemberProfileSave(type: string, user: IAnalyticsUserInfo | null, payload?: any) {
     const params = {
       type,
       user,
@@ -74,34 +73,34 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MEMBER_PROFILE_SAVE, params);
   }
 
-  function recordMemberEmailAdminEditClick(email: string, user: IAnalyticsUserInfo | null){
+  function recordMemberEmailAdminEditClick(email: string, user: IAnalyticsUserInfo | null) {
     const params = {
       email,
-      user
+      user,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MEMBER_EMAIL_ADMIN_EDIT_CLICK, params);
   }
 
-  function recordMemberEmailAdminEditCancel(email: string, user: IAnalyticsUserInfo | null){
+  function recordMemberEmailAdminEditCancel(email: string, user: IAnalyticsUserInfo | null) {
     const params = {
       email,
-      user
+      user,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MEMBER_EMAIL_ADMIN_EDIT_CANCEL, params);
   }
 
-  function recordMemberEmailAdminEditSuccess(user: IAnalyticsUserInfo | null){
+  function recordMemberEmailAdminEditSuccess(user: IAnalyticsUserInfo | null) {
     const params = {
-      user
+      user,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MEMBER_EMAIL_ADMIN_EDIT_SUCCESS, params);
   }
 
-  function recordMemberPreferenceChange(type: string, user: IAnalyticsUserInfo | null, payload?:any) {
+  function recordMemberPreferenceChange(type: string, user: IAnalyticsUserInfo | null, payload?: any) {
     const params = {
       type,
       user,
-      ...payload
+      ...payload,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_USER_PREFERENCES, params);
   }
@@ -109,73 +108,84 @@ export const useSettingsAnalytics = () => {
   function recordMemberPreferenceReset(user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      name: "reset",
-      value: true
+      name: 'reset',
+      value: true,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_USER_PREFERENCES_RESET, params);
   }
 
-  function recordMemberProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string){
+  function recordMemberProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string) {
     const params = {
       user,
-      name: tabName
+      name: tabName,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_MEMBER_PROFILE_EDIT_FORM, params);
   }
 
-
-  function recordUserProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string){
+  function recordUserProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string) {
     const params = {
       user,
-      name: tabName
+      name: tabName,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_USER_PROFILE_EDIT_FORM, params);
   }
 
-  function recordTeamProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string){
+  function recordTeamProfileFormEdit(user: IAnalyticsUserInfo | null, tabName: string) {
     const params = {
       user,
-      itemName: tabName
+      itemName: tabName,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_TEAM_PROFILE_EDIT_FORM, params);
   }
 
-  function recordMemberProjectContributionAdd(type: string, user:IAnalyticsUserInfo|null) {
+  function recordMemberProjectContributionAdd(type: string, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      type
+      type,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.PR_CONRTIBUTIONS_LIST_ITEM_ADD, params);
   }
 
-  function recordMemberProjectContributionDelete(type: string, user:IAnalyticsUserInfo|null) {
+  function recordMemberProjectContributionDelete(type: string, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      type
+      type,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.PR_CONRTIBUTIONS_LIST_ITEM_DELETE, params);
   }
 
-  function recordMemberProjectContributionAddProject(type: string, user:IAnalyticsUserInfo|null) {
+  function recordMemberProjectContributionAddProject(type: string, user: IAnalyticsUserInfo | null) {
     const params = {
       user,
-      type
+      type,
     };
     captureEvent(SETTINGS_ANALYTICS_EVENTS.PR_CONRTIBUTIONS_LIST_ITEM_ADDPROJECT, params);
   }
 
-  function recordManageTeamsMemberTeamLeadToggleChange(params:any) {
+  function recordManageTeamsMemberTeamLeadToggleChange(params: any) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.MANAGE_TEAMS_MEMBER_TEAM_LEAD_TOGGLE_CHANGE, params);
   }
 
-  function recordManageTeamsMemberRemove(params:any) {
+  function recordManageTeamsMemberRemove(params: any) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.MANAGE_TEAMS_MEMBER_REMOVE, params);
   }
 
-  function recordManageTeamsMemberUndo(params:any) {
+  function recordManageTeamsMemberUndo(params: any) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.MANAGE_TEAMS_MEMBER_UNDO, params);
   }
-  
+
+  function onRecommendationsPageOpenFromMail(params: any) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_RECOMMENDATIONS_PAGE_OPEN_FROM_MAIL, params);
+  }
+
+  function onRecommendationsSettingsSaveClicked(params: any) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_RECOMMENDATIONS_SAVE_CLICKED, params);
+  }
+
+  function onRecommendationsSettingsResetClicked() {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_RECOMMENDATIONS_RESET_CLICKED);
+  }
+
   return {
     recordSettingsSideMenuClick,
     recordManageTeamsTeamChange,
@@ -195,6 +205,9 @@ export const useSettingsAnalytics = () => {
     recordMemberProjectContributionAddProject,
     recordManageTeamsMemberTeamLeadToggleChange,
     recordManageTeamsMemberRemove,
-    recordManageTeamsMemberUndo
+    recordManageTeamsMemberUndo,
+    onRecommendationsPageOpenFromMail,
+    onRecommendationsSettingsSaveClicked,
+    onRecommendationsSettingsResetClicked,
   };
 };

--- a/components/page/recommendations/components/GeneralSettings/GeneralSettings.tsx
+++ b/components/page/recommendations/components/GeneralSettings/GeneralSettings.tsx
@@ -66,8 +66,8 @@ const ArrowIcon = () => (
       />
     </g>
     <defs>
-      <filter id="filter0_d_2699_934" x="-2" y="-1" width="22" height="22" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-        <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <filter id="filter0_d_2699_934" x="-2" y="-1" width="22" height="22" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
         <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
         <feOffset dy="1" />
         <feGaussianBlur stdDeviation="1" />

--- a/components/page/recommendations/components/RecommendationSettingsFormControls/RecommendationSettingsFormControls.tsx
+++ b/components/page/recommendations/components/RecommendationSettingsFormControls/RecommendationSettingsFormControls.tsx
@@ -4,12 +4,15 @@ import s from './RecommendationSettingsFormControls.module.scss';
 import { useFormContext } from 'react-hook-form';
 import clsx from 'clsx';
 import { Spinner } from '@/components/ui/Spinner';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
 
 export const RecommendationSettingsFormControls = () => {
   const {
     reset,
     formState: { isDirty, isSubmitting },
   } = useFormContext();
+
+  const { onRecommendationsSettingsResetClicked } = useSettingsAnalytics();
 
   return (
     <div
@@ -21,7 +24,15 @@ export const RecommendationSettingsFormControls = () => {
         <SaveIcon /> Attention! You have unsaved changes!
       </div>
       <div className={s.right}>
-        <button type="button" className={s.btn} disabled={!isDirty || isSubmitting} onClick={() => reset()}>
+        <button
+          type="button"
+          className={s.btn}
+          disabled={!isDirty || isSubmitting}
+          onClick={() => {
+            onRecommendationsSettingsResetClicked();
+            reset();
+          }}
+        >
           Reset
         </button>
         <button type="submit" className={s.primaryBtn} disabled={!isDirty || isSubmitting}>

--- a/components/page/recommendations/components/RecommendationsSettingsForm/RecommendationsSettingsForm.tsx
+++ b/components/page/recommendations/components/RecommendationsSettingsForm/RecommendationsSettingsForm.tsx
@@ -14,6 +14,8 @@ import { useRouter } from 'next/navigation';
 
 import s from './RecommendationsSettingsForm.module.scss';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useRecommendationsSettingsEvents } from '@/components/page/recommendations/components/RecommendationsSettingsForm/hooks';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
 
 interface Props {
   uid: string;
@@ -32,6 +34,9 @@ export const RecommendationsSettingsForm = ({ uid, userInfo, initialData }: Prop
 
   const { mutateAsync } = useUpdateMemberNotificationsSettings();
 
+  useRecommendationsSettingsEvents();
+  const { onRecommendationsSettingsSaveClicked } = useSettingsAnalytics();
+
   useEffect(() => {
     if (initialData) {
       reset(initialData);
@@ -39,7 +44,7 @@ export const RecommendationsSettingsForm = ({ uid, userInfo, initialData }: Prop
   }, [initialData, reset]);
 
   const onSubmit = async (formData: TRecommendationsSettingsForm) => {
-    const res = await mutateAsync({
+    const payload = {
       memberUid: userInfo.uid,
       subscribed: formData.enabled,
       emailFrequency: formData.frequency.value,
@@ -48,7 +53,11 @@ export const RecommendationsSettingsForm = ({ uid, userInfo, initialData }: Prop
       fundingStageList: formData.fundingStage.map((stage) => stage.label),
       technologyList: formData.teamTechnology.map((stage) => stage.label),
       keywordList: formData.keywords,
-    });
+    };
+
+    onRecommendationsSettingsSaveClicked(payload);
+
+    const res = await mutateAsync(payload);
 
     if (res) {
       router.refresh();

--- a/components/page/recommendations/components/RecommendationsSettingsForm/hooks.ts
+++ b/components/page/recommendations/components/RecommendationsSettingsForm/hooks.ts
@@ -1,0 +1,27 @@
+import { useSearchParams } from 'next/navigation';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
+import { useEffect, useRef } from 'react';
+
+export function useRecommendationsSettingsEvents() {
+  const reportedRef = useRef(false);
+  const searchParams = useSearchParams();
+
+  const isFromExampleMail = searchParams.get('utm_source') === 'recommendations_example';
+  const isFromRecommendationMail = searchParams.get('utm_source') === 'recommendations';
+
+  const { onRecommendationsPageOpenFromMail } = useSettingsAnalytics();
+
+  useEffect(() => {
+    if (reportedRef.current) {
+      return;
+    }
+
+    if (!isFromExampleMail && !isFromRecommendationMail) {
+      return;
+    }
+
+    reportedRef.current = true;
+
+    onRecommendationsPageOpenFromMail(searchParams);
+  }, [isFromExampleMail, isFromRecommendationMail, onRecommendationsPageOpenFromMail, searchParams]);
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -165,6 +165,10 @@ export const SETTINGS_ANALYTICS_EVENTS = {
   SETTINGS_MEMBER_PROFILE_EDIT_FORM: 'settings-member-profile-edit-form',
   SETTINGS_TEAM_PROFILE_EDIT_FORM: 'settings-team-profile-edit-form',
 
+  SETTINGS_RECOMMENDATIONS_PAGE_OPEN_FROM_MAIL: 'settings-recommendations-page-open-from-mail',
+  SETTINGS_RECOMMENDATIONS_SAVE_CLICKED: 'settings-recommendations-save-clicked',
+  SETTINGS_RECOMMENDATIONS_RESET_CLICKED: 'settings-recommendations-reset-clicked',
+
   PR_CONRTIBUTIONS_LIST_ITEM_ADD: 'pr-contributions-list-item-add',
   PR_CONRTIBUTIONS_LIST_ITEM_DELETE: 'pr-contributions-list-item-delete',
   PR_CONRTIBUTIONS_LIST_ITEM_ADDPROJECT: 'pr-contributions-list-item-addproject',


### PR DESCRIPTION
Introduced new analytics events to track interactions with the recommendations settings feature, including page opens, saves, and resets. Updated corresponding components and hooks to trigger these events, ensuring better monitoring of user behavior.