### PR TITLE
Restrict feature visibility based on user access level.

### DIFF
--- a/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
+++ b/components/core/navbar/components/SubscribeToRecoomendations/SubscribeToRecoomendations.tsx
@@ -84,7 +84,7 @@ export const SubscribeToRecoomendations = ({ userInfo }: Props) => {
     !data.recommendationsEnabled ||
     !data.showInvitationDialog ||
     isOnboardingLoginFlow ||
-    accessLevel === 'base'
+    accessLevel !== 'advanced'
   ) {
     return null;
   }

--- a/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
+++ b/components/page/member-info/components/SubscribeToRecommendationsWidget/SubscribeToRecommendationsWidget.tsx
@@ -13,6 +13,7 @@ import { MembersQueryKeys } from '@/services/members/constants';
 import { FloatingWidgets } from '@/components/page/member-info/components/FloatingWidgets';
 // import { useMember } from '@/services/members/hooks/useMember';
 import { useMemberAnalytics } from '@/analytics/members.analytics';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 interface Props {
   userInfo: IUserInfo;
@@ -26,6 +27,7 @@ export const SubscribeToRecommendationsWidget = ({ userInfo }: Props) => {
   const { mutateAsync, isPending } = useUpdateMemberNotificationsSettings();
   const queryClient = useQueryClient();
   const { onSubscribeToRecommendationsClicked, onCloseSubscribeToRecommendationsClicked } = useMemberAnalytics();
+  const accessLevel = getAccessLevel(userInfo, true);
 
   const handleSubscribe = useCallback(async () => {
     if (!userInfo) {
@@ -70,7 +72,7 @@ export const SubscribeToRecommendationsWidget = ({ userInfo }: Props) => {
 
   // const isProfileFilled = member?.memberInfo.telegramHandler && member?.memberInfo.officeHours;
 
-  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || data.exampleSent || !data.recommendationsEnabled || !data.showInvitationDialog) {
+  if (!userInfo || userInfo.uid !== id || !data || data.subscribed || data.exampleSent || !data.recommendationsEnabled || !data.showInvitationDialog || accessLevel !== 'advanced') {
     return null;
   }
 

--- a/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
+++ b/components/page/member-info/components/UpcomingEventsWidget/UpcomingEventsWidget.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link';
 import { useMemberNotificationsSettings } from '@/services/members/hooks/useMemberNotificationsSettings';
 import { useEventsAnalytics } from '@/analytics/events.analytics';
 import { useParams } from 'next/navigation';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 interface Props {
   userInfo: IUserInfo;
@@ -27,12 +28,13 @@ export const UpcomingEventsWidget = ({ userInfo }: Props) => {
   const { data, isLoading } = useUpcomingEvents();
   const { data: settings } = useMemberNotificationsSettings(userInfo?.uid);
   const { onUpcomingEventsWidgetShowAllClicked, onUpcomingEventsWidgetDismissClicked, onUpcomingEventsItemClicked } = useEventsAnalytics();
+  const accessLevel = getAccessLevel(userInfo, true);
 
   if (!userInfo || isLoading || !data?.length || userInfo.uid !== id || !settings?.recommendationsEnabled) {
     return null;
   }
 
-  if (!settings?.showInvitationDialog || (!settings?.subscribed && userInfo.uid === id) || !visible) {
+  if (!settings?.showInvitationDialog || (!settings?.subscribed && userInfo.uid === id) || !visible || accessLevel !== 'advanced') {
     return null;
   }
 


### PR DESCRIPTION
Integrated `getAccessLevel` checks to ensure certain features like upcoming events and subscription widgets are accessible only to users with an 'advanced' access level. This enhances feature gating and improves user segmentation.