### PR TITLE
Update button text to clarify 'Save' as 'Save changes'

### DIFF
--- a/components/page/forum/CreatePost/CreatePost.tsx
+++ b/components/page/forum/CreatePost/CreatePost.tsx
@@ -152,7 +152,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
                   Cancel
                 </button>
                 <button className={s.submitBtn} disabled={isSubmitting || !isDirty}>
-                  {isSubmitting ? 'Processing...' : isEdit ? 'Save' : 'Post'}
+                  {isSubmitting ? 'Processing...' : isEdit ? 'Save changes' : 'Post'}
                 </button>
               </div>
             </div>
@@ -172,7 +172,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
                 Cancel
               </button>
               <button className={s.submitBtn} disabled={isSubmitting || !isDirty}>
-                {isSubmitting ? 'Processing...' : isEdit ? 'Save' : 'Post'}
+                {isSubmitting ? 'Processing...' : isEdit ? 'Save changes' : 'Post'}
               </button>
             </div>
 


### PR DESCRIPTION
Revised the button text for edit mode from 'Save' to 'Save changes' to improve clarity for users. This adjustment provides a clearer distinction between editing and creating a new post.