### PR TITLE
Refactor CommentInput to reset on focus and remove cancel button

### DIFF
--- a/components/page/forum/CommentInput/CommentInput.tsx
+++ b/components/page/forum/CommentInput/CommentInput.tsx
@@ -63,9 +63,10 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
 
   const handleFocus = useCallback(() => {
     if (isEditorEmpty(comment)) {
+      onReset();
       setFocused(false);
     }
-  }, [comment]);
+  }, [comment, onReset]);
 
   useClickAway(formRef, handleFocus);
 
@@ -167,9 +168,9 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
             <span className={s.lbl}>
               Replying to <b className={s.accent}>{replyToName}</b>
             </span>
-            <button type="button" onClick={onReset}>
-              Cancel
-            </button>
+            {/*<button type="button" onClick={onReset}>*/}
+            {/*  Cancel*/}
+            {/*</button>*/}
           </div>
         )}
         <div className={s.content}>


### PR DESCRIPTION
The `onReset` function is now called in `handleFocus` to ensure proper input reset behavior. The unused cancel button in the reply section has been commented out for clarity and future refactoring.