### PR TITLE
Fix undefined accessLevel check in UserInfoChecker logic

### DIFF
--- a/components/core/login/UserInfoChecker.tsx
+++ b/components/core/login/UserInfoChecker.tsx
@@ -12,7 +12,7 @@ export const UserInfoChecker = ({ userInfo }: { userInfo: IUserInfo }) => {
   const router = useRouter();
 
   useEffect(() => {
-    if (userInfoCookie && userInfo && member && member.memberInfo.accessLevel !== userInfo.accessLevel) {
+    if (userInfoCookie && userInfo && member && userInfo.accessLevel && member.memberInfo.accessLevel !== userInfo.accessLevel) {
       try {
         const _userInfo = JSON.parse(userInfoCookie);
 


### PR DESCRIPTION
Previously, the code did not properly check if `userInfo.accessLevel` was defined, which could lead to errors. This update ensures a safe comparison by adding a proper existence check before accessing the value.