### PR TITLE
Prevent multiple error toasts for large file uploads

### DIFF
--- a/components/page/member-details/ProfileDetails/components/ProfileImageInput/ProfileImageInput.tsx
+++ b/components/page/member-details/ProfileDetails/components/ProfileImageInput/ProfileImageInput.tsx
@@ -28,6 +28,7 @@ export const ProfileImageInput = ({ member }: Props) => {
         el.errors.forEach((item) => {
           if (item.code === 'file-too-large') {
             toast.error('File is larger than 4Mb');
+            return;
           }
 
           toast.error(item.message);


### PR DESCRIPTION
Added a return statement to stop further error handling after displaying the 'file-too-large' message. This ensures only one toast is shown, improving user experience.