### PR TITLE
Update forum navigation to preserve 'from' category context

### DIFF
--- a/app/forum/topics/[categoryId]/[topicId]/edit/page.tsx
+++ b/app/forum/topics/[categoryId]/[topicId]/edit/page.tsx
@@ -15,9 +15,12 @@ interface PageProps {
     categoryId: string;
     topicId: string;
   };
+  searchParams: {
+    from?: string;
+  };
 }
 
-const EditPostPage = async ({ params }: PageProps) => {
+const EditPostPage = async ({ params, searchParams }: PageProps) => {
   const { isLoggedIn, userInfo, authToken } = getCookiesFromHeaders();
   const isAdmin = !!(userInfo?.roles && userInfo?.roles?.length > 0 && userInfo?.roles.includes(ADMIN_ROLE));
 
@@ -47,18 +50,20 @@ const EditPostPage = async ({ params }: PageProps) => {
   });
 
   if (!response?.ok) {
-    redirect(`/forum/topics/${params.categoryId}/${params.topicId}?error=post-not-found`);
+    const redirectUrl = `/forum/topics/${params.categoryId}/${params.topicId}?error=post-not-found${searchParams.from ? `&from=${searchParams.from}` : ''}`;
+    redirect(redirectUrl);
   }
 
   const data = (await response.json()) as TopicResponse;
 
   if (!data) {
-    redirect(`/forum/topics/${params.categoryId}/${params.topicId}?error=post-not-found`);
+    const redirectUrl = `/forum/topics/${params.categoryId}/${params.topicId}?error=post-not-found${searchParams.from ? `&from=${searchParams.from}` : ''}`;
+    redirect(redirectUrl);
   }
 
   return (
     <div className={s.root}>
-      <BackButton to={`/forum/topics/${params.categoryId}/${params.topicId}`} />
+      <BackButton to={`/forum/topics/${params.categoryId}/${params.topicId}${searchParams.from ? `?from=${searchParams.from}` : ''}`} />
       <CreatePost
         pid={data.mainPid}
         isEdit

--- a/components/page/forum/CreatePost/CreatePost.tsx
+++ b/components/page/forum/CreatePost/CreatePost.tsx
@@ -14,7 +14,7 @@ import { createPostSchema } from '@/components/page/forum/CreatePost/helpers';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { extractTextWithImages, replaceImagesWithMarkdown } from '@/utils/decode';
 import { useMobileNavVisibility } from '@/hooks/useMobileNavVisibility';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEditPost } from '@/services/forum/hooks/useEditPost';
 import useBlockNavigation from '@/hooks/useUnsavedChangesWarning';
 import { UnsavedChangesPrompt } from '@/components/core/UnsavedChangesPrompt';
@@ -35,6 +35,8 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
   const analytics = useForumAnalytics();
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
+  const fromCategory = searchParams.get('from');
   useMobileNavVisibility(true);
   const isAdmin = !!(userInfo?.roles && userInfo?.roles?.length > 0 && userInfo?.roles.includes(ADMIN_ROLE));
   const { data: allMembers } = useAllMembers();
@@ -86,7 +88,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
   const handleCancel = () => {
     if (isEdit) {
       analytics.onEditPostCancel();
-      router.push(`/forum/topics/${params.categoryId}/${params.topicId}`);
+      router.push(`/forum/topics/${params.categoryId}/${params.topicId}${fromCategory ? `?from=${fromCategory}` : ''}`);
     } else {
       analytics.onCreatePostCancel();
       router.push('/forum?cid=0');
@@ -111,7 +113,7 @@ export const CreatePost = ({ isEdit, initialData, pid, userInfo }: { isEdit?: bo
           toast.success('Post updated successfully');
           reset(data);
           setTimeout(() => {
-            router.push(`/forum/topics/${params.categoryId}/${params.topicId}`);
+            router.push(`/forum/topics/${params.categoryId}/${params.topicId}${fromCategory ? `?from=${fromCategory}` : ''}`);
           }, 500);
         }
       } else {

--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -32,6 +32,10 @@ export const Post = ({ userInfo }: { userInfo: IUserInfo }) => {
   const [replyToPid, setReplyToPid] = React.useState<number | null>(null);
   const replyToItem = data?.posts?.slice(1).find((item) => item.pid === replyToPid);
 
+  // Get the category to navigate back to from the 'from' query parameter
+  // If not provided, fallback to the current post's category
+  const fromCategory = searchParams.get('from') || categoryId;
+
   const post = useMemo(() => {
     if (!data) {
       return null;
@@ -77,7 +81,7 @@ export const Post = ({ userInfo }: { userInfo: IUserInfo }) => {
   if (!post) {
     return (
       <div className={s.container}>
-        <BackButton to={`/forum?cid=${categoryId}`} />
+        <BackButton to={`/forum?cid=${fromCategory}`} />
         <PostPageLoader />
       </div>
     );
@@ -85,9 +89,9 @@ export const Post = ({ userInfo }: { userInfo: IUserInfo }) => {
 
   return (
     <div className={s.container}>
-      <BackButton to={`/forum?cid=${categoryId}`} />
+      <BackButton to={`/forum?cid=${fromCategory}`} />
       <div className={s.root}>
-        <Link href={`/forum?cid=${categoryId}`} className={s.back}>
+        <Link href={`/forum?cid=${fromCategory}`} className={s.back}>
           <ChevronLeftIcon /> Back to forum
         </Link>
 

--- a/components/page/forum/Posts/Posts.tsx
+++ b/components/page/forum/Posts/Posts.tsx
@@ -72,7 +72,7 @@ export const Posts = () => {
             <Link
               className={s.listItem}
               key={post.tid}
-              href={`/forum/topics/${post.cid}/${post.tid}`}
+              href={`/forum/topics/${post.cid}/${post.tid}?from=${cid || '0'}`}
               // prefetch={false}
               onClick={() => {
                 analytics.onPostClicked({ tid: post.tid });


### PR DESCRIPTION
Added support for retaining the 'from' query parameter across navigation to ensure users return to the expected category context. This includes updating links, buttons, and redirects in post creation, editing, and browsing workflows.