### PR TITLE
Refactor FormSwitch component to update visuals and simplify usage.

### DIFF
--- a/components/form/FormSwitch/FormSwitch.tsx
+++ b/components/form/FormSwitch/FormSwitch.tsx
@@ -23,9 +23,8 @@ export const FormSwitch = ({ name, label, variant = 'primary' }: Props) => {
     >
       {label}
       <Switch.Root defaultChecked className={s.Switch} checked={val} onCheckedChange={() => setValue(name, !val, { shouldValidate: true, shouldDirty: true })}>
-        <CloseIcon />
         <Switch.Thumb className={s.Thumb}>
-          <CheckIcon />
+          <div className={s.dot} />
         </Switch.Thumb>
       </Switch.Root>
     </label>

--- a/components/page/member-details/ContactDetails/components/EditContactForm/EditContactForm.tsx
+++ b/components/page/member-details/ContactDetails/components/EditContactForm/EditContactForm.tsx
@@ -211,7 +211,7 @@ export const EditContactForm = ({ onClose, member, userInfo }: Props) => {
               <div className={s.switchLabel}>Show contact details to PL network members</div>
               <div className={s.switchDesc}>Contact details are never displayed publicly</div>
             </div>
-            <FormSwitch name="shareContacts" variant="secondary" />
+            <FormSwitch name="shareContacts" />
           </div>
           <div className={s.separator} />
           <div className={s.row}>


### PR DESCRIPTION
Replaced icons with a single dot for a cleaner design in FormSwitch. Removed the unnecessary "variant" prop from the EditContactForm usage to simplify the component API.