### PR TITLE
Update accepted file types for profile image upload

### DIFF
--- a/components/page/sign-up/components/ProfileImageInput/ProfileImageInput.tsx
+++ b/components/page/sign-up/components/ProfileImageInput/ProfileImageInput.tsx
@@ -39,7 +39,7 @@ export const ProfileImageInput = () => {
     maxSize: 4 * 1024 * 1024,
     accept: {
       'image/png': ['.png'],
-      'image/jpg': ['.jpg'],
+      'image/jpg': ['.jpg', '.jpeg'],
     },
   });
 


### PR DESCRIPTION
Add support for .jpeg files in the profile image uploader by modifying the accepted file type list. This ensures broader compatibility with common image formats.