### PR TITLE
Add tracking for onboarding Explore PL Network action

### DIFF
--- a/analytics/members.analytics.ts
+++ b/analytics/members.analytics.ts
@@ -382,6 +382,10 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_DELETE_EXPERIENCE_SAVE_CLICKED, params);
   }
 
+  function onExplorePlNetworkCLicked(params: Record<string, string | null>) {
+    captureEvent(MEMBER_ANALYTICS_EVENTS.ONBOARDING_EXPLORE_PL_NETWORK_CLICKED, params);
+  }
+
   function onOpenProfileByRecommendationEmailLink(utmSource: string, utmMedium: string, utmCode: string, recommendedMember: string, targetId: string, targetEmail: string) {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAILS_BY_RECOMMENDATION_EMAIL_LINK, {
       utmSource,
@@ -563,5 +567,6 @@ export const useMemberAnalytics = () => {
     onOnboardingWizardStartClicked,
     onOnboardingWizardBrowseFilesClicked,
     onConnectLinkedInClicked,
+    onExplorePlNetworkCLicked,
   };
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { OnboardingFlowTrigger } from '@/components/page/onboarding/components/O
 import PostHogIdentifier from '@/components/page/posthog-identifier';
 import PostLoginRedirectHandler from '@/components/page/recommendations/components/RecommendationsPreloader/PostLoginRedirectHandler';
 import { CompleteYourProfile } from '@/components/core/navbar/components/CompleteYourProfile';
+import { LoginFlowTrigger } from '@/components/page/onboarding/components/LoginFlowTrigger';
 
 // dynamic components:
 const Loader = dynamic(() => import('../components/core/loader'), { ssr: false });
@@ -80,6 +81,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <RatingContainer userInfo={userInfo} isLoggedIn={isLoggedIn} authToken={authToken} />
             <MemberRegisterDialog />
             <OnboardingFlowTrigger isLoggedIn={isLoggedIn} userInfo={userInfo} />
+            <LoginFlowTrigger isLoggedIn={isLoggedIn} userInfo={userInfo} />
             <PostLoginRedirectHandler isLoggedIn={isLoggedIn} />
             {/* <TeamRegisterDialog /> */}
             <CookieChecker isLoggedIn={isLoggedIn} />

--- a/components/page/onboarding/components/LoginFlowTrigger/LoginFlowTrigger.tsx
+++ b/components/page/onboarding/components/LoginFlowTrigger/LoginFlowTrigger.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { IUserInfo } from '@/types/shared.types';
+import { useMemberApprovalEvents } from '@/services/members/hooks/useMemberApprovalEvents';
+
+interface Props {
+  isLoggedIn: boolean;
+  userInfo: IUserInfo;
+}
+
+export const LoginFlowTrigger = ({ isLoggedIn }: Props) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isLoginFlow = searchParams.get('loginFlow') === 'login';
+
+  useEffect(() => {
+    if (!isLoggedIn && isLoginFlow) {
+      router.push(`${window.location.pathname}${window.location.search}#login`);
+    }
+  }, [isLoggedIn, router, isLoginFlow]);
+
+  useMemberApprovalEvents();
+
+  return null;
+};

--- a/components/page/onboarding/components/LoginFlowTrigger/index.ts
+++ b/components/page/onboarding/components/LoginFlowTrigger/index.ts
@@ -1,0 +1,1 @@
+export * from './LoginFlowTrigger';

--- a/services/members/hooks/useMemberApprovalEvents.ts
+++ b/services/members/hooks/useMemberApprovalEvents.ts
@@ -1,0 +1,33 @@
+import { useSearchParams } from 'next/navigation';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
+import { useEffect, useRef } from 'react';
+import { useMemberAnalytics } from '@/analytics/members.analytics';
+
+export function useMemberApprovalEvents() {
+  const reportedRef = useRef(false);
+  const searchParams = useSearchParams();
+
+  const isFromApprovalMail = searchParams.get('utm_source') === 'member_approval';
+
+  const { onExplorePlNetworkCLicked } = useMemberAnalytics();
+
+  useEffect(() => {
+    if (reportedRef.current) {
+      return;
+    }
+
+    if (!isFromApprovalMail) {
+      return;
+    }
+
+    reportedRef.current = true;
+
+    const searchParamsObj = {
+      utmSource: searchParams.get('utm_source'),
+      targetUid: searchParams.get('target_uid'),
+      targetEmail: searchParams.get('target_email'),
+    };
+
+    onExplorePlNetworkCLicked(searchParamsObj);
+  }, [isFromApprovalMail, onExplorePlNetworkCLicked, searchParams]);
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -384,7 +384,7 @@ export const MEMBER_ANALYTICS_EVENTS = {
   MEMBER_DETAIL_DELETE_EXPERIENCE_SAVE_CLICKED: 'member_detail_delete_experience_save_clicked',
 
   MEMBER_DETAILS_BY_RECOMMENDATION_EMAIL_LINK: 'recommendation-email-connect_clicked',
-
+  ONBOARDING_EXPLORE_PL_NETWORK_CLICKED: 'onboarding-explore-pl-network-clicked',
   ONBOARDING_WIZARD_OPEN: 'onboarding-wizard-open',
   ONBOARDING_WIZARD_CLOSE: 'onboarding-wizard-close',
   ONBOARDING_WIZARD_COMPLETE: 'onboarding-wizard-complete',


### PR DESCRIPTION
Introduced a new event to track user clicks during the onboarding phase when exploring the PL network. Implemented `LoginFlowTrigger` and `useMemberApprovalEvents` to trigger the event based on specific URL parameters and login state. Updated constants and analytics files to support the new functionality.