### PR TITLE
Comment out border and box-shadow styles in selectors.

### DIFF
--- a/components/page/recommendations/components/MatchesEditor/MatchesEditor.module.scss
+++ b/components/page/recommendations/components/MatchesEditor/MatchesEditor.module.scss
@@ -105,9 +105,9 @@
 
   @include mixins.placeholder {
     border-radius: var(--corner-radius-sm, 6px);
-    border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+    //border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
     background: var(--background-base-white, #FFF);
-    box-shadow: 0 1px 2px 0 var(--transparent-dark-6, rgba(14, 15, 17, 0.06));
+    //box-shadow: 0 1px 2px 0 var(--transparent-dark-6, rgba(14, 15, 17, 0.06));
     display: flex;
     padding: var(--spacing-4xs, 6px) var(--spacing-3xs, 6px);
     justify-content: center;

--- a/components/page/recommendations/components/MatchesSelector/MatchesSelector.module.scss
+++ b/components/page/recommendations/components/MatchesSelector/MatchesSelector.module.scss
@@ -236,9 +236,9 @@
   text-align: left;
   justify-content: flex-start;
   border-radius: var(--corner-radius-sm, 6px);
-  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  //border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
   background: var(--background-base-white, #FFF);
-  box-shadow: 0 1px 2px 0 var(--transparent-dark-6, rgba(14, 15, 17, 0.06));
+  //box-shadow: 0 1px 2px 0 var(--transparent-dark-6, rgba(14, 15, 17, 0.06));
   display: flex;
   padding: var(--spacing-4xs, 4px) var(--spacing-3xs, 6px);
   align-items: center;


### PR DESCRIPTION
The border and box-shadow properties were commented out in both MatchesSelector and MatchesEditor styles. This change likely simplifies or adjusts the visual appearance, aligning with design updates or reducing unnecessary styling.