### PR TITLE
Add analytics tracking for newsletter and forum digest updates

### DIFF
--- a/analytics/settings.analytics.ts
+++ b/analytics/settings.analytics.ts
@@ -190,6 +190,14 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.RECOMMENDATION_EMAIL_FEEDBACK_CLICKED, params);
   }
 
+  function onForumDigestOptionSelect(params: any) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_OPTION_SELECTED, params);
+  }
+
+  function onSubscribeToPlNewsletterChange(params: Record<any, boolean>) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_SUBSCRIBE_TO_NEWSLETTER_CHANGE, params);
+  }
+
   return {
     recordSettingsSideMenuClick,
     recordManageTeamsTeamChange,
@@ -213,6 +221,8 @@ export const useSettingsAnalytics = () => {
     onRecommendationsPageOpenFromMail,
     onRecommendationsSettingsSaveClicked,
     onRecommendationsSettingsResetClicked,
-    onRecommendationEmailFeedbackClicked
+    onRecommendationEmailFeedbackClicked,
+    onForumDigestOptionSelect,
+    onSubscribeToPlNewsletterChange,
   };
 };

--- a/components/core/navbar/components/AccountMenu/AccountMenu.tsx
+++ b/components/core/navbar/components/AccountMenu/AccountMenu.tsx
@@ -21,6 +21,7 @@ import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/services/members/store';
 import { useMember } from '@/services/members/hooks/useMember';
 import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
+import { useMedia } from 'react-use';
 
 interface Props {
   userInfo: IUserInfo;
@@ -30,6 +31,7 @@ interface Props {
 }
 
 export const AccountMenu = ({ userInfo, authToken, isLoggedIn, profileFilledPercent }: Props) => {
+  const isMobile = useMedia('(max-width: 960px)', false);
   const menuTriggerRef = React.useRef<HTMLButtonElement>(null);
   const defaultAvatarImage = useDefaultAvatar(userInfo?.name);
   const analytics = useCommonAnalytics();
@@ -112,7 +114,7 @@ export const AccountMenu = ({ userInfo, authToken, isLoggedIn, profileFilledPerc
                 Settings
                 <Menu.Separator className={s.Separator} />
               </div>
-              <Link href="/settings/profile">
+              <Link href={isMobile ? '/settings' : '/settings/profile'}>
                 <Menu.Item className={s.Item} onClick={() => analytics.onNavGetHelpItemClicked('Settings Profile', getAnalyticsUserInfo(userInfo))}>
                   <SettingsIcon /> Account Settings
                 </Menu.Item>

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
@@ -9,6 +9,7 @@ import { Field } from '@base-ui-components/react/field';
 import { clsx } from 'clsx';
 import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
 import dynamic from 'next/dynamic';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
 const Select = dynamic(() => import('react-select'), { ssr: false });
 
 const options = [
@@ -32,6 +33,7 @@ const options = [
 export const ForumDigest = ({ userInfo }: { userInfo: IUserInfo }) => {
   const { mutate } = useUpdateForumDigestSettings();
   const { data } = useGetForumDigestSettings(userInfo.uid);
+  const analytics = useSettingsAnalytics();
 
   const value = useMemo(() => {
     if (!data) {
@@ -59,39 +61,51 @@ export const ForumDigest = ({ userInfo }: { userInfo: IUserInfo }) => {
     }
 
     if (value.value === 'no_digest') {
+      const _payload = {
+        ...data,
+        forumDigestEnabled: false,
+      };
+
       mutate({
         uid: userInfo.uid,
-        payload: {
-          ...data,
-          forumDigestEnabled: false,
-        },
+        payload: _payload,
       });
+
+      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }
 
     if (value.value === 'daily_digest') {
+      const _payload = {
+        ...data,
+        forumDigestEnabled: true,
+        forumDigestFrequency: 1,
+      };
+
       mutate({
         uid: userInfo.uid,
-        payload: {
-          ...data,
-          forumDigestEnabled: true,
-          forumDigestFrequency: 1,
-        },
+        payload: _payload,
       });
+
+      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }
 
     if (value.value === 'weekly_digest') {
+      const _payload = {
+        ...data,
+        forumDigestEnabled: true,
+        forumDigestFrequency: 7,
+      };
+
       mutate({
         uid: userInfo.uid,
-        payload: {
-          ...data,
-          forumDigestEnabled: true,
-          forumDigestFrequency: 7,
-        },
+        payload: _payload,
       });
+
+      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }

--- a/components/page/email-preferences/components/Newsletter/Newsletter.tsx
+++ b/components/page/email-preferences/components/Newsletter/Newsletter.tsx
@@ -1,29 +1,33 @@
 import React from 'react';
 
 import s from './Newsletter.module.scss';
-import { useGetForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import { IUserInfo } from '@/types/shared.types';
-import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
 import { clsx } from 'clsx';
 import { Switch } from '@base-ui-components/react/switch';
 import { useMember } from '@/services/members/hooks/useMember';
 import { useUpdateMemberParams } from '@/services/members/hooks/useUpdateMemberParams';
+import { useSettingsAnalytics } from '@/analytics/settings.analytics';
 
 export const Newsletter = ({ userInfo }: { userInfo: IUserInfo }) => {
   const { mutate } = useUpdateMemberParams();
   const { data } = useMember(userInfo.uid);
+  const analytics = useSettingsAnalytics();
 
   const handleChange = (checked: boolean) => {
     if (!userInfo.uid || !data) {
       return;
     }
 
+    const _payload = {
+      isSubscribedToNewsletter: checked,
+    };
+
     mutate({
       uid: userInfo.uid,
-      payload: {
-        isSubscribedToNewsletter: checked,
-      },
+      payload: _payload,
     });
+
+    analytics.onSubscribeToPlNewsletterChange(_payload);
   };
 
   return (

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -184,6 +184,9 @@ export const SETTINGS_ANALYTICS_EVENTS = {
   MANAGE_TEAMS_MEMBER_TEAM_LEAD_TOGGLE_CHANGE: 'manage-teams-member-team-lead-toggle-change',
   MANAGE_TEAMS_MEMBER_REMOVE: 'manage-teams-member-remove',
   MANAGE_TEAMS_MEMBER_UNDO: 'manage-teams-member-undo',
+
+  SETTINGS_SUBSCRIBE_TO_NEWSLETTER_CHANGE: 'settings-subscribe-to-newsletter-change',
+  FORUM_DIGEST_OPTION_SELECTED: 'settings-forum-digest-option-selected',
 };
 
 export const JOIN_NETWORK_ANALYTICS_EVENTS = {


### PR DESCRIPTION
Introduce functions to track changes in forum digest options and newsletter subscriptions in settings analytics. Updated components to fire these events when users make relevant changes, improving insight into user preferences.