### PR TITLE
fix: preserve founder guides scope filter across navigation

### DIFF
--- a/__tests__/page/founder-guides/articles-sidebar.test.tsx
+++ b/__tests__/page/founder-guides/articles-sidebar.test.tsx
@@ -11,6 +11,11 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
 }));
 
+jest.mock('nuqs', () => ({
+  useQueryState: () => [null, jest.fn()],
+  parseAsString: { withOptions: () => ({ withOptions: jest.fn() }) },
+}));
+
 jest.mock('@/services/articles/hooks/useGetArticles', () => ({
   useGetArticles: () => mockUseGetArticles(),
 }));

--- a/components/page/founder-guides/ArticleContent/ArticleContent.module.scss
+++ b/components/page/founder-guides/ArticleContent/ArticleContent.module.scss
@@ -589,7 +589,6 @@
   line-height: 24px;
   letter-spacing: -0.3px;
   text-decoration: none;
-  white-space: nowrap;
 
   @include tablet-landscape {
     font-size: 16px;

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
@@ -4,7 +4,8 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import Select from 'react-select';
 import { useFounderGuidesAnalytics } from '@/analytics/founder-guides.analytics';
 import Link from 'next/link';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
+import { useQueryState, parseAsString } from 'nuqs';
 import { useGetArticles } from '@/services/articles/hooks/useGetArticles';
 import { useFounderGuidesCreateAccess } from '@/services/rbac/hooks/useFounderGuidesCreateAccess';
 import { useFounderGuidesScopes } from '@/services/rbac/hooks/useFounderGuidesScopes';
@@ -181,8 +182,7 @@ function getCategoryIcon(category: string) {
 
 export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSidebarProps) {
   const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const [scopeParam, setScopeParam] = useQueryState('scope', parseAsString.withOptions({ history: 'replace', shallow: true }));
   const { byCategory, isLoading } = useGetArticles();
   const { scopes: userScopes } = useFounderGuidesScopes();
   const scopeOptions = useMemo(() => userScopes.map((s) => ({ label: SCOPE_LABELS[s] ?? s, value: s })), [userScopes]);
@@ -193,10 +193,9 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
 
   const selectedScope = useMemo(() => {
     if (userScopes.length < 2) return null;
-    const raw = searchParams.get('scope');
-    if (raw && userScopes.includes(raw)) return raw;
+    if (scopeParam && userScopes.includes(scopeParam)) return scopeParam;
     return userScopes.includes(DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE) ? DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE : userScopes[0];
-  }, [searchParams, userScopes]);
+  }, [scopeParam, userScopes]);
 
   useEffect(() => {
     if (searchDebounceSkipRef.current) {
@@ -274,12 +273,7 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
           <Select
             options={scopeOptions}
             value={scopeOptions.find((o) => o.value === selectedScope) ?? null}
-            onChange={(opt) => {
-              if (!opt) return;
-              const params = new URLSearchParams(searchParams.toString());
-              params.set('scope', opt.value);
-              router.replace(`${pathname}?${params.toString()}`);
-            }}
+            onChange={(opt) => opt && setScopeParam(opt.value)}
             isSearchable={false}
             styles={{
               container: (base) => ({ ...base, width: '100%' }),

--- a/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
+++ b/components/page/founder-guides/ArticlesSidebar/ArticlesSidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import Select from 'react-select';
 import { useFounderGuidesAnalytics } from '@/analytics/founder-guides.analytics';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useGetArticles } from '@/services/articles/hooks/useGetArticles';
 import { useFounderGuidesCreateAccess } from '@/services/rbac/hooks/useFounderGuidesCreateAccess';
 import { useFounderGuidesScopes } from '@/services/rbac/hooks/useFounderGuidesScopes';
@@ -181,14 +181,22 @@ function getCategoryIcon(category: string) {
 
 export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSidebarProps) {
   const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { byCategory, isLoading } = useGetArticles();
   const { scopes: userScopes } = useFounderGuidesScopes();
   const scopeOptions = useMemo(() => userScopes.map((s) => ({ label: SCOPE_LABELS[s] ?? s, value: s })), [userScopes]);
   const [search, setSearch] = useState('');
-  const [selectedScope, setSelectedScope] = useState<string | null>(null);
   const [openCategories, setOpenCategories] = useState<Set<string> | null>(null);
   const { trackSidebarSearch, trackRequestGuideLinkClicked } = useFounderGuidesAnalytics();
   const searchDebounceSkipRef = useRef(true);
+
+  const selectedScope = useMemo(() => {
+    if (userScopes.length < 2) return null;
+    const raw = searchParams.get('scope');
+    if (raw && userScopes.includes(raw)) return raw;
+    return userScopes.includes(DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE) ? DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE : userScopes[0];
+  }, [searchParams, userScopes]);
 
   useEffect(() => {
     if (searchDebounceSkipRef.current) {
@@ -200,14 +208,6 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
     }, 400);
     return () => clearTimeout(t);
   }, [search, trackSidebarSearch]);
-
-  useEffect(() => {
-    if (userScopes.length >= 2 && selectedScope === null) {
-      const next =
-        userScopes.includes(DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE) ? DEFAULT_FOUNDER_GUIDES_VIEW_SCOPE : userScopes[0];
-      setSelectedScope(next);
-    }
-  }, [userScopes, selectedScope]);
 
   const scopeFiltered = useMemo(() => {
     if (!selectedScope) return byCategory;
@@ -274,7 +274,12 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
           <Select
             options={scopeOptions}
             value={scopeOptions.find((o) => o.value === selectedScope) ?? null}
-            onChange={(opt) => opt && setSelectedScope(opt.value)}
+            onChange={(opt) => {
+              if (!opt) return;
+              const params = new URLSearchParams(searchParams.toString());
+              params.set('scope', opt.value);
+              router.replace(`${pathname}?${params.toString()}`);
+            }}
             isSearchable={false}
             styles={{
               container: (base) => ({ ...base, width: '100%' }),
@@ -326,7 +331,7 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
 
       {canCreate && (
         <Link
-          href="/founder-guides/new"
+          href={selectedScope ? `/founder-guides/new?scope=${selectedScope}` : '/founder-guides/new'}
           className={`${s.createLink} ${isCreateActive ? s.createLinkActive : ''}`}
           onClick={onNavigate}
         >
@@ -368,8 +373,9 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
                 {isOpen && (
                   <div className={s.articleList}>
                     {articles.map((article) => {
-                      const href = `/founder-guides/${article.slugURL}`;
-                      const isActive = pathname === href;
+                      const articlePath = `/founder-guides/${article.slugURL}`;
+                      const href = selectedScope ? `${articlePath}?scope=${selectedScope}` : articlePath;
+                      const isActive = pathname === articlePath;
                       const headings = isActive ? extractHeadings(article.content) : [];
                       return (
                         <div key={article.uid}>
@@ -407,7 +413,7 @@ export default function ArticlesSidebar({ onNavigate, hideHeader }: ArticlesSide
             );
           })}
         <Link
-          href="/founder-guides/request"
+          href={selectedScope ? `/founder-guides/request?scope=${selectedScope}` : '/founder-guides/request'}
           className={`${s.requestLink} ${isRequestActive ? s.requestLinkActive : ''}`}
           onClick={() => {
             trackRequestGuideLinkClicked();


### PR DESCRIPTION
Replace `useState` + `useEffect` scope init with `useSearchParams()`. Scope now lives in `?scope=PLCC` URL param. All article links carry the current scope param; scope changes use `router.replace` (no history pollution)
