### PR TITLE
fix: prevent StoreInitializer from overwriting API-enriched user data…

### DIFF
--- a/components/core/login/components/UserInfoChecker/UserInfoChecker.tsx
+++ b/components/core/login/components/UserInfoChecker/UserInfoChecker.tsx
@@ -98,7 +98,7 @@ export function UserInfoChecker({ uid }: { uid: string }) {
       setUserInfoCookie(JSON.stringify(updatedRbac), {
         domain: process.env.COOKIE_DOMAIN || '',
       });
-      useCurrentUserStore.getState().actions.setCurrentUser(updatedRbac);
+      useCurrentUserStore.getState().actions.setCurrentUserFromApi(updatedRbac);
       router.refresh();
       return;
     }
@@ -118,7 +118,7 @@ export function UserInfoChecker({ uid }: { uid: string }) {
       setUserInfoCookie(JSON.stringify(updatedRoles), {
         domain: process.env.COOKIE_DOMAIN || '',
       });
-      useCurrentUserStore.getState().actions.setCurrentUser(updatedRoles);
+      useCurrentUserStore.getState().actions.setCurrentUserFromApi(updatedRoles);
       router.refresh();
       return;
     }
@@ -135,7 +135,7 @@ export function UserInfoChecker({ uid }: { uid: string }) {
       setUserInfoCookie(JSON.stringify(updatedLeadingTeams), {
         domain: process.env.COOKIE_DOMAIN || '',
       });
-      useCurrentUserStore.getState().actions.setCurrentUser(updatedLeadingTeams);
+      useCurrentUserStore.getState().actions.setCurrentUserFromApi(updatedLeadingTeams);
       router.refresh();
       return;
     }
@@ -148,7 +148,7 @@ export function UserInfoChecker({ uid }: { uid: string }) {
         profileImageUrl: memberInfo.imageUrl,
       };
       setUserInfoCookie(JSON.stringify(updatedProfile), { domain: process.env.COOKIE_DOMAIN || '' });
-      useCurrentUserStore.getState().actions.setCurrentUser(updatedProfile);
+      useCurrentUserStore.getState().actions.setCurrentUserFromApi(updatedProfile);
       router.refresh();
     }
   }, [handleLogout, member, router, setUserInfoCookie, userInfoCookie]);

--- a/providers/StoreInitializer.tsx
+++ b/providers/StoreInitializer.tsx
@@ -16,7 +16,11 @@ export default function StoreInitializer({ userInfo }: StoreInitializerProps) {
   const { actions } = useCurrentUserStore();
 
   useSyncLayoutEffect(() => {
-    actions.setCurrentUser(userInfo);
+    // Skip if UserInfoChecker already enriched the store with fresher API data,
+    // unless this is a logout (null) — always honour that.
+    if (userInfo === null || !useCurrentUserStore.getState().isEnrichedByApi) {
+      actions.setCurrentUser(userInfo);
+    }
   }, [userInfo, actions]);
 
   return null;

--- a/services/auth/store.ts
+++ b/services/auth/store.ts
@@ -4,15 +4,19 @@ import { IUserInfo } from '@/types/shared.types';
 interface CurrentUserState {
   readonly currentUser: IUserInfo | null;
   readonly isHydrated: boolean;
+  readonly isEnrichedByApi: boolean;
   readonly actions: {
     setCurrentUser: (user: IUserInfo | null) => void;
+    setCurrentUserFromApi: (user: IUserInfo | null) => void;
   };
 }
 
 export const useCurrentUserStore = create<CurrentUserState>((set) => ({
   currentUser: null,
   isHydrated: false,
+  isEnrichedByApi: false,
   actions: {
-    setCurrentUser: (user) => set({ currentUser: user, isHydrated: true }),
+    setCurrentUser: (user) => set({ currentUser: user, isHydrated: true, isEnrichedByApi: false }),
+    setCurrentUserFromApi: (user) => set({ currentUser: user, isHydrated: true, isEnrichedByApi: true }),
   },
 }));


### PR DESCRIPTION
… on router.refresh()

UserInfoChecker calls router.refresh() after patching the cookie, which causes StoreInitializer to re-fire with stale SSR data (fewer permissions). Fix:

- Add isEnrichedByApi flag + setCurrentUserFromApi action to the store
- StoreInitializer skips the update when the store was already enriched by the API (unless userInfo is null, which always means logout)
- UserInfoChecker uses setCurrentUserFromApi to mark its updates as authoritative

This stops the 11→23→11 permission flicker during app render.