### PR TITLE
Add auto-scroll to comments and improve reply input behavior

### DIFF
--- a/components/page/forum/CommentInput/CommentInput.tsx
+++ b/components/page/forum/CommentInput/CommentInput.tsx
@@ -121,7 +121,7 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
     <FormProvider {...methods}>
       <form
         className={clsx('input-form', s.root, {
-          [s.hidden]: scrollDirection === 'down',
+          [s.hidden]: scrollDirection === 'down' && !replyToName,
         })}
         noValidate
         onSubmit={handleSubmit(onSubmit)}

--- a/components/page/forum/PostComments/PostComments.tsx
+++ b/components/page/forum/PostComments/PostComments.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useCallback, useEffect, useRef } from 'react';
 
 import { TopicResponse } from '@/services/forum/hooks/useForumPost';
 import { Avatar } from '@base-ui-components/react/avatar';
@@ -70,12 +70,19 @@ export const PostComments = ({ comments, tid, mainPid, onReply, userInfo }: Prop
 };
 
 const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment; isReply?: boolean; onReply?: (pid: number) => void; userInfo: IUserInfo }) => {
+  const ref = useRef<HTMLDivElement>(null);
   const [replyToPid, setReplyToPid] = React.useState<number | null>(null);
   const [editPid, setEditPid] = React.useState<number | null>(null);
 
+  const scrollIntoView = useCallback(() => {
+    if (ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, []);
+
   return (
     <>
-      <div className={s.itemRoot} key={item.pid}>
+      <div className={s.itemRoot} key={item.pid} ref={ref}>
         <div className={s.footer}>
           <Avatar.Root className={s.Avatar}>
             <Avatar.Image src={getDefaultAvatar(item.user.username)} width="32" height="32" className={s.Image} />
@@ -118,6 +125,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
                   onClick={() => {
                     if (onReply) {
                       onReply(item.pid);
+                      scrollIntoView();
                     } else {
                       setReplyToPid(item.pid);
                     }


### PR DESCRIPTION
Implemented a smooth scroll feature for comments when replying, using `useRef` and `useCallback`. Also updated the reply input to remain visible when replying, regardless of scroll direction.