### PR TITLE
Add `useScrollIntoViewOnFocus` hook for improved UX

### DIFF
--- a/components/form/FormField/FormField.tsx
+++ b/components/form/FormField/FormField.tsx
@@ -4,6 +4,7 @@ import { Field } from '@base-ui-components/react/field';
 import { useFormContext } from 'react-hook-form';
 
 import s from './FormField.module.scss';
+import { useScrollIntoViewOnFocus } from '@/hooks/useScrollIntoViewOnFocus';
 
 interface Props extends PropsWithChildren {
   name: string;
@@ -19,6 +20,8 @@ export const FormField = ({ name, placeholder, label, description, disabled, chi
     register,
     formState: { errors },
   } = useFormContext();
+
+  useScrollIntoViewOnFocus<HTMLInputElement>({ id: name });
 
   return (
     <Field.Root className={s.field}>
@@ -37,7 +40,7 @@ export const FormField = ({ name, placeholder, label, description, disabled, chi
         })}
       >
         <div className={s.inputContent}>
-          <Field.Control {...register(name)} disabled={disabled} placeholder={placeholder} className={s.inputElement} />
+          <Field.Control {...register(name)} disabled={disabled} placeholder={placeholder} className={s.inputElement} id={name} />
         </div>
         {children}
       </div>

--- a/components/form/FormMultiSelect/FormMultiSelect.tsx
+++ b/components/form/FormMultiSelect/FormMultiSelect.tsx
@@ -8,6 +8,7 @@ import s from './FormMultiSelect.module.scss';
 import { clsx } from 'clsx';
 import { TRecommendationsSettingsForm } from '@/components/page/recommendations/components/RecommendationsSettingsForm/types';
 import { useToggle } from 'react-use';
+import { useScrollIntoViewOnFocus } from '@/hooks/useScrollIntoViewOnFocus';
 
 interface Props {
   name: string;
@@ -27,7 +28,6 @@ const filterAndSort = (option: { value: string; label: string }, input: string) 
 
 export const FormMultiSelect = ({ name, placeholder, label, description, options, disabled, isRequired }: Props) => {
   const {
-    watch,
     formState: { errors },
     setValue,
     getValues,
@@ -39,6 +39,8 @@ export const FormMultiSelect = ({ name, placeholder, label, description, options
 
   // Sort filtered options by label dynamically
   const sortedOptions = [...options].filter((option) => filterAndSort(option, inputValue)).sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+
+  useScrollIntoViewOnFocus<HTMLInputElement>({ id: name });
 
   return (
     <Field.Root className={s.field}>
@@ -61,6 +63,7 @@ export const FormMultiSelect = ({ name, placeholder, label, description, options
         filterOption={() => true}
         isClearable={false}
         placeholder={placeholder}
+        inputId={name}
         // @ts-ignore
         value={val}
         onChange={(val) => {

--- a/components/form/FormSelect/FormSelect.tsx
+++ b/components/form/FormSelect/FormSelect.tsx
@@ -8,6 +8,7 @@ import Select from 'react-select';
 import s from './FormSelect.module.scss';
 import { clsx } from 'clsx';
 import { useMedia, useToggle } from 'react-use';
+import { useScrollIntoViewOnFocus } from '@/hooks/useScrollIntoViewOnFocus';
 
 interface Props {
   name: string;
@@ -33,6 +34,8 @@ export const FormSelect = ({ name, placeholder, label, description, options, dis
   const [open, toggleOpen] = useToggle(false);
   const isMobile = useMedia('(max-width: 960px)', false);
   const [searchTerm, setSearchTerm] = useState('');
+
+  useScrollIntoViewOnFocus<HTMLInputElement>({ id: name });
 
   return (
     <>
@@ -90,6 +93,7 @@ export const FormSelect = ({ name, placeholder, label, description, options, dis
           defaultValue={value}
           onChange={(val) => setValue(name, val, { shouldValidate: true, shouldDirty: true })}
           isDisabled={disabled}
+          inputId={name}
           onMenuOpen={() => {
             if (!isMobile) {
               return;

--- a/components/form/MonthYearSelect/MonthYearSelect.tsx
+++ b/components/form/MonthYearSelect/MonthYearSelect.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import Select from 'react-select';
 import s from './MonthYearSelect.module.scss';
 import clsx from 'clsx';
+import { useScrollIntoViewOnFocus } from '@/hooks/useScrollIntoViewOnFocus';
 
 const getYearOptions = (start: number, end: number) =>
   Array.from({ length: end - start + 1 }, (_, i) => {
@@ -62,6 +63,8 @@ export const MonthYearSelect = ({ label, value, onChange, disabled, error, isReq
     }, 0);
   }, [value]);
 
+  useScrollIntoViewOnFocus<HTMLInputElement>({ id: label });
+
   const emitChange = (newMonth: typeof month, newYear: typeof year) => {
     if (justSynced.current) return;
     if (newMonth && newYear) {
@@ -103,6 +106,7 @@ export const MonthYearSelect = ({ label, value, onChange, disabled, error, isReq
           value={month}
           onChange={handleMonthChange}
           isDisabled={disabled}
+          inputId={label}
           styles={{
             container: (base) => ({
               ...base,

--- a/components/page/member-details/ExperienceDetails/components/EditExperienceForm/EditExperienceForm.tsx
+++ b/components/page/member-details/ExperienceDetails/components/EditExperienceForm/EditExperienceForm.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useTransition } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { FormField } from '@/components/form/FormField';
 import { IMember } from '@/types/members.types';
-import { IUserInfo } from '@/types/shared.types';
 import { EditFormControls } from '@/components/page/member-details/components/EditFormControls';
 import { FormattedMemberExperience } from '@/services/members/hooks/useMemberExperience';
 import { TEditExperienceForm } from '@/components/page/member-details/ExperienceDetails/types';

--- a/hooks/useScrollIntoViewOnFocus.ts
+++ b/hooks/useScrollIntoViewOnFocus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+type Options = {
+  id?: string;
+  behavior?: ScrollBehavior;
+  block?: ScrollLogicalPosition;
+  mobileOnly?: boolean; // ✅ new option
+};
+
+export function useScrollIntoViewOnFocus<T extends HTMLElement>({ id, behavior = 'smooth', block = 'center', mobileOnly = true }: Options = {}) {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const element: T | null = id ? (document.getElementById(id) as T | null) : ref.current;
+
+    if (!element) return;
+
+    const handleFocus = () => {
+      const isMobile = window.innerWidth < 1024;
+
+      if (!mobileOnly || isMobile) {
+        setTimeout(() => {
+          element.scrollIntoView({ behavior, block });
+        }, 100);
+      }
+    };
+
+    element.addEventListener('focus', handleFocus);
+
+    return () => {
+      element.removeEventListener('focus', handleFocus);
+    };
+  }, [id, behavior, block, mobileOnly]);
+
+  return ref;
+}


### PR DESCRIPTION
Integrate `useScrollIntoViewOnFocus` across form components to ensure inputs scroll into view when focused, especially on mobile. Introduce the reusable hook and update relevant components to pass input IDs for smoother navigation. Removed unused imports for cleanup.