### PR TITLE
Update forum feed and header to handle root category sorting

### DIFF
--- a/components/page/forum/Feed/Feed.tsx
+++ b/components/page/forum/Feed/Feed.tsx
@@ -22,6 +22,11 @@ export const Feed = () => {
     (value: string) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set('cid', value); // or use `params.delete(key)` to remove
+
+      if (value === '0') {
+        params.set('categoryTopicSort', 'recently_created');
+      }
+
       router.push(`?${params.toString()}`, { scroll: false });
     },
     [router, searchParams],

--- a/components/page/forum/ForumHeader/ForumHeader.tsx
+++ b/components/page/forum/ForumHeader/ForumHeader.tsx
@@ -33,6 +33,7 @@ export const ForumHeader = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[0];
+  const selectedCategory = searchParams.get('cid');
 
   const onValueChange = (_value: string) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -52,6 +53,7 @@ export const ForumHeader = () => {
           options={sortOptions}
           value={value}
           defaultValue={value}
+          isDisabled={selectedCategory === '0'}
           onChange={(val) => {
             if (val) {
               onValueChange(val.value);


### PR DESCRIPTION
Add logic in the forum feed to default to "recently_created" sorting when the root category is selected. Disable the sort dropdown in the forum header when the root category is active to prevent invalid selections.