### PR TITLE
Add OhBadge to SearchResultsSection for available connections

### DIFF
--- a/components/core/application-search/components/SearchResultsSection/SearchResultsSection.module.scss
+++ b/components/core/application-search/components/SearchResultsSection/SearchResultsSection.module.scss
@@ -72,16 +72,27 @@ $padding-inline: 16px;
   }
 
   .type {
-    display: none;
+    position: relative;
     margin-left: auto;
-    padding: 4px;
-    border-radius: 4px;
-    background: var(--Neutral-Slate-100, #F1F5F9);
+
+    > div {
+      position: relative !important;
+      left: unset !important;
+      transform: unset !important;
+      top: unset !important;
+    }
   }
 
   .matches {
     list-style: none;
-    margin-bottom: 8px;
+
+    > li:first-of-type {
+      margin-top: 4px;
+    }
+
+    > li:last-of-type {
+      margin-bottom: 8px;
+    }
   }
 
   .matchRow {

--- a/components/core/application-search/components/SearchResultsSection/SearchResultsSection.tsx
+++ b/components/core/application-search/components/SearchResultsSection/SearchResultsSection.tsx
@@ -8,6 +8,7 @@ import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { useRouter } from 'next/navigation';
 import { useUnifiedSearchAnalytics } from '@/analytics/unified-search.analytics';
 import { formatDistanceToNow } from 'date-fns';
+import { OhBadge } from '@/components/core/OhBadge/OhBadge';
 
 interface Props {
   title?: string;
@@ -143,9 +144,11 @@ export const SearchResultsSection = ({ title, items, query, onSelect }: Props) =
                     {item.name}
                     {/*<HighlightedText text={item.name} query={query} />*/}
                   </div>
-                  <div className={s.type}>
-                    <Image src={SECTION_TYPE_ICONS[item.index]} alt={item.name} width={14} height={14} />
-                  </div>
+                  {!!item.availableToConnect && (
+                    <div className={s.type}>
+                      <OhBadge variant="primary" />
+                    </div>
+                  )}
                 </div>
                 <ul className={s.matches}>
                   {item.matches

--- a/services/search/types.ts
+++ b/services/search/types.ts
@@ -7,6 +7,8 @@ export type FoundItem = {
     field: string;
     content: string;
   }[];
+  availableToConnect?: boolean;
+  scheduleMeetingCount?: number;
 };
 
 export type ForumFoundItem = {


### PR DESCRIPTION
Introduce `OhBadge` to visually indicate items with `availableToConnect` status in the search results. Update related styles and types to support the new badge integration.