### PR TITLE
Refactor forum post fetching to depend on login status

### DIFF
--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -30,17 +30,18 @@ export const Post = () => {
   const { categoryId, topicId } = useParams();
   const searchParams = useSearchParams();
   const analytics = useForumAnalytics();
-  const { data } = useForumPost(topicId as string);
+
+  // Get user info from client-side cookies
+  const { userInfo } = getCookiesFromClient();
+  const isLoggedIn = !!userInfo;
+
+  const { data } = useForumPost(topicId as string, isLoggedIn);
   const [replyToPid, setReplyToPid] = React.useState<number | null>(null);
   const replyToItem = data?.posts?.slice(1).find((item) => item.pid === replyToPid);
 
   // Get the category to navigate back to from the 'from' query parameter
   // If not provided, fallback to the current post's category
   const fromCategory = searchParams.get('from') || categoryId;
-
-  // Get user info from client-side cookies
-  const { userInfo } = getCookiesFromClient();
-  const isLoggedIn = !!userInfo;
 
   const post = useMemo(() => {
     if (!data || !userInfo) {

--- a/services/forum/hooks/useForumPost.ts
+++ b/services/forum/hooks/useForumPost.ts
@@ -247,9 +247,10 @@ export async function fetcher(tid: string) {
   return data as TopicResponse;
 }
 
-export function useForumPost(tid: string) {
+export function useForumPost(tid: string, isLoggedIn?: boolean) {
   return useQuery({
     queryKey: [ForumQueryKeys.GET_TOPIC, tid],
     queryFn: () => fetcher(tid),
+    enabled: isLoggedIn,
   });
 }


### PR DESCRIPTION
Moved user login determination to improve logical flow and refactored `useForumPost` to accept `isLoggedIn` as a parameter. Query execution is now conditionally enabled based on the user's login status for better efficiency.