### PR TITLE
Add back button and optimize forum query behavior

### DIFF
--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -72,6 +72,7 @@ export const Post = ({ userInfo }: { userInfo: IUserInfo }) => {
   if (!post) {
     return (
       <div className={s.container}>
+        <BackButton to={`/forum?cid=${categoryId}`} />
         <PostPageLoader />
       </div>
     );

--- a/components/page/forum/Posts/Posts.tsx
+++ b/components/page/forum/Posts/Posts.tsx
@@ -71,7 +71,7 @@ export const Posts = () => {
               className={s.listItem}
               key={post.tid}
               href={`/forum/topics/${post.cid}/${post.tid}`}
-              prefetch={false}
+              // prefetch={false}
               onClick={() => {
                 analytics.onPostClicked({ tid: post.tid });
               }}

--- a/services/forum/hooks/useForumCategories.ts
+++ b/services/forum/hooks/useForumCategories.ts
@@ -227,5 +227,7 @@ export function useForumCategories() {
   return useQuery({
     queryKey: [ForumQueryKeys.GET_TOPICS],
     queryFn: fetcher,
+    refetchOnWindowFocus: false,
+    staleTime: 60000,
   });
 }


### PR DESCRIPTION
Introduce a back button for easier navigation on missing post pages. Adjust forum query settings to disable window-focus refetch and set a 60-second stale time to improve client-side performance. Commented out prefetch setting in the post list for future evaluation.