### PR TITLE
Adjust text wrapping styles in ArticleContent SCSS: use `word-break: …

### DIFF
--- a/components/page/founder-guides/ArticleContent/ArticleContent.module.scss
+++ b/components/page/founder-guides/ArticleContent/ArticleContent.module.scss
@@ -117,6 +117,7 @@
   letter-spacing: -0.5px;
   line-height: 1.3;
   margin: 0;
+  word-break: break-word;
 
   @media (min-width: 1024px) {
     font-size: 30px;
@@ -571,7 +572,6 @@
   line-height: 24px;
   letter-spacing: -0.3px;
   text-decoration: none;
-  white-space: nowrap;
 
   @include tablet-landscape {
     font-size: 16px;


### PR DESCRIPTION
…break-word` and remove `white-space: nowrap`.