### PR TITLE
Allow owners to access and edit their own member details

### DIFF
--- a/app/members/[id]/page.tsx
+++ b/app/members/[id]/page.tsx
@@ -21,6 +21,7 @@ import { getAccessLevel } from '@/utils/auth.utils';
 const MemberDetails = async ({ params }: { params: any }) => {
   const memberId = params?.id;
   const { member, teams, redirectMemberId, isError, isLoggedIn, userInfo } = await getpageData(memberId);
+  const isOwner = userInfo?.uid === member.id;
 
   if (redirectMemberId) {
     redirect(`${PAGE_ROUTES.MEMBERS}/${redirectMemberId}`, RedirectType.replace);
@@ -44,7 +45,7 @@ const MemberDetails = async ({ params }: { params: any }) => {
 
         <ExperienceDetails userInfo={userInfo} member={member} isLoggedIn={isLoggedIn} />
 
-        {isLoggedIn && getAccessLevel(userInfo, isLoggedIn) === 'advanced' && (
+        {isLoggedIn && (getAccessLevel(userInfo, isLoggedIn) === 'advanced' || isOwner) && (
           <div className={styles?.memberDetail__container__teams}>
             <MemberTeams member={member} isLoggedIn={isLoggedIn} teams={teams ?? []} userInfo={userInfo} />
           </div>

--- a/components/page/member-details/ContributionsDetails/ContributionsDetails.tsx
+++ b/components/page/member-details/ContributionsDetails/ContributionsDetails.tsx
@@ -28,7 +28,7 @@ export const ContributionsDetails = ({ isLoggedIn, userInfo, member }: Props) =>
   const isEditable = isOwner || isAdmin;
   const { onEditContributionDetailsClicked, onAddContributionDetailsClicked } = useMemberAnalytics();
 
-  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
+  if (!isLoggedIn || (getAccessLevel(userInfo, isLoggedIn) !== 'advanced' && !isOwner)) {
     return null;
   }
 

--- a/components/page/member-details/ExperienceDetails/ExperienceDetails.tsx
+++ b/components/page/member-details/ExperienceDetails/ExperienceDetails.tsx
@@ -30,7 +30,7 @@ export const ExperienceDetails = ({ isLoggedIn, userInfo, member }: Props) => {
   const isEditable = isOwner || isAdmin;
   const { onAddExperienceDetailsClicked, onEditExperienceDetailsClicked } = useMemberAnalytics();
 
-  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
+  if (!isLoggedIn || (getAccessLevel(userInfo, isLoggedIn) !== 'advanced' && !isOwner)) {
     return null;
   }
 

--- a/components/page/member-details/RepositoriesDetails/RepositoriesDetails.tsx
+++ b/components/page/member-details/RepositoriesDetails/RepositoriesDetails.tsx
@@ -23,7 +23,7 @@ export const RepositoriesDetails = ({ isLoggedIn, userInfo, member }: Props) => 
   const isOwner = userInfo?.uid === member.id;
   const isEditable = isOwner || isAdmin;
 
-  if (!isLoggedIn || getAccessLevel(userInfo, isLoggedIn) !== 'advanced') {
+  if (!isLoggedIn || (getAccessLevel(userInfo, isLoggedIn) !== 'advanced' && !isOwner)) {
     return null;
   }
 


### PR DESCRIPTION
Previously, editing and viewing certain member details required an "advanced" access level. This update ensures that users who own the corresponding member profile can bypass this requirement, granting them appropriate access and functionality.