### PR TITLE
Add event tracking for broken office hours link booking attempts

### DIFF
--- a/analytics/members.analytics.ts
+++ b/analytics/members.analytics.ts
@@ -515,6 +515,10 @@ export const useMemberAnalytics = () => {
     captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_FIX_BROKEN_OFFICEHOURS_LINK_CLICKED, params);
   }
 
+  function onBrokenOfficeHoursLinkBookAttemptClicked(params: Record<string, string | null>) {
+    captureEvent(MEMBER_ANALYTICS_EVENTS.MEMBER_DETAIL_BROKEN_OFFICEHOURS_LINK_BOOK_ATTEMPT_CLICKED, params);
+  }
+
   return {
     onOfficeHourClicked,
     onProjectContributionEditClicked,
@@ -588,5 +592,6 @@ export const useMemberAnalytics = () => {
     onErrorLinkedInVerification,
     onSubmitUpdatedOfficeHours,
     onFixBrokenOfficeHoursLinkClicked,
+    onBrokenOfficeHoursLinkBookAttemptClicked,
   };
 };

--- a/components/page/member-details/hooks.ts
+++ b/components/page/member-details/hooks.ts
@@ -6,7 +6,7 @@ export function useFixBrokenOfficeHoursLinkEventCapture() {
   const reportedRef = useRef(false);
   const searchParams = useSearchParams();
 
-  const isCorrectSource = searchParams.get('utm_source') === 'broken_oh_link';
+  const isCorrectSource = searchParams.get('utm_source') === 'oh_broken_link_fixed';
 
   const { onFixBrokenOfficeHoursLinkClicked } = useMemberAnalytics();
 
@@ -19,12 +19,43 @@ export function useFixBrokenOfficeHoursLinkEventCapture() {
 
     const searchParamsObj = {
       utmSource: searchParams.get('utm_source'),
-      utmMedium: searchParams.get('utm_medium'),
-      utmCode: searchParams.get('utm_code'),
       targetUid: searchParams.get('target_uid'),
       targetEmail: searchParams.get('target_email'),
+      requesterUid: searchParams.get('requester_uid'),
+      requesterEmail: searchParams.get('requester_email'),
     };
 
     onFixBrokenOfficeHoursLinkClicked(searchParamsObj);
   }, [isCorrectSource, onFixBrokenOfficeHoursLinkClicked, searchParams]);
+
+  return {
+    forceEditMode: isCorrectSource,
+  };
+}
+
+export function useBrokenOfficeHoursLinkBookAttemptEventCapture() {
+  const reportedRef = useRef(false);
+  const searchParams = useSearchParams();
+
+  const isCorrectSource = searchParams.get('utm_source') === 'oh_broken_link_book_attempt';
+
+  const { onBrokenOfficeHoursLinkBookAttemptClicked } = useMemberAnalytics();
+
+  useEffect(() => {
+    if (reportedRef.current || !isCorrectSource) {
+      return;
+    }
+
+    reportedRef.current = true;
+
+    const searchParamsObj = {
+      utmSource: searchParams.get('utm_source'),
+      targetUid: searchParams.get('target_uid'),
+      targetEmail: searchParams.get('target_email'),
+      requesterUid: searchParams.get('requester_uid'),
+      requesterEmail: searchParams.get('requester_email'),
+    };
+
+    onBrokenOfficeHoursLinkBookAttemptClicked(searchParamsObj);
+  }, [isCorrectSource, onBrokenOfficeHoursLinkBookAttemptClicked, searchParams]);
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -364,6 +364,7 @@ export const MEMBER_ANALYTICS_EVENTS = {
   MEMBER_DETAIL_ADD_OFFICEHOURS_CLICKED: 'member-add-officehours-clicked',
   MEMBER_DETAIL_EDIT_OFFICEHOURS_CLICKED: 'member-edit-officehours-clicked',
   MEMBER_DETAIL_FIX_BROKEN_OFFICEHOURS_LINK_CLICKED: 'member-fix-broken-office-hours-link-clicked',
+  MEMBER_DETAIL_BROKEN_OFFICEHOURS_LINK_BOOK_ATTEMPT_CLICKED: 'member-broken-office-hours-link-book-attempt-clicked',
   MEMBER_DETAIL_SUBMIT_UPDATED__OFFICEHOURS: 'member-submit-updated-officehours',
   MEMBER_DETAIL_PROJECT_CONTRIBUTIONS_EDIT: 'member-pr-contributions-edit',
   MEMBER_DETAIL_PROJECT_CONTRIBUTIONS_ADD: 'member-pr-contributions-add',


### PR DESCRIPTION
Introduce an analytics event to capture attempts to book office hours via broken links. Update related hooks, components, and constants to enable accurate tracking and enhance UX by enforcing edit mode under specific conditions.