### PR TITLE
Replace Tooltip with CustomTooltip and add styles

### DIFF
--- a/components/page/member-details/member-detail-header.tsx
+++ b/components/page/member-details/member-detail-header.tsx
@@ -14,6 +14,7 @@ import { useDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { useRecommendationLinkAnalyticsReport } from '@/services/members/hooks/useRecommendationLinkAnalyticsReport';
 import { EditButton } from '@/components/page/member-details/components/EditButton';
 import clsx from 'clsx';
+import CustomTooltip from '@/components/ui/Tooltip/Tooltip';
 
 interface IMemberDetailHeader {
   member: IMember;
@@ -75,19 +76,18 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
         <div className="header__details">
           <div className="header__details__specifics">
             <div className="header__details__specifics__hdr">
-              <Tooltip asChild trigger={<h1 className="header__details__specifics__name">{name}</h1>} content={name} />
+              <CustomTooltip trigger={<h1 className="header__details__specifics__name">{name}</h1>} content={name} />
             </div>
             <div className="header__details__roleandlocation">
               {member?.teams[0]?.name && (
                 <div className="header__details__roleandlocation__teams">
-                  <Tooltip
-                    asChild
+                  <CustomTooltip
                     trigger={<p className="header__details__roleandlocation__teams__name"> {member?.teams?.length > 0 ? mainTeam?.name : ''} </p>}
                     content={member?.teams?.length > 0 ? mainTeam?.name : ''}
                   />
                   {member?.teams?.length > 1 && (
-                    <Tooltip
-                      asChild
+                    <CustomTooltip
+                      forceTooltip
                       trigger={
                         <button onClick={(e) => e.preventDefault()} className="header__details__roleandlocation__teams__count">
                           +{(member?.teams?.length - 1).toString()}
@@ -107,7 +107,7 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
                   )}
                 </div>
               )}
-              <Tooltip asChild trigger={<p className="header__details__roleandlocation__role">{role}</p>} content={role} />
+              <CustomTooltip trigger={<p className="header__details__roleandlocation__role">{role}</p>} content={role} />
               {isLoggedIn && (
                 <div className="header__details__roleandlocation__location">
                   <img loading="lazy" src="/icons/location.svg" height={13} width={11} />
@@ -150,8 +150,7 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
           {skills?.map((skill: any, index: number) => (
             <Fragment key={`${skill} + ${index}`}>
               {index < 3 && (
-                <Tooltip
-                  asChild
+                <CustomTooltip
                   trigger={
                     <div>
                       <Tag value={skill?.title} tagsLength={skills?.length} />
@@ -163,8 +162,7 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
             </Fragment>
           ))}
           {skills?.length > 3 && (
-            <Tooltip
-              asChild
+            <CustomTooltip
               trigger={
                 <div>
                   <Tag variant="primary" value={'+' + (skills?.length - 3).toString()}></Tag>{' '}

--- a/components/ui/Tooltip/Tooltip.module.scss
+++ b/components/ui/Tooltip/Tooltip.module.scss
@@ -1,0 +1,70 @@
+.Popup {
+  box-sizing: border-box;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  background-color: var(--Neutral-Slate-900);
+  color: var(--Neutral-White);
+  transform-origin: var(--transform-origin);
+  transition:
+          transform 150ms,
+          opacity 150ms;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+
+  &[data-instant] {
+    transition-duration: 0ms;
+  }
+
+  outline: 1px solid var(--color-gray-200);
+  box-shadow:
+          0 10px 15px -3px var(--color-gray-200),
+          0 4px 6px -4px var(--color-gray-200);
+}
+
+.Arrow {
+  display: flex;
+
+  &[data-side='top'] {
+    bottom: -8px;
+    rotate: 180deg;
+  }
+
+  &[data-side='bottom'] {
+    top: -8px;
+    rotate: 0deg;
+  }
+
+  &[data-side='left'] {
+    right: -13px;
+    rotate: 90deg;
+  }
+
+  &[data-side='right'] {
+    left: -13px;
+    rotate: -90deg;
+  }
+}
+
+.ArrowFill {
+  fill: var(--Neutral-Slate-900);
+}
+
+.ArrowOuterStroke {
+  @media (prefers-color-scheme: light) {
+    fill: var(--Neutral-Slate-600);
+  }
+}
+
+.ArrowInnerStroke {
+  @media (prefers-color-scheme: dark) {
+    fill: var(--Neutral-Slate-600);
+  }
+}

--- a/components/ui/Tooltip/Tooltip.tsx
+++ b/components/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { Tooltip } from '@base-ui-components/react/tooltip';
+import styles from './Tooltip.module.scss';
+import clsx from 'clsx';
+
+interface Props {
+  trigger: React.ReactElement;
+  content: React.ReactNode;
+  className?: string;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  sideOffset?: number;
+  delay?: number;
+  forceTooltip?: boolean;
+}
+
+export default function CustomTooltip({
+  trigger,
+  content,
+  className,
+  side = 'top',
+  sideOffset = 10,
+  delay = 0,
+  forceTooltip = false, // ✅ default to false
+}: Props) {
+  const triggerRef = React.useRef<HTMLElement>(null);
+  const [isTruncated, setIsTruncated] = React.useState(false);
+
+  React.useEffect(() => {
+    if (forceTooltip) return;
+
+    const checkTruncation = () => {
+      const el = triggerRef.current;
+      if (el) {
+        setIsTruncated(el.scrollWidth > el.clientWidth);
+      }
+    };
+
+    checkTruncation();
+
+    const resizeObserver = new ResizeObserver(checkTruncation);
+    if (triggerRef.current) {
+      resizeObserver.observe(triggerRef.current);
+    }
+
+    return () => {
+      if (triggerRef.current) {
+        resizeObserver.unobserve(triggerRef.current);
+      }
+    };
+  }, [trigger, forceTooltip]);
+
+  const clonedTrigger = React.cloneElement(trigger, {
+    ref: triggerRef,
+    tabIndex: 0,
+  });
+
+  // ✅ Only show tooltip if forced or truncated
+  if (!forceTooltip && !isTruncated) return clonedTrigger;
+
+  return (
+    <Tooltip.Provider delay={delay}>
+      <Tooltip.Root>
+        <Tooltip.Trigger>{clonedTrigger}</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner side={side} sideOffset={sideOffset}>
+            <Tooltip.Popup className={clsx(styles.Popup, className)}>
+              <Tooltip.Arrow className={styles.Arrow}>
+                <ArrowSvg />
+              </Tooltip.Arrow>
+              {content}
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}
+
+const ArrowSvg = React.memo(function ArrowSvg(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className={styles.ArrowFill}
+      />
+      <path
+        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+        className={styles.ArrowOuterStroke}
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className={styles.ArrowInnerStroke}
+      />
+    </svg>
+  );
+});


### PR DESCRIPTION
Introduced a new `CustomTooltip` component with enhanced styling and behavior, including truncation checks and forced display support. Updated member detail header to use `CustomTooltip` and added a dedicated SCSS module for tooltip styles.