### PR TITLE
Restrict member details access to advanced users

### DIFF
--- a/app/members/[id]/page.tsx
+++ b/app/members/[id]/page.tsx
@@ -16,6 +16,7 @@ import { RepositoriesDetails } from '@/components/page/member-details/Repositori
 import { SubscribeToRecommendationsWidget } from '@/components/page/member-info/components/SubscribeToRecommendationsWidget';
 import { UpcomingEventsWidget } from '@/components/page/member-info/components/UpcomingEventsWidget';
 import { OneClickVerification } from '@/components/page/member-details/OneClickVerification';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 const MemberDetails = async ({ params }: { params: any }) => {
   const memberId = params?.id;
@@ -43,9 +44,11 @@ const MemberDetails = async ({ params }: { params: any }) => {
 
         <ExperienceDetails userInfo={userInfo} member={member} isLoggedIn={isLoggedIn} />
 
-        <div className={styles?.memberDetail__container__teams}>
-          <MemberTeams member={member} isLoggedIn={isLoggedIn} teams={teams ?? []} userInfo={userInfo} />
-        </div>
+        {isLoggedIn && getAccessLevel(userInfo, isLoggedIn) === 'advanced' && (
+          <div className={styles?.memberDetail__container__teams}>
+            <MemberTeams member={member} isLoggedIn={isLoggedIn} teams={teams ?? []} userInfo={userInfo} />
+          </div>
+        )}
 
         <ContributionsDetails userInfo={userInfo} member={member} isLoggedIn={isLoggedIn} />
 

--- a/components/page/member-details/ContributionsDetails/ContributionsDetails.tsx
+++ b/components/page/member-details/ContributionsDetails/ContributionsDetails.tsx
@@ -12,6 +12,7 @@ import s from './ContributionsDetails.module.scss';
 import { ContributionsList } from '@/components/page/member-details/ContributionsDetails/components/ContributionsList';
 import { EditContributionsForm } from '@/components/page/member-details/ContributionsDetails/components/EditContributionsForm';
 import { useMemberAnalytics } from '@/analytics/members.analytics';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 interface Props {
   member: IMember;
@@ -27,7 +28,7 @@ export const ContributionsDetails = ({ isLoggedIn, userInfo, member }: Props) =>
   const isEditable = isOwner || isAdmin;
   const { onEditContributionDetailsClicked, onAddContributionDetailsClicked } = useMemberAnalytics();
 
-  if (!isLoggedIn) {
+  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
     return null;
   }
 

--- a/components/page/member-details/ExperienceDetails/ExperienceDetails.tsx
+++ b/components/page/member-details/ExperienceDetails/ExperienceDetails.tsx
@@ -14,6 +14,7 @@ import s from './ExperienceDetails.module.scss';
 import { FormattedMemberExperience } from '@/services/members/hooks/useMemberExperience';
 import { EditExperienceForm } from '@/components/page/member-details/ExperienceDetails/components/EditExperienceForm';
 import { useMemberAnalytics } from '@/analytics/members.analytics';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 interface Props {
   member: IMember;
@@ -29,7 +30,7 @@ export const ExperienceDetails = ({ isLoggedIn, userInfo, member }: Props) => {
   const isEditable = isOwner || isAdmin;
   const { onAddExperienceDetailsClicked, onEditExperienceDetailsClicked } = useMemberAnalytics();
 
-  if (!isLoggedIn) {
+  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
     return null;
   }
 

--- a/components/page/member-details/RepositoriesDetails/RepositoriesDetails.tsx
+++ b/components/page/member-details/RepositoriesDetails/RepositoriesDetails.tsx
@@ -10,6 +10,7 @@ import { ADMIN_ROLE } from '@/utils/constants';
 import { RepositoriesList } from '@/components/page/member-details/RepositoriesDetails/components/RepositoriesList';
 
 import s from './RepositoriesDetails.module.scss';
+import { getAccessLevel } from '@/utils/auth.utils';
 
 interface Props {
   member: IMember;
@@ -22,7 +23,7 @@ export const RepositoriesDetails = ({ isLoggedIn, userInfo, member }: Props) => 
   const isOwner = userInfo?.uid === member.id;
   const isEditable = isOwner || isAdmin;
 
-  if (!isLoggedIn) {
+  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
     return null;
   }
 


### PR DESCRIPTION
Added a check using `getAccessLevel` to ensure certain components, such as ContributionsDetails, RepositoriesDetails, and ExperienceDetails, are only accessible to users with "advanced" access level. This ensures proper access control and limits visibility of specific member details.