### PR TITLE
feat(founder-guides): scope support — Create/Edit form field + Browse sidebar filter

### DIFF
--- a/__tests__/page/founder-guides/articles-sidebar.test.tsx
+++ b/__tests__/page/founder-guides/articles-sidebar.test.tsx
@@ -19,6 +19,10 @@ jest.mock('@/services/rbac/hooks/useFounderGuidesCreateAccess', () => ({
   useFounderGuidesCreateAccess: () => ({ canCreate: false }),
 }));
 
+jest.mock('@/services/rbac/hooks/useFounderGuidesScopes', () => ({
+  useFounderGuidesScopes: () => ({ scopes: [], isLoading: false }),
+}));
+
 jest.mock('@/analytics/founder-guides.analytics', () => ({
   useFounderGuidesAnalytics: () => ({
     trackSidebarSearch: jest.fn(),

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
@@ -44,63 +44,59 @@
 
 // ── Search ────────────────────────────────────────────────
 .searchWrapper {
-  position: relative;
-  margin: 12px 16px;
+  display: flex;
+  height: 50px;
+  padding-left: 12px;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 16px 0;
   flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid rgba(203, 213, 225, 0.5);
+  background: #fff;
+
+  &:focus-within {
+    border-color: #5e718d;
+    box-shadow: 0 0 0 4px rgba(27, 56, 96, 0.12);
+  }
 }
 
-.searchIconWrap {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
+.searchIcon {
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #94a3b8;
   pointer-events: none;
 }
 
 .searchInput {
-  width: 100%;
-  height: 40px;
-  padding: 10px 36px 10px 38px;
-  border: 1px solid rgba(27, 56, 96, 0.12);
-  border-radius: 10px;
-  font-size: 14px;
-  font-weight: 400;
-  letter-spacing: -0.2px;
-  color: #0a0c11;
-  background: #fff;
-  box-shadow:
-    0px 1px 2px rgba(14, 15, 17, 0.08),
-    inset 0px -2px 8px rgba(14, 15, 17, 0.02);
+  flex: 1;
+  border: none;
+  background: transparent;
   outline: none;
-  box-sizing: border-box;
+  font-size: 14px;
+  color: #455468;
+  padding: 10px 4px;
 
   &::placeholder {
-    color: #afbaca;
-  }
-
-  &:focus {
-    border-color: #1b4dff;
+    color: #cbd5e1;
   }
 }
 
 .searchClearBtn {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
   background: none;
   border: none;
-  padding: 2px;
+  padding: 4px 12px 4px 4px;
   cursor: pointer;
-  border-radius: 4px;
+  flex-shrink: 0;
+  color: #94a3b8;
 
-  &:hover svg path {
-    stroke: #455468;
+  &:hover {
+    color: #64748b;
   }
 }
 

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
@@ -41,28 +41,6 @@
   letter-spacing: -0.1px;
 }
 
-.scopeSelect {
-  width: 100%;
-  height: 40px;
-  padding: 0 10px;
-  border: 1px solid rgba(27, 56, 96, 0.12);
-  border-radius: 10px;
-  font-size: 14px;
-  font-weight: 400;
-  color: #0a0c11;
-  background: #fff;
-  box-shadow:
-    0px 1px 2px rgba(14, 15, 17, 0.08),
-    inset 0px -2px 8px rgba(14, 15, 17, 0.02);
-  outline: none;
-  cursor: pointer;
-  appearance: auto;
-  box-sizing: border-box;
-
-  &:focus {
-    border-color: #1b4dff;
-  }
-}
 
 // ── Search ────────────────────────────────────────────────
 .searchWrapper {

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
@@ -25,6 +25,42 @@
   text-align: left;
 }
 
+// ── Viewing As ────────────────────────────────────────────
+.viewingAs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 0;
+  flex-shrink: 0;
+}
+
+.viewingAsLabel {
+  font-size: 13px;
+  font-weight: 400;
+  color: #6d7b8d;
+  white-space: nowrap;
+  letter-spacing: -0.1px;
+}
+
+.scopeSelect {
+  flex: 1;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid rgba(27, 56, 96, 0.12);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #0a0c11;
+  background: #fff;
+  outline: none;
+  cursor: pointer;
+  appearance: auto;
+
+  &:focus {
+    border-color: #1b4dff;
+  }
+}
+
 // ── Search ────────────────────────────────────────────────
 .searchWrapper {
   position: relative;

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.module.scss
@@ -28,33 +28,36 @@
 // ── Viewing As ────────────────────────────────────────────
 .viewingAs {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px 0;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 16px 0;
   flex-shrink: 0;
 }
 
 .viewingAsLabel {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 400;
   color: #6d7b8d;
-  white-space: nowrap;
   letter-spacing: -0.1px;
 }
 
 .scopeSelect {
-  flex: 1;
-  height: 32px;
-  padding: 0 8px;
+  width: 100%;
+  height: 40px;
+  padding: 0 10px;
   border: 1px solid rgba(27, 56, 96, 0.12);
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 500;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 400;
   color: #0a0c11;
   background: #fff;
+  box-shadow:
+    0px 1px 2px rgba(14, 15, 17, 0.08),
+    inset 0px -2px 8px rgba(14, 15, 17, 0.02);
   outline: none;
   cursor: pointer;
   appearance: auto;
+  box-sizing: border-box;
 
   &:focus {
     border-color: #1b4dff;

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
@@ -305,7 +305,7 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
       )}
 
       <div className={s.searchWrapper}>
-        <span className={s.searchIconWrap}>
+        <span className={s.searchIcon}>
           <SearchIcon />
         </span>
         <input

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useRef } from 'react';
+import Select from 'react-select';
 import { useFounderGuidesAnalytics } from '@/analytics/founder-guides.analytics';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -182,6 +183,7 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
   const pathname = usePathname();
   const { byCategory, isLoading } = useGetArticles();
   const { scopes: userScopes } = useFounderGuidesScopes();
+  const scopeOptions = useMemo(() => userScopes.map((s) => ({ label: SCOPE_LABELS[s] ?? s, value: s })), [userScopes]);
   const [search, setSearch] = useState('');
   const [selectedScope, setSelectedScope] = useState<string | null>(null);
   const [openCategories, setOpenCategories] = useState<Set<string> | null>(null);
@@ -267,17 +269,38 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
       {userScopes.length >= 2 && (
         <div className={s.viewingAs}>
           <span className={s.viewingAsLabel}>Viewing as:</span>
-          <select
-            value={selectedScope ?? ''}
-            onChange={(e) => setSelectedScope(e.target.value)}
-            className={s.scopeSelect}
-          >
-            {userScopes.map((scope) => (
-              <option key={scope} value={scope}>
-                {SCOPE_LABELS[scope] ?? scope}
-              </option>
-            ))}
-          </select>
+          <Select
+            options={scopeOptions}
+            value={scopeOptions.find((o) => o.value === selectedScope) ?? null}
+            onChange={(opt) => opt && setSelectedScope(opt.value)}
+            isSearchable={false}
+            styles={{
+              container: (base) => ({ ...base, width: '100%' }),
+              control: (base) => ({
+                ...base,
+                borderRadius: '8px',
+                border: '1px solid rgba(203, 213, 225, 0.50)',
+                boxShadow: 'none',
+                fontSize: '14px',
+                color: '#455468',
+                minHeight: '40px',
+                '&:hover': {
+                  border: '1px solid #5E718D',
+                  boxShadow: '0 0 0 4px rgba(27, 56, 96, 0.12)',
+                },
+              }),
+              indicatorSeparator: () => ({ display: 'none' }),
+              option: (base, state) => ({
+                ...base,
+                fontSize: '14px',
+                fontWeight: 300,
+                color: '#455468',
+                background: state.isSelected ? 'rgba(27, 56, 96, 0.12)' : 'transparent',
+                '&:hover': { background: 'rgba(27, 56, 96, 0.12)' },
+              }),
+              menu: (base) => ({ ...base, zIndex: 3 }),
+            }}
+          />
         </div>
       )}
 

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useGetArticles } from '@/services/articles/hooks/useGetArticles';
 import { useFounderGuidesCreateAccess } from '@/services/rbac/hooks/useFounderGuidesCreateAccess';
+import { useFounderGuidesScopes } from '@/services/rbac/hooks/useFounderGuidesScopes';
+import { SCOPE_LABELS } from '@/services/articles/constants';
 import { extractHeadings } from '@/utils/markdown';
 import s from './ArticlesSidebar.module.scss';
 
@@ -179,7 +181,9 @@ function getCategoryIcon(category: string) {
 export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSidebarProps) {
   const pathname = usePathname();
   const { byCategory, isLoading } = useGetArticles();
+  const { scopes: userScopes } = useFounderGuidesScopes();
   const [search, setSearch] = useState('');
+  const [selectedScope, setSelectedScope] = useState<string | null>(null);
   const [openCategories, setOpenCategories] = useState<Set<string> | null>(null);
   const { trackSidebarSearch, trackRequestGuideLinkClicked } = useFounderGuidesAnalytics();
   const searchDebounceSkipRef = useRef(true);
@@ -195,6 +199,22 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
     return () => clearTimeout(t);
   }, [search, trackSidebarSearch]);
 
+  useEffect(() => {
+    if (userScopes.length >= 2 && selectedScope === null) {
+      setSelectedScope(userScopes[0]);
+    }
+  }, [userScopes, selectedScope]);
+
+  const scopeFiltered = useMemo(() => {
+    if (!selectedScope) return byCategory;
+    return byCategory
+      .map(({ category, articles }) => ({
+        category,
+        articles: articles.filter((a) => a.scope === selectedScope || a.scope === null),
+      }))
+      .filter(({ articles }) => articles.length > 0);
+  }, [byCategory, selectedScope]);
+
   const effectiveOpenCategories = useMemo(
     () => openCategories ?? new Set(byCategory.map((c) => c.category)),
     [byCategory, openCategories],
@@ -205,15 +225,15 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
   const isRequestActive = pathname === '/founder-guides/request';
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return byCategory;
+    if (!search.trim()) return scopeFiltered;
     const q = search.toLowerCase();
-    return byCategory
+    return scopeFiltered
       .map((cat) => ({
         ...cat,
         articles: cat.articles.filter((a) => a.title.toLowerCase().includes(q) || a.content.toLowerCase().includes(q)),
       }))
       .filter((cat) => cat.articles.length > 0);
-  }, [byCategory, search]);
+  }, [scopeFiltered, search]);
 
   // Auto-expand categories when searching
   const visibleCategories = useMemo(() => {
@@ -241,6 +261,23 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
       {!hideHeader && (
         <div className={s.header}>
           <span className={s.title}>Browse Guides</span>
+        </div>
+      )}
+
+      {userScopes.length >= 2 && (
+        <div className={s.viewingAs}>
+          <span className={s.viewingAsLabel}>Viewing as:</span>
+          <select
+            value={selectedScope ?? ''}
+            onChange={(e) => setSelectedScope(e.target.value)}
+            className={s.scopeSelect}
+          >
+            {userScopes.map((scope) => (
+              <option key={scope} value={scope}>
+                {SCOPE_LABELS[scope] ?? scope}
+              </option>
+            ))}
+          </select>
         </div>
       )}
 

--- a/components/page/founder-guides/CreateArticle/CreateArticle.tsx
+++ b/components/page/founder-guides/CreateArticle/CreateArticle.tsx
@@ -15,7 +15,8 @@ import useBlockNavigation from '@/hooks/useUnsavedChangesWarning';
 import { useMember } from '@/services/members/hooks/useMember';
 import { useCreateArticleMutation } from '@/services/articles/hooks/useCreateArticleMutation';
 import { useUpdateArticleMutation } from '@/services/articles/hooks/useUpdateArticleMutation';
-import { ARTICLE_CATEGORIES } from '@/services/articles/constants';
+import { ARTICLE_CATEGORIES, SCOPE_LABELS } from '@/services/articles/constants';
+import { useFounderGuidesScopes } from '@/services/rbac/hooks/useFounderGuidesScopes';
 import { IArticle } from '@/types/articles.types';
 import { AuthorAutocomplete } from './AuthorAutocomplete';
 import { createArticleSchema, CreateArticleForm, articleToFormValues } from './helpers';
@@ -47,12 +48,16 @@ export default function CreateArticle({ article, isEditMode }: CreateArticleProp
 
   const categoryOptions = useMemo(() => ARTICLE_CATEGORIES.map((c) => ({ label: c, value: c })), []);
 
+  const { scopes: userScopes } = useFounderGuidesScopes();
+  const scopeOptions = useMemo(() => userScopes.map((s) => ({ label: SCOPE_LABELS[s] ?? s, value: s })), [userScopes]);
+
   const defaultValues = useMemo(
     () =>
       isEditMode && article
         ? articleToFormValues(article)
         : {
             category: null,
+            scope: null,
             title: '',
             summary: '',
             readingTime: null,
@@ -101,6 +106,7 @@ export default function CreateArticle({ article, isEditMode }: CreateArticleProp
       title: data.title,
       summary: data.summary || undefined,
       category: data.category?.value,
+      scope: data.scope?.value ?? null,
       readingTime: data.readingTime || undefined,
       content: data.content,
       authorMemberUid: author?.type === 'member' ? author.value : undefined,
@@ -171,6 +177,16 @@ export default function CreateArticle({ article, isEditMode }: CreateArticleProp
                 options={categoryOptions}
                 isRequired
               />
+
+              {userScopes.length > 0 && (
+                <FormSelect
+                  name="scope"
+                  placeholder="Select scope"
+                  label="Scope"
+                  options={scopeOptions}
+                  isClearable
+                />
+              )}
 
               <FormField
                 name="title"

--- a/components/page/founder-guides/CreateArticle/CreateArticle.tsx
+++ b/components/page/founder-guides/CreateArticle/CreateArticle.tsx
@@ -179,13 +179,7 @@ export default function CreateArticle({ article, isEditMode }: CreateArticleProp
               />
 
               {userScopes.length > 0 && (
-                <FormSelect
-                  name="scope"
-                  placeholder="Select scope"
-                  label="Scope"
-                  options={scopeOptions}
-                  isClearable
-                />
+                <FormSelect name="scope" placeholder="Select scope" label="Scope" options={scopeOptions} isClearable />
               )}
 
               <FormField

--- a/components/page/founder-guides/CreateArticle/helpers.ts
+++ b/components/page/founder-guides/CreateArticle/helpers.ts
@@ -1,9 +1,10 @@
 import * as yup from 'yup';
 import { IArticle } from '@/types/articles.types';
-import { ARTICLE_CATEGORIES } from '@/services/articles/constants';
+import { ARTICLE_CATEGORIES, SCOPE_LABELS } from '@/services/articles/constants';
 
 export const createArticleSchema = yup.object().shape({
   category: yup.object().required('Category is required'),
+  scope: yup.object().nullable().optional(),
   title: yup.string().max(255, 'Title exceeds 255 characters. Please shorten.').required('Title is required'),
   summary: yup.string().max(100, 'Max 100 characters.').required('Summary is required'),
   readingTime: yup
@@ -37,6 +38,7 @@ export const createArticleSchema = yup.object().shape({
 
 export type CreateArticleForm = {
   category: { label: string; value: string } | null;
+  scope: { label: string; value: string } | null;
   title: string;
   summary: string;
   readingTime: number | null;
@@ -62,8 +64,13 @@ export function articleToFormValues(article: IArticle): CreateArticleForm {
     author = { label: article.authorTeam.name, value: article.authorTeam.uid, type: 'team' };
   }
 
+  const scopeOption = article.scope
+    ? { label: SCOPE_LABELS[article.scope] ?? article.scope, value: article.scope }
+    : null;
+
   return {
     category: categoryOption,
+    scope: scopeOption,
     title: article.title || '',
     summary: article.summary || '',
     readingTime: article.readingTime || null,

--- a/services/articles/constants.ts
+++ b/services/articles/constants.ts
@@ -11,3 +11,10 @@ export const ARTICLE_CATEGORIES = [
 ] as const;
 
 export type ArticleCategory = (typeof ARTICLE_CATEGORIES)[number];
+
+export const AVAILABLE_SCOPES = ['PLVS', 'PLCC'] as const;
+export type ArticleScope = (typeof AVAILABLE_SCOPES)[number];
+export const SCOPE_LABELS: Record<string, string> = {
+  PLVS: 'PLVS Founder',
+  PLCC: 'PLCC Founder',
+};

--- a/services/articles/hooks/useCreateArticleMutation.ts
+++ b/services/articles/hooks/useCreateArticleMutation.ts
@@ -9,6 +9,7 @@ type CreateArticlePayload = {
   title: string;
   summary?: string;
   category: string;
+  scope?: string | null;
   content: string;
   authorMemberUid?: string;
   authorTeamUid?: string;

--- a/services/articles/hooks/useUpdateArticleMutation.ts
+++ b/services/articles/hooks/useUpdateArticleMutation.ts
@@ -9,6 +9,7 @@ type UpdateArticlePayload = {
   title: string;
   summary?: string;
   category: string;
+  scope?: string | null;
   content: string;
   authorMemberUid?: string;
   authorTeamUid?: string;

--- a/services/rbac/hooks/useFounderGuidesScopes.ts
+++ b/services/rbac/hooks/useFounderGuidesScopes.ts
@@ -3,23 +3,20 @@ import { RbacQueryKeys } from '../constants';
 import { fetchRbacMe } from '../rbac.service';
 import { getUserInfoFromLocal } from '@/utils/common.utils';
 
-export function useDemoDayAnalyticsAccess() {
+export function useFounderGuidesScopes(): { scopes: string[]; isLoading: boolean } {
   const userInfo = getUserInfoFromLocal();
 
-  const {
-    data: hasAccess = false,
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: [RbacQueryKeys.RBAC_ME, 'demo-day-analytics'],
+  const { data: scopes = [], isLoading } = useQuery({
+    queryKey: [RbacQueryKeys.RBAC_ME, 'founder-guides-scopes'],
     queryFn: async () => {
       const rbac = await fetchRbacMe();
-      return rbac.permissions.some((p) => p.name === 'demo_day.report_link.view');
+      const perm = rbac.permissions.find((p) => p.name === 'founder_guides.view');
+      return perm?.scopes ?? [];
     },
     staleTime: 5 * 60 * 1000,
     enabled: !!userInfo,
     retry: 2,
   });
 
-  return { hasAccess, isLoading, isError };
+  return { scopes, isLoading };
 }

--- a/types/articles.types.ts
+++ b/types/articles.types.ts
@@ -4,6 +4,7 @@ export interface IArticle {
   title: string;
   summary: string;
   category: string;
+  scope: string | null;
   tags: string[];
   content: string;
   readingTime: number;


### PR DESCRIPTION
## Summary

- Adds a **Scope** dropdown to the Create/Edit guide form (shown only when the user has accessible scopes; clearable to `null` = globally visible)
- Adds a **Viewing as** selector to the Browse Guides sidebar (shown only when the user has 2+ scopes); filters articles client-side to `scope === selectedScope || scope === null`
- New `useFounderGuidesScopes` hook reads `founder_guides.view` scopes from `fetchRbacMe()`
- Scope is sent in both create and update mutation payloads
- Hydrates scope on edit via `articleToFormValues`
- Fixes `useDemoDayAnalyticsAccess` to use new `RbacPermission` shape (pre-existing bug from PR #2295)