### PR TITLE
Fix null post rendering when userInfo is missing

### DIFF
--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -43,7 +43,7 @@ export const Post = () => {
   const isLoggedIn = !!userInfo;
 
   const post = useMemo(() => {
-    if (!data) {
+    if (!data || !userInfo) {
       return null;
     }
 
@@ -66,7 +66,7 @@ export const Post = () => {
       },
       isEditable: data.posts[0].user.memberUid === userInfo.uid,
     };
-  }, [data, userInfo.uid]);
+  }, [data, userInfo]);
 
   useEffect(() => {
     if (!post) {


### PR DESCRIPTION
Previously, the post would render incorrectly if userInfo was not available. This change ensures that the post is not rendered when either data or userInfo is missing. Additionally, the dependency array of the useMemo hook is updated to include the entire userInfo object for accuracy.