### PR TITLE
Refactor forum components to simplify sorting logic

### DIFF
--- a/components/page/forum/ForumHeader/ForumHeader.tsx
+++ b/components/page/forum/ForumHeader/ForumHeader.tsx
@@ -35,7 +35,6 @@ export const ForumHeader = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[1];
-  const selectedCategory = searchParams.get('cid');
   const analytics = useForumAnalytics();
 
   const onValueChange = (_value: string) => {
@@ -62,7 +61,6 @@ export const ForumHeader = () => {
           options={sortOptions}
           value={value}
           defaultValue={value}
-          isDisabled={selectedCategory === '0'}
           onChange={(val) => {
             if (val) {
               onValueChange(val.value);

--- a/components/page/forum/Posts/Posts.tsx
+++ b/components/page/forum/Posts/Posts.tsx
@@ -23,7 +23,7 @@ export const Posts = () => {
   const categoryTopicSort = searchParams.get('categoryTopicSort') as string;
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteForumPosts({
     cid,
-    categoryTopicSort,
+    categoryTopicSort: categoryTopicSort ?? 'recently_created',
   });
 
   const posts = useMemo(() => {


### PR DESCRIPTION
Removed unused `selectedCategory` check in ForumHeader and provided a fallback for `categoryTopicSort` in Posts to ensure consistent behavior and simplify the codebase. These changes enhance maintainability without affecting functionality.