### PR TITLE
Switch forceEditMode return to correct hook

### DIFF
--- a/components/page/member-details/OfficeHoursDetails/OfficeHoursDetails.tsx
+++ b/components/page/member-details/OfficeHoursDetails/OfficeHoursDetails.tsx
@@ -40,8 +40,8 @@ export const OfficeHoursDetails = ({ isLoggedIn, userInfo, member }: Props) => {
 
   useMobileNavVisibility(editView);
 
-  const { forceEditMode } = useFixBrokenOfficeHoursLinkEventCapture();
-  useBrokenOfficeHoursLinkBookAttemptEventCapture();
+  useFixBrokenOfficeHoursLinkEventCapture();
+  const { forceEditMode } = useBrokenOfficeHoursLinkBookAttemptEventCapture();
 
   useEffect(() => {
     if (forceEditMode && !editView && !forcedEditModeRef.current) {

--- a/components/page/member-details/hooks.ts
+++ b/components/page/member-details/hooks.ts
@@ -27,10 +27,6 @@ export function useFixBrokenOfficeHoursLinkEventCapture() {
 
     onFixBrokenOfficeHoursLinkClicked(searchParamsObj);
   }, [isCorrectSource, onFixBrokenOfficeHoursLinkClicked, searchParams]);
-
-  return {
-    forceEditMode: isCorrectSource,
-  };
 }
 
 export function useBrokenOfficeHoursLinkBookAttemptEventCapture() {
@@ -58,4 +54,8 @@ export function useBrokenOfficeHoursLinkBookAttemptEventCapture() {
 
     onBrokenOfficeHoursLinkBookAttemptClicked(searchParamsObj);
   }, [isCorrectSource, onBrokenOfficeHoursLinkBookAttemptClicked, searchParams]);
+
+  return {
+    forceEditMode: isCorrectSource,
+  };
 }


### PR DESCRIPTION
Moved `forceEditMode` return logic from `useFixBrokenOfficeHoursLinkEventCapture` to `useBrokenOfficeHoursLinkBookAttemptEventCapture` to ensure proper handling and alignment with the intended functionality. Updated related imports and usage accordingly.