### PR TITLE
Add "not found" message with link for select dropdowns

### DIFF
--- a/components/form/FormSelect/FormSelect.module.scss
+++ b/components/form/FormSelect/FormSelect.module.scss
@@ -73,3 +73,19 @@
     color: #A0BEFF;
   }
 }
+
+.notFound {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  span {
+    color: var(--Neutral-Slate-600);
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 14px; /* 116.667% */
+    letter-spacing: 0.12px;
+  }
+}

--- a/components/form/FormSelect/FormSelect.tsx
+++ b/components/form/FormSelect/FormSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Field } from '@base-ui-components/react/field';
 import { useFormContext } from 'react-hook-form';
 
@@ -15,9 +15,10 @@ interface Props {
   options: OptionsOrGroups<string, GroupBase<string>>;
   disabled?: boolean;
   isRequired?: boolean;
+  notFoundContent?: ReactNode;
 }
 
-export const FormSelect = ({ name, placeholder, label, description, options, disabled, isRequired }: Props) => {
+export const FormSelect = ({ name, placeholder, label, description, options, disabled, isRequired, notFoundContent }: Props) => {
   const {
     watch,
     formState: { errors },
@@ -109,6 +110,16 @@ export const FormSelect = ({ name, placeholder, label, description, options, dis
           indicatorSeparator: (base) => ({
             display: 'none',
           }),
+        }}
+        components={{
+          NoOptionsMessage: () => {
+            return (
+              <div className={s.notFound}>
+                <span>No options found</span>
+                {notFoundContent}
+              </div>
+            );
+          },
         }}
       />
       {!errors[name] && description ? (

--- a/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.module.scss
+++ b/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.module.scss
@@ -27,6 +27,19 @@
   width: 100%;
 }
 
+.secondaryLabel {
+  color: var(--Neutral-Slate-600);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 14px; /* 116.667% */
+  letter-spacing: 0.12px;
+
+  .link {
+    color: #1B4DFF;
+  }
+}
+
 .deleteBtn {
   display: flex;
   align-items: center;

--- a/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.tsx
+++ b/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.tsx
@@ -22,6 +22,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { editContributionsSchema } from '@/components/page/member-details/ContributionsDetails/components/EditContributionsForm/helpers';
 import { useMemberAnalytics } from '@/analytics/members.analytics';
 import { EditFormMobileControls } from '@/components/page/member-details/components/EditFormMobileControls';
+import Link from 'next/link';
 
 interface Props {
   onClose: () => void;
@@ -121,6 +122,15 @@ export const EditContributionsForm = ({ onClose, member, initialData }: Props) =
                   value: item.projectUid,
                   label: item.projectName,
                 })) ?? []
+              }
+              notFoundContent={
+                <div className={s.secondaryLabel}>
+                  If you don&apos;t see your project on this list, please{' '}
+                  <Link href="/projects/add" className={s.link}>
+                    add your project
+                  </Link>{' '}
+                  first.
+                </div>
               }
             />
           </div>

--- a/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.module.scss
+++ b/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.module.scss
@@ -42,7 +42,6 @@
   margin: 0 auto;
 }
 
-
 .expItem {
   display: flex;
   padding: 16px 32px 16px 16px;
@@ -70,6 +69,10 @@
   font-weight: 400;
   line-height: 14px; /* 116.667% */
   letter-spacing: 0.12px;
+
+  .link {
+    color: #1B4DFF;
+  }
 }
 
 .Separator {

--- a/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.tsx
+++ b/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.tsx
@@ -22,6 +22,7 @@ import Image from 'next/image';
 import { useGetTeam } from '@/services/teams/hooks/useGetTeam';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
+import Link from 'next/link';
 
 interface Props {
   onClose: () => void;
@@ -151,9 +152,9 @@ export const EditTeamForm = ({ onClose, member, initialData }: Props) => {
             )
           )}
 
-          <div className={s.row}>
-            <FormField name="url" label="Team URL" placeholder="Enter team url" />
-          </div>
+          {/*<div className={s.row}>*/}
+          {/*  <FormField name="url" label="Team URL" placeholder="Enter team url" />*/}
+          {/*</div>*/}
           <div className={s.row}>
             <FormSelect
               name="name"
@@ -165,6 +166,15 @@ export const EditTeamForm = ({ onClose, member, initialData }: Props) => {
                   value: item.teamUid,
                   label: item.teamTitle,
                 })) ?? []
+              }
+              notFoundContent={
+                <div className={s.secondaryLabel}>
+                  If you don&apos;t see your team on this list, please{' '}
+                  <Link href="/teams/add" className={s.link}>
+                    add your team
+                  </Link>{' '}
+                  first.
+                </div>
               }
             />
           </div>


### PR DESCRIPTION
Introduce a customizable "not found" message to `FormSelect`, allowing users to provide additional contextual content when no options are available. Update team and project forms to include helpful links for creating new entities when the dropdown list is empty. Style adjustments added for consistency with the UI.

<img width="1009" height="388" alt="image" src="https://github.com/user-attachments/assets/6684168c-d808-4ea6-b3bc-06c45af9a159" />
