### PR TITLE
[In App Notifications] Fix infinite socket reconnect

### DIFF
--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -22,6 +22,7 @@ interface UsePushNotificationsOptions {
 
 interface UsePushNotificationsReturn {
   isConnected: boolean;
+  connectionEstablished: boolean;
   error: string | null;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
@@ -30,6 +31,9 @@ interface UsePushNotificationsReturn {
 
 const WS_URL = process.env.DIRECTORY_API_URL;
 const DEFAULT_HEALTH_CHECK_INTERVAL = 30000; // 30 seconds
+const RECONNECTION_ATTEMPTS = 5;
+const RECONNECTION_DELAY_MS = 2000;
+const RECONNECTION_DELAY_MAX_MS = 10000;
 
 export function usePushNotifications(options: UsePushNotificationsOptions): UsePushNotificationsReturn {
   const {
@@ -45,6 +49,7 @@ export function usePushNotifications(options: UsePushNotificationsOptions): UseP
   const socketRef = useRef<Socket | null>(null);
   const healthCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [connectionEstablished, setConnectionEstablished] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Store callbacks in refs to avoid reconnection on callback changes
@@ -73,9 +78,9 @@ export function usePushNotifications(options: UsePushNotificationsOptions): UseP
       auth: { token },
       transports: ['websocket', 'polling'],
       reconnection: true,
-      reconnectionAttempts: Infinity,
-      reconnectionDelay: 1000,
-      reconnectionDelayMax: 10000,
+      reconnectionAttempts: RECONNECTION_ATTEMPTS,
+      reconnectionDelay: RECONNECTION_DELAY_MS,
+      reconnectionDelayMax: RECONNECTION_DELAY_MAX_MS,
       timeout: 20000,
     });
 
@@ -85,18 +90,28 @@ export function usePushNotifications(options: UsePushNotificationsOptions): UseP
       callbacksRef.current.onConnectionChange?.(true);
     });
 
-    socket.on('disconnect', (reason) => {
+    socket.on('disconnect', () => {
       setIsConnected(false);
+      setConnectionEstablished(false);
       callbacksRef.current.onConnectionChange?.(false);
+    });
 
-      // If the disconnection was initiated by the server, try to reconnect
-      if (reason === 'io server disconnect') {
-        socket.connect();
-      }
+    socket.on(WebSocketEvent.CONNECTION_SUCCESS, () => {
+      setConnectionEstablished(true);
     });
 
     socket.on(WebSocketEvent.CONNECTION_ERROR, (data) => {
       setError(data.message);
+    });
+
+    // Stop the health check once Socket.IO has exhausted its retries —
+    // otherwise the 30s timer would re-trigger socket.connect() and start
+    // a fresh round of attempts against a permanently-broken connection.
+    socket.io.on('reconnect_failed', () => {
+      if (healthCheckIntervalRef.current) {
+        clearInterval(healthCheckIntervalRef.current);
+        healthCheckIntervalRef.current = null;
+      }
     });
 
     socket.on(WebSocketEvent.NOTIFICATION_NEW, (notification: PushNotification) => {
@@ -164,6 +179,7 @@ export function usePushNotifications(options: UsePushNotificationsOptions): UseP
       socket.disconnect();
       socketRef.current = null;
       setIsConnected(false);
+      setConnectionEstablished(false);
     };
   }, [token, enabled, createSocket, checkConnectionHealth, healthCheckInterval]);
 
@@ -177,6 +193,7 @@ export function usePushNotifications(options: UsePushNotificationsOptions): UseP
 
   return {
     isConnected,
+    connectionEstablished,
     error,
     markAsRead,
     markAllAsRead,

--- a/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
+++ b/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
@@ -175,6 +175,7 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
 
   const {
     isConnected,
+    connectionEstablished,
     error,
     markAsRead: wsMarkAsRead,
     markAllAsRead: wsMarkAllAsRead,
@@ -186,18 +187,21 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
     onCountUpdate: handleCountUpdate,
   });
 
-  // Track previous connection state to detect reconnections
-  const wasConnectedRef = useRef(isConnected);
+  // Track previous server-acknowledged auth state to detect reconnections.
+  // Keyed on `connectionEstablished` (set by `connection:success`) rather than
+  // `isConnected` (transport-level), so a doomed-loop cycle of connect→reject
+  // never triggers a refetch.
+  const wasEstablishedRef = useRef(connectionEstablished);
 
   // Refetch notifications on WebSocket reconnect to catch any missed events
   useEffect(() => {
-    const wasDisconnected = !wasConnectedRef.current;
-    const isNowConnected = isConnected;
+    const wasDisestablished = !wasEstablishedRef.current;
+    const isNowEstablished = connectionEstablished;
 
     // Update ref for next comparison
-    wasConnectedRef.current = isConnected;
+    wasEstablishedRef.current = connectionEstablished;
 
-    if (!isNowConnected || !authToken) {
+    if (!isNowEstablished || !authToken) {
       return;
     }
 
@@ -208,10 +212,10 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
     }
 
     // Only refetch on actual reconnections (was disconnected, now connected again)
-    if (wasDisconnected) {
+    if (wasDisestablished) {
       void fetchNotifications();
     }
-  }, [isConnected, authToken, fetchNotifications]);
+  }, [connectionEstablished, authToken, fetchNotifications]);
 
   // Keep wsMarkAsReadRef in sync
   wsMarkAsReadRef.current = wsMarkAsRead;


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                           
                                                                            
  When the WebSocket gateway rejects a connection (e.g. `Member not found`, `Invalid token`), the frontend gets stuck in a tight reconnect loop:                                                                                                                         
                                                                                                                                                                                                                                                                         
  - The Socket.IO client was configured with `reconnectionAttempts: Infinity` and an explicit override that re-called `socket.connect()` on `io server disconnect`. A 30s health check also force-reconnected if the socket was down. Together, these defeated           
  Socket.IO's built-in safety against unrecoverable server-side disconnects.                                                                                                                                                                                             
  - On every cycle of the loop, the transport-level `connect` event fired *before* the backend rejected auth. The `PushNotificationsProvider` watched `isConnected` and re-fetched notifications on every false→true flip, so each failed cycle triggered a fresh `GET   
  /v1/push-notifications` and `GET /v1/push-notifications/unread-links`.                                                                                                                                                                                                 
   
  Result in production: ~5 rejected handshakes per second per affected user, plus continuous REST spam against the same two endpoints.                                                                                                                                   
                                                         
  ## Fix                                                                                                                                                                                                                                                                 
                                                         
  Frontend-only change in two files:                                                                                                                                                                                                                                     
   
  - **`hooks/usePushNotifications.ts`** — Bound the retry count to 5 attempts with a 2s base delay (Socket.IO's exponential backoff caps at 10s, so the retry window is ~34s — enough for transient blips, not enough to spam). Removed the `io server disconnect`       
  force-reconnect override. Added a `reconnect_failed` listener that stops the 30s health check once retries are exhausted, so the timer can't restart a doomed cycle. Added a new `connectionEstablished` flag that flips `true` only on the server's
  `connection:success` event (i.e. after auth is acknowledged), not on the transport-level `connect`.                                                                                                                                                                    
                                                         
  - **`providers/PushNotificationsProvider/PushNotificationsProvider.tsx`** — Switched the reconnect-refetch effect to key on `connectionEstablished` instead of `isConnected`. REST endpoints can no longer fire during a connect→reject cycle, because a doomed cycle  
  never receives `connection:success`.
                                                                                                                                                                                                                                                                         
  ## Why this approach                                   

  - **No string matching against backend error messages** — frontend doesn't need to classify which errors are "fatal." A bounded retry count handles both cases uniformly: transient failures succeed within the window; permanent failures stop quietly.               
  - **No backend changes required** — backend rejection logic was already correct; the loop is the client's responsibility to stop.
  - **No regression for transient outages** — Socket.IO's built-in reconnection with 5 attempts covers brief network blips, server restarts, and TLS renegotiation. The existing `reconnect()` function is still exposed for user-initiated retry on longer outages.     
  - **Mark-read reliability preserved** — REST is the source of truth for read state; the WS is only used for cross-device sync, so a permanently disconnected socket doesn't lose data.  