### PR TITLE
Refine RichTextEditor styles and submission button logic

### DIFF
--- a/components/page/forum/CreatePost/CreatePost.tsx
+++ b/components/page/forum/CreatePost/CreatePost.tsx
@@ -140,7 +140,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
                 >
                   Cancel
                 </button>
-                <button className={s.submitBtn} disabled={isSubmitting || !isValid || !isDirty}>
+                <button className={s.submitBtn} disabled={isSubmitting || !isDirty}>
                   {isSubmitting ? 'Processing...' : isEdit ? 'Save' : 'Post'}
                 </button>
               </div>
@@ -155,7 +155,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
               >
                 Cancel
               </button>
-              <button className={s.submitBtn} disabled={isSubmitting || !isValid || !isDirty}>
+              <button className={s.submitBtn} disabled={isSubmitting || !isDirty}>
                 {isSubmitting ? 'Processing...' : isEdit ? 'Save' : 'Post'}
               </button>
             </div>

--- a/components/ui/RichTextEditor/RichTextEditor.module.scss
+++ b/components/ui/RichTextEditor/RichTextEditor.module.scss
@@ -4,11 +4,19 @@
   gap: 4px;
   width: 100%;
   border-radius: 8px;
-  border: 1px solid transparent;
+  //border: 1px solid transparent;
 
   &:focus-within {
-    border-color: #5E718D !important;
+    //border-color: #5E718D !important;
     box-shadow: 0 0 0 4px rgba(27, 56, 96, 0.12) !important;
+
+    :global(.ql-toolbar) {
+      border-color: #5E718D;
+    }
+
+    :global(.ql-container) {
+      border-color: #5E718D;
+    }
   }
 
   &.error {

--- a/components/ui/RichTextEditor/RichTextEditor.tsx
+++ b/components/ui/RichTextEditor/RichTextEditor.tsx
@@ -8,7 +8,6 @@ import ImageUploader from 'quill-image-uploader';
 import 'quill-image-uploader/dist/quill.imageUploader.min.css';
 
 import s from './RichTextEditor.module.scss';
-import { useMember } from '@/services/members/hooks/useMember';
 import { getCookiesFromClient } from '@/utils/third-party.helper';
 import { saveRegistrationImage } from '@/services/registration.service';
 


### PR DESCRIPTION
Comment out redundant border styles in RichTextEditor, introducing global styling for better visual consistency. Simplify the button `disabled` logic in CreatePost by removing reliance on `isValid`, focusing on `isDirty` and `isSubmitting` states instead. Also, clean up an unused import in RichTextEditor.