### PR TITLE
Fix post handling with trimmed titles and adjusted styles

### DIFF
--- a/components/page/forum/CreatePost/CreatePost.tsx
+++ b/components/page/forum/CreatePost/CreatePost.tsx
@@ -72,7 +72,7 @@ export const CreatePost = ({ isEdit, initialData, pid }: { isEdit?: boolean; ini
       if (isEdit && pid) {
         const res = await editPost({
           pid,
-          title: data.title,
+          title: data.title?.trim() || '',
           content,
         });
 
@@ -86,7 +86,7 @@ export const CreatePost = ({ isEdit, initialData, pid }: { isEdit?: boolean; ini
       } else {
         const res = await createPost({
           cid: data.topic.value,
-          title: data.title,
+          title: data.title?.trim(),
           content,
         });
 

--- a/components/page/forum/CreatePost/helpers.ts
+++ b/components/page/forum/CreatePost/helpers.ts
@@ -21,7 +21,7 @@ export const createPostSchema = yup.object().shape({
       },
     })
     .required('Required'),
-  title: yup.string().min(3, 'The title must be at least 3 characters long').required('Required').max(10, 'Please enter a shorter title. Titles cannot be longer than 255 character(s).'),
+  title: yup.string().min(3, 'The title must be at least 3 characters long').required('Required').max(255, 'Please enter a shorter title. Titles cannot be longer than 255 character(s).'),
   content: yup
     .string()
     .test({

--- a/components/page/forum/Post/Post.module.scss
+++ b/components/page/forum/Post/Post.module.scss
@@ -102,6 +102,7 @@
   letter-spacing: -0.4px;
   margin-top: 8px;
   width: 100%;
+  word-break: break-all;
 }
 
 .sub {

--- a/components/page/forum/Posts/Posts.module.scss
+++ b/components/page/forum/Posts/Posts.module.scss
@@ -100,6 +100,7 @@
   line-height: 24px;
   letter-spacing: -0.3px;
   width: 100%;
+  word-break: break-all;
 }
 
 .desc {

--- a/components/page/forum/Posts/Posts.tsx
+++ b/components/page/forum/Posts/Posts.tsx
@@ -60,7 +60,7 @@ export const Posts = () => {
         const content = decoded.length > 200 ? `${decoded.slice(0, 200)}...` : decoded;
 
         return (
-          <Link className={s.listItem} key={post.tid} href={`/forum/categories/${post.cid}/${post.tid}`}>
+          <Link className={s.listItem} key={post.tid} href={`/forum/categories/${post.cid}/${post.tid}`} prefetch={false}>
             <div className={s.title}>{post.title}</div>
             <div className={s.desc}>
               <span dangerouslySetInnerHTML={{ __html: content ?? '' }} />


### PR DESCRIPTION
Ensure titles are trimmed before submission to avoid issues with leading/trailing spaces. Update title validation to correctly enforce a 255-character limit. Enhance UI with a word-break style for better text wrapping and optimize link prefetching in the posts list.