### PR TITLE
fix: enhance recommendation subscription logic and add new service for roles

### DIFF
--- a/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
+++ b/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
@@ -73,7 +73,16 @@ export const SubscribeToRecoomendations = ({ userInfo }: Props) => {
 
   // const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours;
 
-  if (!userInfo || pathname.includes(`/members/${userInfo.uid}`) || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog || isOnboardingLoginFlow) {
+  if (
+    !userInfo ||
+    pathname.includes(`/members/${userInfo.uid}`) ||
+    !data ||
+    data.subscribed ||
+    data.exampleSent ||
+    !data.recommendationsEnabled ||
+    !data.showInvitationDialog ||
+    isOnboardingLoginFlow
+  ) {
     return null;
   }
 

--- a/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
+++ b/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
@@ -70,7 +70,7 @@ export const SubscribeToRecommendationsWidget = ({ userInfo }: Props) => {
 
   // const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours;
 
-  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || !data.recommendationsEnabled || !data.showInvitationDialog) {
+  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || data.exampleSent || !data.recommendationsEnabled || !data.showInvitationDialog) {
     return null;
   }
 

--- a/components/page/recommendations/components/FineTuneMatches/FineTuneMatches.tsx
+++ b/components/page/recommendations/components/FineTuneMatches/FineTuneMatches.tsx
@@ -29,10 +29,12 @@ export const FineTuneMatches = () => {
         value: val.name,
         label: val.name,
       })),
-      fundingStageOptions: data.fundingStage.map((val: { id: any; name: any }) => ({
-        value: val.name,
-        label: val.name,
-      })),
+      fundingStageOptions: data.fundingStage
+        .filter((val: { id: any; name: any }) => val.name !== 'Not Applicable')
+        .map((val: { id: any; name: any }) => ({
+          value: val.name,
+          label: val.name,
+        })),
       teamTechnologiesOptions: data.technologies.map((val: { id: any; name: any }) => ({
         value: val.name,
         label: val.name,
@@ -41,13 +43,13 @@ export const FineTuneMatches = () => {
   }, [data]);
 
   const rolesOptions = useMemo(() => {
-    if (!rolesData) {
+    if (!rolesData || 'isError' in rolesData) {
       return [];
     }
 
-    return rolesData.map((val: { role: string }) => ({
-      value: val.role,
-      label: val.role,
+    return rolesData.map((val: string) => ({
+      value: val,
+      label: val,
     }));
   }, [rolesData]);
 
@@ -80,7 +82,7 @@ export const FineTuneMatches = () => {
         />
         <MatchesSelector
           placeholder="Add role"
-          hint="We’ll prioritize members who match these roles."
+          hint="We'll prioritize members who match these roles."
           icon={<RoleIcon />}
           title="Preferred Roles"
           selectLabel="Select Role"
@@ -90,7 +92,7 @@ export const FineTuneMatches = () => {
         />
         <MatchesSelector
           placeholder="Add technology used"
-          hint="We’ll highlight members working with these technologies."
+          hint="We'll highlight members working with these technologies."
           icon={<TechIcon />}
           title="Technologies used"
           selectLabel="Select Technology"

--- a/services/members/hooks/useMemberRolesOptions.ts
+++ b/services/members/hooks/useMemberRolesOptions.ts
@@ -1,10 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { MembersQueryKeys } from '@/services/members/constants';
-import { getMemberInfoFormValues } from '@/utils/member.utils';
-import { getMemberRoles } from '@/services/members.service';
+import { getRecommendationRoles } from '@/services/recommendations.service';
 
 async function fetcher() {
-  return getMemberRoles({});
+  return getRecommendationRoles();
 }
 
 export function useMemberRolesOptions() {

--- a/services/members/types.ts
+++ b/services/members/types.ts
@@ -7,6 +7,7 @@ export type MemberNotificationSettings = {
   recommendationsEnabled: boolean;
   subscribed: boolean;
   showInvitationDialog: boolean;
+  exampleSent: boolean;
   emailFrequency: number;
   byFocusArea: boolean;
   byRole: boolean;

--- a/services/recommendations.service.ts
+++ b/services/recommendations.service.ts
@@ -1,0 +1,16 @@
+import { getHeader } from '@/utils/common.utils';
+
+export const getRecommendationRoles = async (): Promise<string[] | { isError: boolean; error: { status: number; statusText: string } }> => {
+  const response = await fetch(`${process.env.DIRECTORY_API_URL}/v1/recommendations/settings/roles`, {
+    cache: 'force-cache',
+    method: 'GET',
+    headers: getHeader(''),
+    next: { tags: ['recommendation-roles'] },
+  });
+
+  if (!response.ok) {
+    return { isError: true, error: { status: response.status, statusText: response.statusText } };
+  }
+
+  return await response.json();
+};


### PR DESCRIPTION
- Updated the recommendations subscription components to include a new condition for `data.exampleSent`
- Added a new service to fetch recommendation roles to fix issue with role options in recommendations settings
- Remove `'Not Applicable'` from `fundingStageOptions` in recommendations settings