### PR TITLE
Ensure settings are only visible when valid and dirty.

### DIFF
--- a/components/page/recommendations/components/RecommendationSettingsFormControls/RecommendationSettingsFormControls.tsx
+++ b/components/page/recommendations/components/RecommendationSettingsFormControls/RecommendationSettingsFormControls.tsx
@@ -17,7 +17,7 @@ export const RecommendationSettingsFormControls = () => {
   return (
     <div
       className={clsx(s.root, {
-        [s.visible]: isDirty,
+        [s.visible]: isDirty && isValid,
       })}
     >
       <div className={s.message}>


### PR DESCRIPTION
Previously, the visibility check relied solely on the `isDirty` state. This change adds an additional condition to verify `isValid`, ensuring settings are displayed only when the form is both valid and dirty, improving UX and preventing unintended behavior.