### PR TITLE
Update image input types and add padding to ConfirmDialog

### DIFF
--- a/components/core/ConfirmDialog/ConfirmDialog.module.css
+++ b/components/core/ConfirmDialog/ConfirmDialog.module.css
@@ -9,6 +9,7 @@
     align-items: center;
     justify-content: center;
     background: #00000066;
+    padding: 16px;
 }
 
 .closeButton {

--- a/components/page/member-details/ProfileDetails/components/ProfileImageInput/ProfileImageInput.tsx
+++ b/components/page/member-details/ProfileDetails/components/ProfileImageInput/ProfileImageInput.tsx
@@ -45,7 +45,7 @@ export const ProfileImageInput = ({ member }: Props) => {
     maxSize: 4 * 1024 * 1024,
     accept: {
       'image/png': ['.png'],
-      'image/jpg': ['.jpg'],
+      'image/jpeg': ['.jpg', '.jpeg'],
     },
   });
 


### PR DESCRIPTION
Enhanced `ProfileImageInput` to support `.jpeg` files alongside `.jpg`. Added padding to the `ConfirmDialog` backdrop for better spacing in the layout.