### PR TITLE
Enhance topic and role fetching with `hasOfficeHours` support

### DIFF
--- a/services/members/hooks/useGetRoles.ts
+++ b/services/members/hooks/useGetRoles.ts
@@ -1,9 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { MembersQueryKeys } from '@/services/members/constants';
 import { customFetch } from '@/utils/fetch-wrapper';
+import { useFilterStore } from '@/services/members/store';
 
-async function fetcher(input: string) {
-  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/roles?q=${input}&limit=50`, {}, false);
+async function fetcher(input: string, hasOfficeHours?: boolean) {
+  const params = new URLSearchParams({
+    q: input,
+    limit: '50',
+  });
+
+  // Add hasOfficeHours parameter if it's set
+  if (hasOfficeHours) {
+    params.append('hasOfficeHours', 'true');
+  }
+
+  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/roles?${params.toString()}`, {}, false);
 
   if (!res?.ok) {
     throw new Error('Failed to fetch roles');
@@ -19,9 +30,12 @@ async function fetcher(input: string) {
 }
 
 export function useGetRoles(input: string) {
+  const { params } = useFilterStore();
+  const hasOfficeHours = params.get('hasOfficeHours') === 'true';
+
   return useQuery({
-    queryKey: [MembersQueryKeys.GET_ROLES, input],
-    queryFn: () => fetcher(input),
+    queryKey: [MembersQueryKeys.GET_ROLES, input, hasOfficeHours],
+    queryFn: () => fetcher(input, hasOfficeHours),
     // enabled: !!input,
     staleTime: 1000 * 60 * 60, // 1 hour
   });

--- a/services/members/hooks/useGetTopics.ts
+++ b/services/members/hooks/useGetTopics.ts
@@ -1,9 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { MembersQueryKeys } from '@/services/members/constants';
 import { customFetch } from '@/utils/fetch-wrapper';
+import { useFilterStore } from '@/services/members/store';
 
-async function fetcher(input: string) {
-  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/topics?q=${input}&limit=50`, {}, false);
+async function fetcher(input: string, hasOfficeHours?: boolean) {
+  const params = new URLSearchParams({
+    q: input,
+    limit: '50',
+  });
+
+  // Add hasOfficeHours parameter if it's set
+  if (hasOfficeHours) {
+    params.append('hasOfficeHours', 'true');
+  }
+
+  const res = await customFetch(`${process.env.DIRECTORY_API_URL}/v1/members/autocomplete/topics?${params.toString()}`, {}, false);
 
   if (!res?.ok) {
     throw new Error('Failed to fetch topics');
@@ -19,9 +30,12 @@ async function fetcher(input: string) {
 }
 
 export function useGetTopics(input: string) {
+  const { params } = useFilterStore();
+  const hasOfficeHours = params.get('hasOfficeHours') === 'true';
+
   return useQuery({
-    queryKey: [MembersQueryKeys.GET_TOPICS, input],
-    queryFn: () => fetcher(input),
+    queryKey: [MembersQueryKeys.GET_TOPICS, input, hasOfficeHours],
+    queryFn: () => fetcher(input, hasOfficeHours),
     // enabled: !!input,
     staleTime: 1000 * 60 * 60, // 1 hour
   });


### PR DESCRIPTION
Updated `useGetTopics` and `useGetRoles` hooks to include `hasOfficeHours` parameter from filter store. Improved query key handling and updated fetch logic for more flexible API requests.