### PR TITLE
Allow admins to edit any post and adjust UI padding

### DIFF
--- a/app/forum/topics/[categoryId]/[topicId]/edit/page.tsx
+++ b/app/forum/topics/[categoryId]/[topicId]/edit/page.tsx
@@ -73,6 +73,7 @@ const EditPostPage = async ({ params, searchParams }: PageProps) => {
           title: data.title,
           content: data.posts?.[0]?.content,
         }}
+        userInfo={userInfo}
       />
     </div>
   );

--- a/components/page/forum/ItemMenu/ItemMenu.module.scss
+++ b/components/page/forum/ItemMenu/ItemMenu.module.scss
@@ -24,8 +24,8 @@
   box-shadow: 0 1px 2px 0 rgba(15, 23, 42, 0.16), 0 0 1px 0 rgba(15, 23, 42, 0.12), 0 4px 4px 0 rgba(15, 23, 42, 0.04);
 
   box-sizing: border-box;
-  padding-block: 12px;
-  padding-inline: 16px;
+  padding-block: 8px;
+  padding-inline: 12px;
   transform-origin: top right;
   transition:
           transform 150ms,

--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -23,6 +23,7 @@ import { BackButton } from '@/components/ui/BackButton';
 import { getCookiesFromClient } from '@/utils/third-party.helper';
 import { LoggedOutView } from '@/components/page/forum/LoggedOutView';
 import forumStyles from '@/app/forum/page.module.scss';
+import { ADMIN_ROLE } from '@/utils/constants';
 
 export const Post = () => {
   const router = useRouter();
@@ -64,9 +65,9 @@ export const Post = () => {
         likes: data.posts[0]?.votes,
         comments: data.postcount - 1,
       },
-      isEditable: data.posts[0].user.memberUid === userInfo.uid,
+      isEditable: data.posts[0]?.user?.memberUid === userInfo?.uid || userInfo?.roles?.includes(ADMIN_ROLE),
     };
-  }, [data, userInfo.uid]);
+  }, [data, userInfo?.roles, userInfo?.uid]);
 
   useEffect(() => {
     if (!post) {

--- a/components/page/forum/PostComments/PostComments.tsx
+++ b/components/page/forum/PostComments/PostComments.tsx
@@ -16,6 +16,7 @@ import { IUserInfo } from '@/types/shared.types';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useForumAnalytics } from '@/analytics/forum.analytics';
 import Link from 'next/link';
+import { ADMIN_ROLE } from '@/utils/constants';
 
 interface Props {
   tid: number;
@@ -119,7 +120,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
             </div>
             <div className={clsx(s.time, s.mob)}>{formatDistanceToNow(new Date(item.timestamp), { addSuffix: true })}</div>
           </div>
-          {userInfo.uid === item.user.memberUid && (
+          {(userInfo.uid === item.user.memberUid || userInfo.roles?.includes(ADMIN_ROLE)) && (
             <div className={s.menuWrapper}>
               <ItemMenu
                 onEdit={() => {
@@ -131,7 +132,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
           )}
         </div>
         {editPid ? (
-          <CommentsInputDesktop initialFocused tid={item.tid} toPid={editPid} onCancel={() => setEditPid(null)} isEdit initialContent={item.content} />
+          <CommentsInputDesktop initialFocused itemUid={item.user.memberUid} tid={item.tid} toPid={editPid} onCancel={() => setEditPid(null)} isEdit initialContent={item.content} />
         ) : (
           <div
             className={s.postContent}

--- a/services/forum/hooks/useEditPost.ts
+++ b/services/forum/hooks/useEditPost.ts
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { getCookiesFromClient } from '@/utils/third-party.helper';
 
 export interface EditPostMutationParams {
-  uid?: string;
+  uid?: string | null;
   pid: number;
   title: string;
   content: string;


### PR DESCRIPTION
Admins can now edit any post by validating their role, and the editing mechanism has been updated to support admin privileges. Additionally, padding in the item menu has been slightly reduced for better UI consistency. Minor adjustments were also made to enhance type safety and parameter passing across components.