### PR TITLE
Disable autoFocus and switch onKeyUp to onKeyDown

### DIFF
--- a/components/page/recommendations/components/MatchesEditor/MatchesEditor.tsx
+++ b/components/page/recommendations/components/MatchesEditor/MatchesEditor.tsx
@@ -76,7 +76,7 @@ export const MatchesEditor = ({ icon, title, hint, selectLabel, warning, name, i
                 onChange={(e) => {
                   setInputText(e.target.value);
                 }}
-                onKeyUp={(event) => {
+                onKeyDown={(event) => {
                   if (event.key === 'Enter') {
                     if (inputText.trim() === '') {
                       return;

--- a/components/page/recommendations/components/MatchesSelector/MatchesSelector.tsx
+++ b/components/page/recommendations/components/MatchesSelector/MatchesSelector.tsx
@@ -47,7 +47,7 @@ export const MatchesSelector = ({ icon, title, hint, options, name, menuPlacemen
           <Select
             menuPlacement={menuPlacement}
             isMulti
-            autoFocus
+            // autoFocus
             options={options}
             isClearable={false}
             placeholder={placeholder}


### PR DESCRIPTION
Commented out the autoFocus prop in MatchesSelector to prevent unintended focus behavior. Replaced onKeyUp with onKeyDown in MatchesEditor for better handling of "Enter" key events.