### PR TITLE
Refine office hours validation logic to handle new statuses.

### DIFF
--- a/components/page/member-details/OfficeHoursDetails/OfficeHoursDetails.tsx
+++ b/components/page/member-details/OfficeHoursDetails/OfficeHoursDetails.tsx
@@ -27,7 +27,11 @@ export const OfficeHoursDetails = ({ isLoggedIn, userInfo, member }: Props) => {
   const showWarningUseCaseB = !member?.ohInterest?.length || !member?.ohHelpWith?.length;
   const showIncomplete = !editView && isOwner && (showWarningUseCaseA || showWarningUseCaseB);
   const { data: officeHoursValidationOnLoad } = useValidateOfficeHoursQuery(member?.id);
-  const officeHoursValidation = { isValid: !officeHoursValidationOnLoad ? true : officeHoursValidationOnLoad?.ohStatus === 'OK' };
+  const officeHoursValidation = {
+    isValid: !officeHoursValidationOnLoad
+      ? true
+      : officeHoursValidationOnLoad?.ohStatus === 'OK' || officeHoursValidationOnLoad?.ohStatus === 'NOT_FOUND' || officeHoursValidationOnLoad?.ohStatus === null,
+  };
 
   useMobileNavVisibility(editView);
 


### PR DESCRIPTION
Updated the validation logic to account for additional `ohStatus` values: `NOT_FOUND` and `null`. This ensures better handling of edge cases and improves the overall robustness of office hours validation.