### PR TITLE
Refine forum header default sort and adjust post query fallback logic

### DIFF
--- a/components/page/forum/ForumHeader/ForumHeader.tsx
+++ b/components/page/forum/ForumHeader/ForumHeader.tsx
@@ -38,7 +38,7 @@ export const ForumHeader = () => {
   const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[sortOptions.length - 1];
+  const value = sortOptions.find((option) => option.value === searchParams.get('categoryTopicSort')) || sortOptions[1];
 
   const analytics = useForumAnalytics();
 

--- a/components/page/forum/Posts/Posts.tsx
+++ b/components/page/forum/Posts/Posts.tsx
@@ -23,7 +23,7 @@ export const Posts = () => {
   const categoryTopicSort = searchParams.get('categoryTopicSort') as string;
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteForumPosts({
     cid,
-    categoryTopicSort: categoryTopicSort ?? 'most_views',
+    categoryTopicSort: categoryTopicSort ?? 'recently_created',
   });
 
   const posts = useMemo(() => {


### PR DESCRIPTION
Updated ForumHeader to use the second sort option as the default fallback. Modified Posts query to default to "recently_created" when no categoryTopicSort is provided.