### PR TITLE
Enable recommendations by default and improve MatchesEditor UX.

### DIFF
--- a/components/page/recommendations/components/MatchesEditor/MatchesEditor.tsx
+++ b/components/page/recommendations/components/MatchesEditor/MatchesEditor.tsx
@@ -76,7 +76,24 @@ export const MatchesEditor = ({ icon, title, hint, selectLabel, warning, name, i
                 onChange={(e) => {
                   setInputText(e.target.value);
                 }}
+                onBlur={() => {
+                  if (inputText.trim() === '') {
+                    return;
+                  }
+
+                  if (val.includes(inputText.trim())) {
+                    return;
+                  }
+
+                  setValue(name, [...val, inputText], { shouldValidate: true, shouldDirty: true });
+                  setInputText('');
+                }}
                 onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    setInputText('');
+                    return;
+                  }
+
                   if (event.key === 'Enter') {
                     if (inputText.trim() === '') {
                       return;

--- a/components/page/recommendations/components/RecommendationsSettingsForm/helpers.ts
+++ b/components/page/recommendations/components/RecommendationsSettingsForm/helpers.ts
@@ -15,7 +15,7 @@ export function getSelectedFrequency(freq: number = 7) {
 
 export function getInitialValues() {
   return {
-    enabled: false,
+    enabled: true,
     frequency: { value: 7, label: 'Weekly' },
     // industryTags: [],
     keywords: [],


### PR DESCRIPTION
Changed the default recommendation setting to enabled for a better user experience. Enhanced MatchesEditor by clearing input on Escape key press and validating input on blur to prevent duplicates and empty values.