### PR TITLE
Set default sort option to second item in ForumHeader (#1127)

### DIFF
--- a/components/page/forum/ForumHeader/ForumHeader.tsx
+++ b/components/page/forum/ForumHeader/ForumHeader.tsx
@@ -34,7 +34,7 @@ export const ForumHeader = () => {
   const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[0];
+  const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[1];
   const selectedCategory = searchParams.get('cid');
   const analytics = useForumAnalytics();
 


### PR DESCRIPTION
Previously, the default sort option was set to the first item if no matching option was found. This change updates the fallback to the second item in the sortOptions array, ensuring a more appropriate default behavior. This adjustment enhances usability by aligning the fallback with the desired logic.