### PR TITLE
Enhance API requests with optional authorization token

### DIFF
--- a/services/forum/hooks/useCheckGroupAccess.ts
+++ b/services/forum/hooks/useCheckGroupAccess.ts
@@ -1,23 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { ForumQueryKeys } from '@/services/forum/constants';
 import { customFetch } from '@/utils/fetch-wrapper';
-import { getCookiesFromClient } from '@/utils/third-party.helper';
 
 type GroupAccessResponse = {
   hasAccess: boolean;
 };
 
 async function fetcher(): Promise<GroupAccessResponse> {
-  const { authToken } = getCookiesFromClient();
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
   const response = await customFetch(
     `${process.env.DIRECTORY_API_URL}/v1/forum/check-group-access`,
     {
       headers: {
-        Authorization: `Bearer ${authToken}`,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         'Content-Type': 'application/json',
       },
     },
-    false,
+    !token,
   );
 
   if (!response?.ok) {

--- a/services/forum/hooks/useForumCategories.ts
+++ b/services/forum/hooks/useForumCategories.ts
@@ -198,7 +198,17 @@ type CategoriesResponse = {
 };
 
 async function fetcher() {
-  const response = await customFetch(`${process.env.FORUM_API_URL}/api/categories`, {}, false);
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
+  const response = await customFetch(
+    `${process.env.FORUM_API_URL}/api/categories`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    },
+    !token,
+  );
 
   if (!response?.ok) {
     return [];

--- a/services/forum/hooks/useForumPost.ts
+++ b/services/forum/hooks/useForumPost.ts
@@ -225,7 +225,17 @@ export type TopicResponse = {
 };
 
 export async function fetcher(tid: string) {
-  const response = await customFetch(`${process.env.FORUM_API_URL}/api/topic/${tid}`, {}, false);
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
+  const response = await customFetch(
+    `${process.env.FORUM_API_URL}/api/topic/${tid}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    },
+    !token,
+  );
 
   if (!response?.ok) {
     return null;

--- a/services/forum/hooks/useForumPosts.ts
+++ b/services/forum/hooks/useForumPosts.ts
@@ -63,15 +63,18 @@ export type Topic = {
 };
 
 async function fetcher(cid: number | string, categoryTopicSort: string) {
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
+
   if (cid === '0') {
     const response = await customFetch(
       `${process.env.FORUM_API_URL}/api/recent?categoryTopicSort=${categoryTopicSort}`,
       {
         headers: {
           'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
       },
-      false,
+      !token,
     );
 
     if (!response?.ok) {
@@ -82,8 +85,6 @@ async function fetcher(cid: number | string, categoryTopicSort: string) {
 
     return data.topics as Topic[];
   }
-
-  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
 
   const response = await customFetch(
     `${process.env.FORUM_API_URL}/api/v3/categories/${cid}/topics?categoryTopicSort=${categoryTopicSort}`,

--- a/services/forum/hooks/useInfiniteForumPosts.ts
+++ b/services/forum/hooks/useInfiniteForumPosts.ts
@@ -9,15 +9,17 @@ type QueryParams = {
 };
 
 async function infiniteFetcher(queryParams: QueryParams, page: number) {
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
   if (queryParams.cid === '0') {
     const response = await customFetch(
       `${process.env.FORUM_API_URL}/api/recent?categoryTopicSort=${queryParams.categoryTopicSort}&page=${page}`,
       {
         headers: {
           'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
       },
-      false,
+      !token,
     );
 
     if (!response?.ok) {
@@ -26,8 +28,6 @@ async function infiniteFetcher(queryParams: QueryParams, page: number) {
 
     return await response.json();
   }
-
-  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
 
   const response = await customFetch(
     `${process.env.FORUM_API_URL}/api/v3/categories/${queryParams.cid}/topics?categoryTopicSort=${queryParams.categoryTopicSort}&after=${page}`,


### PR DESCRIPTION
Refactored multiple fetch functions to include an optional Authorization header using `CUSTOM_FORUM_AUTH_TOKEN` from environment variables. This ensures API requests can conditionally include authentication when a token is available, improving flexibility and security.