### PR TITLE
Add timestamp tracking to forum interactions for analytics

### DIFF
--- a/analytics/forum.analytics.ts
+++ b/analytics/forum.analytics.ts
@@ -47,15 +47,15 @@ export const useForumAnalytics = () => {
     captureEvent(FORUM_ANALYTICS_EVENTS.POST_CLICKED, params);
   }
 
-  function onLikePostClicked(params: { tid?: string | number; pid?: string | number }) {
+  function onLikePostClicked(params: { tid?: string | number; pid?: string | number; timeSincePostCreation: number }) {
     captureEvent(FORUM_ANALYTICS_EVENTS.POST_LIKED, params);
   }
 
-  function onCommentInputClicked(params: { tid?: string | number }) {
+  function onCommentInputClicked(params: { tid?: string | number; timeSincePostCreation: number }) {
     captureEvent(FORUM_ANALYTICS_EVENTS.COMMENT_INPUT_CLICKED, params);
   }
 
-  function onPostCommentSubmit(params: PostCommentMutationParams) {
+  function onPostCommentSubmit(params: PostCommentMutationParams & { timeSincePostCreation: number }) {
     captureEvent(FORUM_ANALYTICS_EVENTS.POST_COMMENT_SUBMIT, params);
   }
 
@@ -67,7 +67,7 @@ export const useForumAnalytics = () => {
     captureEvent(FORUM_ANALYTICS_EVENTS.POST_COMMENT_NOTIFICATION_SETTINGS_CLICKED, params);
   }
 
-  function onPostCommentReplyClicked(params: { tid?: string | number; pid?: string | number }) {
+  function onPostCommentReplyClicked(params: { tid?: string | number; pid?: string | number; timeSincePostCreation: number }) {
     captureEvent(FORUM_ANALYTICS_EVENTS.POST_COMMENT_REPLY_CLICKED, params);
   }
 

--- a/components/page/forum/CommentInput/CommentInput.tsx
+++ b/components/page/forum/CommentInput/CommentInput.tsx
@@ -26,6 +26,7 @@ interface Props {
   onReset: () => void;
   isEdit?: boolean;
   initialContent?: string;
+  timestamp: number;
 }
 
 const schema = yup.object().shape({
@@ -33,7 +34,7 @@ const schema = yup.object().shape({
   emailMe: yup.boolean(),
 });
 
-export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initialContent }: Props) => {
+export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initialContent, timestamp }: Props) => {
   const analytics = useForumAnalytics();
   const formRef = useRef<HTMLFormElement | null>(null);
   const [focused, setFocused] = useState(false);
@@ -101,7 +102,7 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
           toPid,
           content,
         };
-        analytics.onPostCommentSubmit(payload);
+        analytics.onPostCommentSubmit({ ...payload, timeSincePostCreation: Date.now() - timestamp });
         const res = await mutateAsync(payload);
 
         if (res?.status?.code === 'ok') {
@@ -181,7 +182,7 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
               name="dummy"
               placeholder="Comment"
               onClick={() => {
-                analytics.onCommentInputClicked({ tid });
+                analytics.onCommentInputClicked({ tid, timeSincePostCreation: Date.now() - timestamp });
                 setFocused(true);
               }}
             />
@@ -192,7 +193,7 @@ export const CommentInput = ({ tid, toPid, replyToName, onReset, isEdit, initial
             disabled={isSubmitting}
             onClick={() => {
               if (!focused) {
-                analytics.onCommentInputClicked({ tid });
+                analytics.onCommentInputClicked({ tid, timeSincePostCreation: Date.now() - timestamp });
                 setFocused(true);
               }
             }}

--- a/components/page/forum/CommentsInputDesktop/CommentsInputDesktop.tsx
+++ b/components/page/forum/CommentsInputDesktop/CommentsInputDesktop.tsx
@@ -29,6 +29,7 @@ interface Props {
   isReply?: boolean;
   initialContent?: string;
   itemUid?: string;
+  timestamp: number;
 }
 
 const schema = yup.object().shape({
@@ -36,7 +37,7 @@ const schema = yup.object().shape({
   emailMe: yup.boolean(),
 });
 
-export const CommentsInputDesktop = ({ tid, toPid, itemUid, replyToName, onCancel, isReply, initialFocused, isEdit, initialContent }: Props) => {
+export const CommentsInputDesktop = ({ tid, toPid, itemUid, replyToName, onCancel, isReply, initialFocused, isEdit, initialContent, timestamp }: Props) => {
   const analytics = useForumAnalytics();
   const ref = useRef<HTMLFormElement | null>(null);
   const { userInfo } = getCookiesFromClient();
@@ -107,7 +108,7 @@ export const CommentsInputDesktop = ({ tid, toPid, itemUid, replyToName, onCance
           toPid,
           content,
         };
-        analytics.onPostCommentSubmit(payload);
+        analytics.onPostCommentSubmit({ ...payload, timeSincePostCreation: Date.now() - timestamp });
         const res = await mutateAsync(payload);
 
         if (res?.status?.code === 'ok') {
@@ -194,7 +195,7 @@ export const CommentsInputDesktop = ({ tid, toPid, itemUid, replyToName, onCance
               name="dummy"
               placeholder="Comment"
               onClick={() => {
-                analytics.onCommentInputClicked({ tid });
+                analytics.onCommentInputClicked({ tid, timeSincePostCreation: Date.now() - timestamp });
                 setFocused(true);
               }}
             />
@@ -204,7 +205,7 @@ export const CommentsInputDesktop = ({ tid, toPid, itemUid, replyToName, onCance
               disabled={isSubmitting}
               onClick={() => {
                 if (!focused) {
-                  analytics.onCommentInputClicked({ tid });
+                  analytics.onCommentInputClicked({ tid, timeSincePostCreation: Date.now() - timestamp });
                   setFocused(true);
                 }
               }}

--- a/components/page/forum/LikesButton/LikesButton.tsx
+++ b/components/page/forum/LikesButton/LikesButton.tsx
@@ -9,9 +9,10 @@ interface Props {
   tid: number;
   likes: number;
   isLiked?: boolean;
+  timestamp: number;
 }
 
-export const LikesButton = ({ tid, pid, likes, isLiked }: Props) => {
+export const LikesButton = ({ tid, pid, likes, isLiked, timestamp }: Props) => {
   const { mutate, isPending } = useLikePost();
   const analytics = useForumAnalytics();
 
@@ -22,7 +23,7 @@ export const LikesButton = ({ tid, pid, likes, isLiked }: Props) => {
       })}
       disabled={isPending || isLiked}
       onClick={() => {
-        analytics.onLikePostClicked({ tid, pid });
+        analytics.onLikePostClicked({ tid, pid, timeSincePostCreation: Date.now() - timestamp });
         mutate({ tid, pid });
       }}
     >

--- a/components/page/forum/Post/Post.tsx
+++ b/components/page/forum/Post/Post.tsx
@@ -61,6 +61,7 @@ export const Post = () => {
       position: data.author.teamRole && data.author.teamName ? `${data.author.teamRole} @${data.author.teamName}` : '',
       time: formatDistanceToNow(new Date(data.timestamp), { addSuffix: true }),
       upvoted: data.posts[0]?.upvoted,
+      timestamp: data.timestamp,
       meta: {
         views: data.viewcount,
         likes: data.posts[0]?.votes,
@@ -68,8 +69,7 @@ export const Post = () => {
       },
       isEditable: data.posts[0]?.user?.memberUid === userInfo?.uid || userInfo?.roles?.includes(ADMIN_ROLE),
     };
-  }, [data, userInfo?.roles, userInfo?.uid]);
-
+  }, [data, userInfo]);
 
   useEffect(() => {
     if (!post) {
@@ -139,7 +139,7 @@ export const Post = () => {
           <div className={s.subItem}>
             <ViewIcon /> {post.meta.views} Views
           </div>
-          <LikesButton tid={post.tid} pid={post?.pid} likes={post.meta.likes} isLiked={post.upvoted} />
+          <LikesButton tid={post.tid} pid={post?.pid} likes={post.meta.likes} isLiked={post.upvoted} timestamp={post.timestamp} />
           <div className={s.subItem}>
             <CommentIcon /> {post.meta.comments} Comments
           </div>
@@ -175,6 +175,7 @@ export const Post = () => {
           tid={post.tid}
           toPid={replyToPid ?? post.pid}
           replyToName={replyToItem?.user.displayname}
+          timestamp={post.timestamp}
           onReset={() => {
             setReplyToPid(null);
             const params = new URLSearchParams(searchParams.toString());
@@ -185,7 +186,7 @@ export const Post = () => {
       </div>
 
       <div className={s.root}>
-        <PostComments comments={data?.posts?.slice(1)} tid={post.tid} mainPid={post.pid} onReply={(pid) => setReplyToPid(pid)} userInfo={userInfo} />
+        <PostComments comments={data?.posts?.slice(1)} tid={post.tid} mainPid={post.pid} onReply={(pid) => setReplyToPid(pid)} userInfo={userInfo} timestamp={post.timestamp} />
       </div>
 
       <ScrollToTopButton />

--- a/components/page/forum/PostComments/PostComments.tsx
+++ b/components/page/forum/PostComments/PostComments.tsx
@@ -24,9 +24,10 @@ interface Props {
   comments: TopicResponse['posts'] | undefined;
   onReply?: (id: number) => void;
   userInfo: IUserInfo;
+  timestamp: number;
 }
 
-export const PostComments = ({ comments, tid, mainPid, onReply, userInfo }: Props) => {
+export const PostComments = ({ comments, tid, mainPid, onReply, userInfo, timestamp }: Props) => {
   const isMobile = useMedia('(max-width: 960px)', false);
 
   if (!comments) return null;
@@ -38,7 +39,7 @@ export const PostComments = ({ comments, tid, mainPid, onReply, userInfo }: Prop
       <div className={s.title}>Comments ({comments.length})</div>
 
       <div className={s.input}>
-        <CommentsInputDesktop tid={tid} toPid={mainPid} />
+        <CommentsInputDesktop tid={tid} toPid={mainPid} timestamp={timestamp} />
       </div>
 
       <div className={s.list}>
@@ -132,7 +133,16 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
           )}
         </div>
         {editPid ? (
-          <CommentsInputDesktop initialFocused itemUid={item.user.memberUid} tid={item.tid} toPid={editPid} onCancel={() => setEditPid(null)} isEdit initialContent={item.content} />
+          <CommentsInputDesktop
+            initialFocused
+            itemUid={item.user.memberUid}
+            tid={item.tid}
+            toPid={editPid}
+            onCancel={() => setEditPid(null)}
+            isEdit
+            initialContent={item.content}
+            timestamp={item.timestamp}
+          />
         ) : (
           <div
             className={s.postContent}
@@ -142,7 +152,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
           />
         )}
         <div className={s.sub}>
-          <LikesButton tid={item.tid} pid={item.pid} likes={item.votes} isLiked={item.upvoted} />
+          <LikesButton tid={item.tid} pid={item.pid} likes={item.votes} isLiked={item.upvoted} timestamp={item.timestamp} />
           {!isReply && (
             <>
               <div className={s.subItem}>
@@ -152,7 +162,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
                 <button
                   className={s.replyBtn}
                   onClick={() => {
-                    analytics.onPostCommentReplyClicked({ tid: item.tid, pid: item.pid });
+                    analytics.onPostCommentReplyClicked({ tid: item.tid, pid: item.pid, timeSincePostCreation: Date.now() - item.timestamp });
                     if (onReply) {
                       onReply(item.pid);
                       scrollIntoView();
@@ -172,6 +182,7 @@ const CommentItem = ({ item, isReply, onReply, userInfo }: { item: NestedComment
       {replyToPid && (
         <CommentsInputDesktop
           isReply
+          timestamp={item.timestamp}
           initialFocused
           tid={item.tid}
           toPid={replyToPid}


### PR DESCRIPTION
This update introduces a `timestamp` property to various components to calculate the time since post creation. The analytics functions now include `timeSincePostCreation` to better track user interaction patterns. This improves the granularity of event data for likes, comments, and replies.