### PR TITLE
Enhance form inputs and interactions for better usability

### DIFF
--- a/components/form/FormSelect/FormSelect.module.scss
+++ b/components/form/FormSelect/FormSelect.module.scss
@@ -150,6 +150,8 @@
   justify-content: center;
   align-items: flex-start;
   flex: 1 0 0;
+
+  outline: none;
 }
 
 .mobileOptions {

--- a/components/form/FormSelect/FormSelect.tsx
+++ b/components/form/FormSelect/FormSelect.tsx
@@ -47,7 +47,7 @@ export const FormSelect = ({ name, placeholder, label, description, options, dis
             </button>
           </div>
           <div className={s.mobileSearchWrapper}>
-            <Input className={s.mobileSearchInput} placeholder={placeholder} value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
+            <Input autoFocus className={s.mobileSearchInput} placeholder={placeholder} value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
             <SearchIcon />
           </div>
           <div className={s.mobileOptions}>
@@ -89,7 +89,7 @@ export const FormSelect = ({ name, placeholder, label, description, options, dis
           value={value}
           defaultValue={value}
           onChange={(val) => setValue(name, val, { shouldValidate: true, shouldDirty: true })}
-          isDisabled={disabled}
+          isDisabled={disabled || open}
           onMenuOpen={() => {
             if (!isMobile) {
               return;

--- a/components/page/member-details/member-detail-header.tsx
+++ b/components/page/member-details/member-detail-header.tsx
@@ -163,6 +163,7 @@ const MemberDetailHeader = (props: IMemberDetailHeader) => {
           ))}
           {skills?.length > 3 && (
             <CustomTooltip
+              forceTooltip
               trigger={
                 <div>
                   <Tag variant="primary" value={'+' + (skills?.length - 3).toString()}></Tag>{' '}


### PR DESCRIPTION
Added `autoFocus` to the mobile search input for improved UX. Disabled form select dropdown when open and removed outline for cleaner styling. Enabled forced tooltip display for additional skill tags in the member detail header.