### PR TITLE
Conditionally render VerifiedIcon based on LinkedIn profile

### DIFF
--- a/components/page/member-details/member-detail-header.tsx
+++ b/components/page/member-details/member-detail-header.tsx
@@ -79,7 +79,7 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
                 asChild
                 trigger={
                   <h1 className="header__details__specifics__name">
-                    {name} <VerifiedIcon />
+                    {name} {member?.linkedinProfile ? <VerifiedIcon /> : null}
                   </h1>
                 }
                 content={name}


### PR DESCRIPTION
Previously, the VerifiedIcon was always displayed next to the member name. This update ensures it is shown only if the member has a LinkedIn profile, adding clarity and preventing incorrect representation.