### PR TITLE
Add dynamic validation for conditional date inputs

### DIFF
--- a/components/page/member-details/ContactDetails/components/EditContactForm/EditContactForm.module.scss
+++ b/components/page/member-details/ContactDetails/components/EditContactForm/EditContactForm.module.scss
@@ -131,6 +131,11 @@
   flex-direction: column;
   width: 100%;
   padding-block: 12px;
+  flex: 1;
+}
+
+.switchLabelWrapper + label {
+  width: unset !important;
 }
 
 .switchLabel {

--- a/components/page/member-details/ContributionsDetails/components/ContributionsDatesInput/ContributionsDatesInput.tsx
+++ b/components/page/member-details/ContributionsDetails/components/ContributionsDatesInput/ContributionsDatesInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { MonthYearSelect } from '@/components/form/MonthYearSelect';
@@ -11,12 +11,19 @@ export const ContributionsDatesInput = () => {
   const {
     watch,
     setValue,
-    formState: { errors },
+    trigger,
+    formState: { errors, dirtyFields, touchedFields },
   } = useFormContext<TEditContributionsForm>();
   const { startDate, endDate, isCurrent } = watch();
 
   const error0 = errors.startDate;
   const error1 = errors.endDate;
+
+  useEffect(() => {
+    if (dirtyFields.isCurrent && errors.endDate) {
+      trigger();
+    }
+  }, [isCurrent, trigger, dirtyFields.isCurrent, errors.endDate]);
 
   return (
     <div className={s.root}>
@@ -35,6 +42,7 @@ export const ContributionsDatesInput = () => {
           }}
         />
         <MonthYearSelect
+          isRequired={!isCurrent}
           error={error1?.message}
           label="End Date"
           value={endDate}

--- a/components/page/member-details/ExperienceDetails/components/ExperienceDatesInput/ExperienceDatesInput.tsx
+++ b/components/page/member-details/ExperienceDetails/components/ExperienceDatesInput/ExperienceDatesInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import s from './ExperienceDatesInput.module.scss';
@@ -10,14 +10,19 @@ export const ExperienceDatesInput = () => {
   const {
     watch,
     setValue,
-    formState: { errors },
+    formState: { errors, dirtyFields },
+    trigger,
   } = useFormContext<TEditExperienceForm>();
   const { startDate, endDate, isCurrent } = watch();
 
   const error0 = errors.startDate;
   const error1 = errors.endDate;
 
-  console.log(errors);
+  useEffect(() => {
+    if (dirtyFields.isCurrent && errors.endDate) {
+      trigger();
+    }
+  }, [isCurrent, trigger, dirtyFields.isCurrent, errors.endDate]);
 
   return (
     <div className={s.root}>
@@ -36,7 +41,7 @@ export const ExperienceDatesInput = () => {
           }}
         />
         <MonthYearSelect
-          isRequired
+          isRequired={!isCurrent}
           error={error1?.message}
           disabled={isCurrent}
           label="End Date"


### PR DESCRIPTION
Introduced `useEffect` to trigger validation when `isCurrent` changes in forms, ensuring dynamic validation for end date fields. Also adjusted styling for switch labels and fixed required status for end date based on `isCurrent`.