### PR TITLE
Add support for signup dialog via query params

### DIFF
--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -12,9 +12,9 @@ const getPageData = async () => {
   const { isLoggedIn, userInfo } = getCookiesFromHeaders();
   let canAccess = false;
   let isLoggedInAndHaveAccess = false;
-  if(userInfo) {
+  if (userInfo) {
     const roles = userInfo.roles ?? [];
-    const isAdmin = roles.includes('DIRECTORYADMIN')
+    const isAdmin = roles.includes('DIRECTORYADMIN');
     const isTeamLead = (userInfo.leadingTeams ?? []).length > 0;
     isLoggedInAndHaveAccess = isAdmin || isTeamLead;
   }
@@ -28,21 +28,20 @@ const getPageData = async () => {
 
   return {
     skillsInfo: memberInfo.skills,
-    canAccess
+    canAccess,
   };
 };
 
 export default async function Page() {
-
   const { skillsInfo, canAccess } = await getPageData();
 
-  if(!canAccess) {
-        redirect(`${PAGE_ROUTES.HOME}`, RedirectType.replace);
+  if (!canAccess) {
+    redirect(`${PAGE_ROUTES.HOME}`, RedirectType.replace);
   }
 
   return (
     <>
-    <Script src={`https://www.google.com/recaptcha/api.js?render=${process.env.GOOGLE_SITE_KEY}`} strategy="lazyOnload"></Script>
+      <Script src={`https://www.google.com/recaptcha/api.js?render=${process.env.GOOGLE_SITE_KEY}`} strategy="lazyOnload"></Script>
       <div className={styles.signup}>
         <div className={styles.signup__cn}>
           <SignUp skillsInfo={skillsInfo} />

--- a/components/core/navbar/components/Signup/Signup.tsx
+++ b/components/core/navbar/components/Signup/Signup.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useAuthAnalytics } from '@/analytics/auth.analytics';
 import { SignupWizard } from '@/components/page/sign-up/components/SignupWizard';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import s from './Signup.module.scss';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 const fade = {
   hidden: { opacity: 0 },
@@ -12,8 +13,10 @@ const fade = {
 };
 
 export const Signup = () => {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const analytics = useAuthAnalytics();
+  const searchParams = useSearchParams();
 
   const handleSignUpClick = () => {
     analytics.onSignUpBtnClicked();
@@ -23,6 +26,17 @@ export const Signup = () => {
   const handleClose = useCallback(() => {
     setOpen(false);
   }, []);
+
+  useEffect(() => {
+    if (searchParams.get('dialog') === 'signup' && !open) {
+      setOpen(true);
+      const params = new URLSearchParams(searchParams.toString());
+
+      params.delete('dialog');
+
+      router.replace(`?${params.toString()}`);
+    }
+  }, [open, router, searchParams]);
 
   return (
     <>

--- a/components/page/sign-up/components/SignupWizard/SignupWizard.module.scss
+++ b/components/page/sign-up/components/SignupWizard/SignupWizard.module.scss
@@ -146,6 +146,7 @@
 
   &:disabled {
     opacity: 0.7;
+    cursor: default;
   }
 }
 

--- a/components/page/sign-up/components/SignupWizard/SignupWizard.tsx
+++ b/components/page/sign-up/components/SignupWizard/SignupWizard.tsx
@@ -46,7 +46,7 @@ export const SignupWizard = ({ onClose }: Props) => {
     handleSubmit,
     setValue,
     watch,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isValid, submitCount },
   } = methods;
   const { subscribe, agreed } = watch();
 
@@ -199,7 +199,7 @@ export const SignupWizard = ({ onClose }: Props) => {
                   network members and will not be available to any individuals or entities outside the network.
                 </p>
 
-                <button type="submit" className={s.actionButton} disabled={isSubmitting}>
+                <button type="submit" className={s.actionButton} disabled={isSubmitting || !agreed || (submitCount > 0 && !isValid)}>
                   {isSubmitting ? (
                     <>
                       <LoaderIcon /> <span>Creating profile</span>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,11 @@ const nextConfig = {
         destination: 'events/irl',
         permanent: true,
       },
+      {
+        source: '/signup',
+        destination: '/?dialog=signup',
+        permanent: true,
+      },
     ];
   },
   env: {


### PR DESCRIPTION
Introduced logic to open the signup modal when the `dialog=signup` query param is present, enhancing navigation flow. Updated routing to handle the `/signup` redirect and improved form validation to prevent multiple invalid submissions. Minor style adjustments and code formatting improvements included.