### PR TITLE
Add query limit parameter and reset input value on selection

### DIFF
--- a/components/page/members/MembersFilter/FilterMultiSelect/FilterMultiSelect.tsx
+++ b/components/page/members/MembersFilter/FilterMultiSelect/FilterMultiSelect.tsx
@@ -158,6 +158,7 @@ export function FilterMultiSelect({ label, placeholder, paramKey, useDataHook = 
               value={val}
               onChange={(selectedOptions) => {
                 setValue(paramKey, selectedOptions ? [...selectedOptions] : [], { shouldValidate: true, shouldDirty: true });
+                setInputValue('');
               }}
               isDisabled={open || isDisabled}
               onMenuOpen={() => {

--- a/services/members/hooks/useGetRoles.ts
+++ b/services/members/hooks/useGetRoles.ts
@@ -3,7 +3,7 @@ import { MembersQueryKeys } from '@/services/members/constants';
 import { customFetch } from '@/utils/fetch-wrapper';
 
 async function fetcher(input: string) {
-  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/roles?q=${input}`, {}, false);
+  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/roles?q=${input}&limit=50`, {}, false);
 
   if (!res?.ok) {
     throw new Error('Failed to fetch roles');
@@ -22,7 +22,7 @@ export function useGetRoles(input: string) {
   return useQuery({
     queryKey: [MembersQueryKeys.GET_ROLES, input],
     queryFn: () => fetcher(input),
-    enabled: !!input,
+    // enabled: !!input,
     staleTime: 1000 * 60 * 60, // 1 hour
   });
 }

--- a/services/members/hooks/useGetTopics.ts
+++ b/services/members/hooks/useGetTopics.ts
@@ -3,7 +3,7 @@ import { MembersQueryKeys } from '@/services/members/constants';
 import { customFetch } from '@/utils/fetch-wrapper';
 
 async function fetcher(input: string) {
-  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/topics?q=${input}`, {}, false);
+  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/topics?q=${input}&limit=50`, {}, false);
 
   if (!res?.ok) {
     throw new Error('Failed to fetch topics');
@@ -22,7 +22,7 @@ export function useGetTopics(input: string) {
   return useQuery({
     queryKey: [MembersQueryKeys.GET_TOPICS, input],
     queryFn: () => fetcher(input),
-    enabled: !!input,
+    // enabled: !!input,
     staleTime: 1000 * 60 * 60, // 1 hour
   });
 }


### PR DESCRIPTION
Set a limit of 50 for autocomplete API queries in roles and topics fetchers to optimize responses. Updated FilterMultiSelect to clear input value upon selection for improved user experience. Disabled `enabled` option in React Query hooks for evaluation.