### PR TITLE
Set links to open in a new tab for team/project additions

### DIFF
--- a/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.tsx
+++ b/components/page/member-details/ContributionsDetails/components/EditContributionsForm/EditContributionsForm.tsx
@@ -127,7 +127,7 @@ export const EditContributionsForm = ({ onClose, member, initialData }: Props) =
               notFoundContent={
                 <div className={s.secondaryLabel}>
                   If you don&apos;t see your project on this list, please{' '}
-                  <Link href="/projects/add" className={s.link}>
+                  <Link href="/projects/add" className={s.link} target="_blank">
                     add your project
                   </Link>{' '}
                   first.

--- a/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.tsx
+++ b/components/page/member-details/TeamsDetails/components/EditTeamForm/EditTeamForm.tsx
@@ -171,7 +171,7 @@ export const EditTeamForm = ({ onClose, member, initialData }: Props) => {
               notFoundContent={
                 <div className={s.secondaryLabel}>
                   If you don&apos;t see your team on this list, please{' '}
-                  <Link href="/teams/add" className={s.link}>
+                  <Link href="/teams/add" className={s.link} target="_blank">
                     add your team
                   </Link>{' '}
                   first.


### PR DESCRIPTION
Updated the "add your team" and "add your project" links to open in a new tab using the `target="_blank"` attribute. This ensures users can add teams or projects without losing their current form progress.