### PR TITLE
Set 'credentials: include' in forum service API requests

### DIFF
--- a/services/forum/hooks/useCreatePost.ts
+++ b/services/forum/hooks/useCreatePost.ts
@@ -28,6 +28,7 @@ async function mutation({ uid, cid, title, content }: CreatePostMutationParams) 
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(uid && uid !== userInfo.uid ? { 'x-impersonate-member-uid': uid } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );

--- a/services/forum/hooks/useEditPost.ts
+++ b/services/forum/hooks/useEditPost.ts
@@ -28,6 +28,7 @@ async function mutation({ pid, title, content, uid }: EditPostMutationParams) {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(uid && uid !== userInfo.uid ? { 'x-impersonate-member-uid': uid } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );

--- a/services/forum/hooks/useForumCategories.ts
+++ b/services/forum/hooks/useForumCategories.ts
@@ -206,6 +206,7 @@ async function fetcher() {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );

--- a/services/forum/hooks/useForumPost.ts
+++ b/services/forum/hooks/useForumPost.ts
@@ -233,6 +233,7 @@ export async function fetcher(tid: string) {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );

--- a/services/forum/hooks/useLikePost.ts
+++ b/services/forum/hooks/useLikePost.ts
@@ -23,6 +23,7 @@ async function mutation({ pid }: MutationParams) {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );

--- a/services/forum/hooks/usePostComment.ts
+++ b/services/forum/hooks/usePostComment.ts
@@ -23,6 +23,7 @@ async function mutation({ tid, toPid, content }: PostCommentMutationParams) {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
+      credentials: 'include',
     },
     !token,
   );


### PR DESCRIPTION
Added the 'credentials: include' option to all relevant forum service API requests to ensure cookies are included with cross-origin requests. This enhances authentication and session management across the application.