### PR TITLE
Refactor AccountMenu and comment out ProtoSphere link.

### DIFF
--- a/components/core/navbar/components/AccountMenu/AccountMenu.tsx
+++ b/components/core/navbar/components/AccountMenu/AccountMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Menu } from '@base-ui-components/react/menu';
 import { Avatar } from '@base-ui-components/react/avatar';
 
@@ -9,7 +9,7 @@ import { getAnalyticsUserInfo } from '@/utils/common.utils';
 import { useCommonAnalytics } from '@/analytics/common.analytics';
 import { clearAllAuthCookies } from '@/utils/third-party.helper';
 import { toast } from 'react-toastify';
-import { EVENTS, TOAST_MESSAGES } from '@/utils/constants';
+import { TOAST_MESSAGES } from '@/utils/constants';
 import { createLogoutChannel } from '@/components/core/login/broadcast-channel';
 import { usePostHog } from 'posthog-js/react';
 
@@ -19,7 +19,6 @@ import { NotificationsMenu } from '@/components/core/navbar/components/Notificat
 import { clsx } from 'clsx';
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/services/members/store';
-import { isNumber } from 'lodash';
 import { useMember } from '@/services/members/hooks/useMember';
 import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 
@@ -84,14 +83,14 @@ export const AccountMenu = ({ userInfo, authToken, isLoggedIn, profileFilledPerc
                 <NotificationsIcon /> Notifications
                 <div className={s.itemSub}>{notifications?.length > 0 && <div className={s.notificationsCount}>{notifications?.length}</div>}</div>
               </Menu.Item>
-              <Link target="_blank" href={process.env.PROTOSPHERE_URL ?? ''}>
-                <Menu.Item className={s.Item} onClick={() => analytics.onNavGetHelpItemClicked('ProtoSphere', getAnalyticsUserInfo(userInfo))}>
-                  <MessageIcon /> ProtoSphere{' '}
-                  <span className={s.itemSub}>
-                    Forum <LinkIcon />
-                  </span>
-                </Menu.Item>
-              </Link>
+              {/*<Link target="_blank" href={process.env.PROTOSPHERE_URL ?? ''}>*/}
+              {/*  <Menu.Item className={s.Item} onClick={() => analytics.onNavGetHelpItemClicked('ProtoSphere', getAnalyticsUserInfo(userInfo))}>*/}
+              {/*    <MessageIcon /> ProtoSphere{' '}*/}
+              {/*    <span className={s.itemSub}>*/}
+              {/*      Forum <LinkIcon />*/}
+              {/*    </span>*/}
+              {/*  </Menu.Item>*/}
+              {/*</Link>*/}
               <div className={s.SeparatorWrapper}>
                 Support
                 <Menu.Separator className={s.Separator} />


### PR DESCRIPTION
Remove unused imports to simplify the component and enhance readability. Comment out the ProtoSphere link and its associated UI for future re-evaluation, ensuring no unintended actions are triggered.