### PR TITLE
feat(home): add Welcome bar and News from the network feed

### DIFF
--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -1,0 +1,153 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { TeamNews } from '@/components/page/home/TeamNews/TeamNews';
+import type { ITeamNewsGroup, ITeamNewsItem, TeamNewsEventType } from '@/types/team-news.types';
+
+const mockOnTabClicked = jest.fn();
+const mockOnCategoryClicked = jest.fn();
+const mockOnLoadMoreClicked = jest.fn();
+const mockOnCardClicked = jest.fn();
+
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({
+    onTeamNewsTabClicked: (...a: unknown[]) => mockOnTabClicked(...a),
+    onTeamNewsCategoryClicked: (...a: unknown[]) => mockOnCategoryClicked(...a),
+    onTeamNewsLoadMoreClicked: (...a: unknown[]) => mockOnLoadMoreClicked(...a),
+    onTeamNewsCardClicked: (...a: unknown[]) => mockOnCardClicked(...a),
+  }),
+}));
+
+jest.mock('@/utils/formatTimeAgo', () => ({
+  formatTimeAgo: () => '2d ago',
+}));
+
+const FA_AI = { uid: 'fa-ai', title: 'AI & Robotics' };
+const FA_DHR = { uid: 'fa-dhr', title: 'Digital Human Rights' };
+
+const makeItem = (uid: string, eventType: TeamNewsEventType, focusAreaTitles: string[]): ITeamNewsItem => ({
+  uid,
+  teamUid: `team-${uid}`,
+  teamName: `Team ${uid}`,
+  teamLogoUrl: null,
+  eventType,
+  eventDate: '2026-05-01T12:00:00.000Z',
+  title: `Headline ${uid}`,
+  summary: `Summary ${uid}`,
+  sourceUrl: `https://example.com/${uid}`,
+  sourceDomain: 'example.com',
+  tags: [],
+  focusAreas: focusAreaTitles,
+  subFocusAreas: [],
+  createdAt: '2026-05-01T12:00:00.000Z',
+});
+
+const aiItems: ITeamNewsItem[] = [
+  makeItem('ai-1', 'FUNDING', ['AI & Robotics']),
+  makeItem('ai-2', 'LAUNCH', ['AI & Robotics']),
+  makeItem('ai-3', 'PARTNERSHIP', ['AI & Robotics']),
+];
+const dhrItems: ITeamNewsItem[] = [
+  makeItem('dhr-1', 'MILESTONE', ['Digital Human Rights']),
+  makeItem('dhr-2', 'ANNOUNCEMENT', ['Digital Human Rights']),
+];
+
+const groups: ITeamNewsGroup[] = [
+  { focusArea: FA_AI, total: aiItems.length, items: aiItems },
+  { focusArea: FA_DHR, total: dhrItems.length, items: dhrItems },
+];
+
+describe('TeamNews', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the global empty state when there are no items', () => {
+    render(<TeamNews groups={[]} />);
+    expect(screen.getByRole('heading', { level: 2, name: /News from the network/i })).toBeInTheDocument();
+    expect(screen.getByText(/No network news in the last 14 days yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+
+  it('renders the section, tabs with counts, and category chips when populated', () => {
+    render(<TeamNews groups={groups} />);
+    expect(screen.getByRole('heading', { level: 2, name: /News from the network/i })).toBeInTheDocument();
+    expect(screen.getByText('5 new')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /All/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: /AI & Robotics/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Digital Human Rights/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /All categories/ })).toHaveClass(/catActive/);
+  });
+
+  it('switches to a focus-area tab and reports analytics', () => {
+    render(<TeamNews groups={groups} />);
+    fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
+    expect(mockOnTabClicked).toHaveBeenCalledWith('Digital Human Rights', dhrItems.length);
+    expect(screen.getByRole('tab', { name: /Digital Human Rights/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText(/Headline dhr-1/)).toBeInTheDocument();
+    expect(screen.queryByText(/Headline ai-1/)).not.toBeInTheDocument();
+  });
+
+  it('filters by category and reports analytics with current tab context', () => {
+    render(<TeamNews groups={groups} />);
+    fireEvent.click(screen.getByRole('button', { name: /Funding/ }));
+    expect(mockOnCategoryClicked).toHaveBeenCalledWith('FUNDING', 1, 'All');
+    expect(screen.getByText(/Headline ai-1/)).toBeInTheDocument();
+    expect(screen.queryByText(/Headline ai-2/)).not.toBeInTheDocument();
+  });
+
+  it('disables a category chip when its count is zero (other than the All chip)', () => {
+    render(<TeamNews groups={groups} />);
+    // Tab to DHR — only MILESTONE + ANNOUNCEMENT items, so FUNDING/LAUNCH/PARTNERSHIP should disable.
+    fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
+    expect(screen.getByRole('button', { name: /^Funding$/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Launch$/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Milestone/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /All categories/ })).not.toBeDisabled();
+  });
+
+  it('paginates with Load more and reports analytics', () => {
+    render(<TeamNews groups={groups} pageSize={2} />);
+    // 5 items total, pageSize=2 → first page shows 2.
+    expect(screen.getByText(/Showing 2 of 5/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Load 2 more/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Load 2 more/ }));
+    expect(mockOnLoadMoreClicked).toHaveBeenCalledWith(2, 5, 'All', 'all');
+    expect(screen.getByText(/Showing 4 of 5/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Load 1 more/ }));
+    expect(screen.queryByRole('button', { name: /Load/ })).not.toBeInTheDocument();
+  });
+
+  it('resets pagination to first page when switching tabs or categories', () => {
+    render(<TeamNews groups={groups} pageSize={2} />);
+    fireEvent.click(screen.getByRole('button', { name: /Load 2 more/ }));
+    expect(screen.getByText(/Showing 4 of 5/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /AI & Robotics/ }));
+    expect(screen.getByText(/Showing 2 of 3/)).toBeInTheDocument();
+    // AI & Robotics has 1 Launch item — chip label is "Launch 1"
+    fireEvent.click(screen.getByRole('button', { name: /^Launch\b/ }));
+    expect(screen.queryByRole('button', { name: /Load/ })).not.toBeInTheDocument();
+  });
+
+  it('renders the per-filter empty state when the active focus area has no items', () => {
+    // A group can come back with items: [] in defensive scenarios; switching to it should render the per-filter empty state.
+    const mixed: ITeamNewsGroup[] = [
+      { focusArea: FA_AI, total: 0, items: [] },
+      { focusArea: FA_DHR, total: 1, items: [makeItem('dhr-only', 'MILESTONE', ['Digital Human Rights'])] },
+    ];
+    render(<TeamNews groups={mixed} />);
+    fireEvent.click(screen.getByRole('tab', { name: /AI & Robotics/ }));
+    expect(screen.getByText(/No network news in this filter/i)).toBeInTheDocument();
+  });
+
+  it('reports analytics when a card is clicked', () => {
+    render(<TeamNews groups={groups} />);
+    const card = screen.getByText(/Headline ai-1/).closest('a');
+    expect(card).toHaveAttribute('href', 'https://example.com/ai-1');
+    expect(card).toHaveAttribute('target', '_blank');
+    expect(card).toHaveAttribute('rel', 'noopener noreferrer');
+    fireEvent.click(within(card!).getByText(/Headline ai-1/));
+    expect(mockOnCardClicked).toHaveBeenCalledTimes(1);
+    const [item, position] = mockOnCardClicked.mock.calls[0];
+    expect(item.uid).toBe('ai-1');
+    expect(typeof position).toBe('number');
+  });
+});

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -138,6 +138,16 @@ describe('TeamNews', () => {
     expect(screen.getByText(/No network news in this filter/i)).toBeInTheDocument();
   });
 
+  it('shows g.total in tab badge, not items.length', () => {
+    const groupsWithLargerTotal: ITeamNewsGroup[] = [
+      { focusArea: FA_AI, total: 99, items: aiItems },
+      { focusArea: FA_DHR, total: dhrItems.length, items: dhrItems },
+    ];
+    render(<TeamNews groups={groupsWithLargerTotal} />);
+    const aiTab = screen.getByRole('tab', { name: /AI & Robotics/ });
+    expect(within(aiTab).getByText('99')).toBeInTheDocument();
+  });
+
   it('reports analytics when a card is clicked', () => {
     render(<TeamNews groups={groups} />);
     const card = screen.getByText(/Headline ai-1/).closest('a');

--- a/__tests__/page/home/welcome.test.tsx
+++ b/__tests__/page/home/welcome.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { Welcome } from '@/components/page/home/Welcome/Welcome';
+
+const mockOnLoginBtnClicked = jest.fn();
+
+jest.mock('@/components/core/navbar/login-btn', () => {
+  return {
+    __esModule: true,
+    default: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+      <button type="button" className={className} onClick={() => mockOnLoginBtnClicked()}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+describe('Welcome', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the brand title and "Welcome to" eyebrow', () => {
+    render(<Welcome firstName={null} isLoggedIn={false} />);
+    expect(screen.getByText('Welcome to')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'LabOS' })).toBeInTheDocument();
+  });
+
+  describe('unauth state', () => {
+    it('renders the unauth pitch and shows the Sign in button', () => {
+      render(<Welcome firstName={null} isLoggedIn={false} />);
+      expect(
+        screen.getByText(/collaboration platform for the Protocol Labs network/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Connect, book office hours, and join IRL Gatherings/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Sign in/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('auth state', () => {
+    it('greets the user by first name and hides the Sign in CTA', () => {
+      render(<Welcome firstName="Aboud" isLoggedIn={true} />);
+      expect(
+        screen.getByText(/Hi Aboud — here's what's new across the Protocol Labs Network today\./),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Sign in/i })).not.toBeInTheDocument();
+    });
+
+    it('falls back to "Welcome back" when the first name is missing', () => {
+      render(<Welcome firstName={null} isLoggedIn={true} />);
+      expect(screen.getByText(/Hi Welcome back — here's what's new/)).toBeInTheDocument();
+    });
+
+    it('trims the first name before using it', () => {
+      render(<Welcome firstName="   Aboud   " isLoggedIn={true} />);
+      expect(screen.getByText(/Hi Aboud —/)).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/page/home/welcome.test.tsx
+++ b/__tests__/page/home/welcome.test.tsx
@@ -27,6 +27,13 @@ describe('Welcome', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'LabOS' })).toBeInTheDocument();
   });
 
+  it('always renders an <h1> regardless of auth state', () => {
+    const { rerender } = render(<Welcome firstName={null} isLoggedIn={false} />);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    rerender(<Welcome firstName="Alice" isLoggedIn={true} />);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
   describe('unauth state', () => {
     it('renders the unauth pitch and shows the Sign in button', () => {
       render(<Welcome firstName={null} isLoggedIn={false} />);

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -1,0 +1,67 @@
+import { TEAM_NEWS_ANALYTICS_EVENTS } from '@/utils/constants';
+import { useCurrentUserStore } from '@/services/auth/store';
+import { usePostHog } from 'posthog-js/react';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+export const useTeamNewsAnalytics = () => {
+  const postHogProps = usePostHog();
+
+  const captureEvent = (eventName: string, eventParams: Record<string, unknown> = {}) => {
+    try {
+      if (postHogProps?.capture) {
+        const userInfo = useCurrentUserStore.getState().currentUser;
+        postHogProps.capture(eventName, {
+          ...eventParams,
+          loggedInUserUid: userInfo?.uid,
+          loggedInUserEmail: userInfo?.email,
+          loggedInUserName: userInfo?.name,
+        });
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onTeamNewsTabClicked = (tab: string, itemCount: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_TAB_CLICKED, {
+      tab,
+      itemCount,
+    });
+  };
+
+  const onTeamNewsCategoryClicked = (category: string, itemCount: number, currentTab: string) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_CATEGORY_CLICKED, {
+      category,
+      itemCount,
+      currentTab,
+    });
+  };
+
+  const onTeamNewsLoadMoreClicked = (currentlyShown: number, total: number, currentTab: string, currentCategory: string) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_LOAD_MORE_CLICKED, {
+      currentlyShown,
+      total,
+      currentTab,
+      currentCategory,
+    });
+  };
+
+  const onTeamNewsCardClicked = (item: ITeamNewsItem, position: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_CARD_CLICKED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      teamName: item.teamName,
+      eventType: item.eventType,
+      sourceDomain: item.sourceDomain,
+      sourceUrl: item.sourceUrl,
+      position,
+    });
+  };
+
+  return {
+    onTeamNewsTabClicked,
+    onTeamNewsCategoryClicked,
+    onTeamNewsLoadMoreClicked,
+    onTeamNewsCardClicked,
+  };
+};

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -34,11 +34,9 @@ export default async function Home() {
     <>
       <div className={styles.home}>
         <div className={styles.home__cn}>
-          {!isLoggedIn && (
-            <div className={styles.home__cn__welcome}>
-              <Welcome firstName={firstName} isLoggedIn={isLoggedIn} />
-            </div>
-          )}
+          <div className={styles.home__cn__welcome}>
+            <Welcome firstName={firstName} isLoggedIn={isLoggedIn} />
+          </div>
           <div className={styles.home__cn__teamnews}>
             <TeamNews groups={teamNewsGroups} />
           </div>
@@ -75,6 +73,7 @@ const getPageData = async () => {
         getDiscoverData(),
         getTeamNewsGroupedByFocusArea(),
       ]);
+    teamNewsGroups = teamNewsResponse?.groups ?? [];
     if (
       teamFocusAreaResponse?.error ||
       projectFocusAreaResponse?.error ||
@@ -102,7 +101,6 @@ const getPageData = async () => {
       : [];
     featuredData = formatFeaturedData(featuredResponse?.data);
     discoverData = discoverResponse?.data;
-    teamNewsGroups = teamNewsResponse?.groups ?? [];
     return {
       isError,
       userInfo,

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -16,34 +16,38 @@ import { getFeaturedData } from '@/services/featured.service';
 import { formatFeaturedData } from '@/utils/home.utils';
 import { RecentUpdatesSection } from '@/components/page/home/recent-updates';
 import { isAdminUser } from '@/utils/user/isAdminUser';
+import { Welcome } from '@/components/page/home/Welcome';
+import { TeamNews } from '@/components/page/home/TeamNews';
+import { getTeamNewsGroupedByFocusArea } from '@/services/team-news/team-news.service';
+import type { ITeamNewsGroup } from '@/types/team-news.types';
 
 export default async function Home() {
-  const { isLoggedIn, isError, userInfo, focusAreas } = await getPageData();
+  const { isLoggedIn, isError, userInfo, focusAreas, teamNewsGroups } = await getPageData();
 
   if (isError) {
     return <Error />;
   }
 
+  const firstName = typeof userInfo?.name === 'string' ? userInfo.name.split(' ')[0] : null;
+
   return (
     <>
       <div className={styles.home}>
         <div className={styles.home__cn}>
-          {/* Focus Area section */}
+          {!isLoggedIn && (
+            <div className={styles.home__cn__welcome}>
+              <Welcome firstName={firstName} isLoggedIn={isLoggedIn} />
+            </div>
+          )}
+          <div className={styles.home__cn__teamnews}>
+            <TeamNews groups={teamNewsGroups} />
+          </div>
           <div className={styles.home__cn__focusarea}>
             <FocusAreaSection focusAreas={focusAreas} userInfo={userInfo} />
           </div>
-          {/* Recent Updates section */}
           <div className={styles.home__cn__recentupdates}>
             <RecentUpdatesSection />
           </div>
-          {/* Discover section */}
-          {/*<div className={styles.home__cn__discover}>*/}
-          {/*  <Discover discoverData={discoverData} userInfo={userInfo} />*/}
-          {/*</div>*/}
-          {/* Featured section */}
-          {/*<div className={styles.home__cn__featured}>*/}
-          {/*  <Featured featuredData={featuredData} isLoggedIn={isLoggedIn} userInfo={userInfo} />*/}
-          {/*</div>*/}
           <ScrollToTop pageName="Home" userInfo={userInfo} />
         </div>
       </div>
@@ -60,14 +64,17 @@ const getPageData = async () => {
   let discoverData = [] as any;
   let teamFocusAreas: IFocusArea[] = [];
   let projectFocusAreas: IFocusArea[] = [];
+  let teamNewsGroups: ITeamNewsGroup[] = [];
 
   try {
-    const [teamFocusAreaResponse, projectFocusAreaResponse, featuredResponse, discoverResponse] = await Promise.all([
-      getFocusAreas('Team', {}),
-      getFocusAreas('Project', {}),
-      getFeaturedData(authToken, isLoggedIn, isAdminUser(userInfo)),
-      getDiscoverData(),
-    ]);
+    const [teamFocusAreaResponse, projectFocusAreaResponse, featuredResponse, discoverResponse, teamNewsResponse] =
+      await Promise.all([
+        getFocusAreas('Team', {}),
+        getFocusAreas('Project', {}),
+        getFeaturedData(authToken, isLoggedIn, isAdminUser(userInfo)),
+        getDiscoverData(),
+        getTeamNewsGroupedByFocusArea(),
+      ]);
     if (
       teamFocusAreaResponse?.error ||
       projectFocusAreaResponse?.error ||
@@ -84,6 +91,7 @@ const getPageData = async () => {
         },
         discoverData,
         featuredData,
+        teamNewsGroups,
       };
     }
     teamFocusAreas = Array.isArray(teamFocusAreaResponse?.data)
@@ -94,6 +102,7 @@ const getPageData = async () => {
       : [];
     featuredData = formatFeaturedData(featuredResponse?.data);
     discoverData = discoverResponse?.data;
+    teamNewsGroups = teamNewsResponse?.groups ?? [];
     return {
       isError,
       userInfo,
@@ -104,6 +113,7 @@ const getPageData = async () => {
       },
       featuredData,
       discoverData,
+      teamNewsGroups,
     };
   } catch (error) {
     console.error(error);
@@ -118,6 +128,7 @@ const getPageData = async () => {
       },
       featuredData,
       discoverData,
+      teamNewsGroups,
     };
   }
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { PAGE_ROUTES, SOCIAL_IMAGE_URL } from '@/utils/constants';
 
 async function LandingPage() {
-  redirect(PAGE_ROUTES.MEMBERS);
+  redirect(PAGE_ROUTES.HOME);
 }
 
 export default LandingPage;

--- a/components/page/home/TeamNews/TeamNews.module.scss
+++ b/components/page/home/TeamNews/TeamNews.module.scss
@@ -1,0 +1,228 @@
+@import 'styles/media.scss';
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  scroll-margin-top: 180px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 32px;
+  letter-spacing: -0.5px;
+  color: #0a0c11;
+  margin: 0;
+
+  @media (min-width: 1024px) {
+    font-size: 32px;
+    line-height: 42px;
+    letter-spacing: -0.75px;
+  }
+}
+
+.unreadBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  background: rgba(27, 77, 255, 0.06);
+  border: 1px solid #aebfff;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #1b4dff;
+  letter-spacing: -0.1px;
+}
+
+.sub {
+  font-size: 14px;
+  line-height: 20px;
+  color: #455468;
+  margin: -8px 0 0;
+  max-width: 720px;
+}
+
+.tabsRow {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  border-bottom: 1px solid rgba(27, 56, 96, 0.08);
+  padding: 4px 0 0;
+  margin: 4px 0 0;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  margin-bottom: -1px;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: #64748b;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    color: #0a0c11;
+  }
+}
+
+.tabActive {
+  color: #1b4dff;
+  border-bottom-color: #1b4dff;
+
+  &:hover {
+    color: #1b4dff;
+  }
+}
+
+.tabCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 9999px;
+  background: rgba(27, 56, 96, 0.06);
+  font-size: 11px;
+  font-weight: 500;
+  color: #455468;
+  letter-spacing: 0;
+}
+
+.tabActive .tabCount {
+  background: rgba(27, 77, 255, 0.12);
+  color: #1b4dff;
+}
+
+.catRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.cat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: #ffffff;
+  border: 1px solid rgba(27, 56, 96, 0.16);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  color: #455468;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.12s ease, background 0.12s ease, color 0.12s ease;
+
+  &:hover:not(:disabled) {
+    border-color: rgba(27, 56, 96, 0.32);
+    color: #0a0c11;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.catActive {
+  background: #1b4dff;
+  border-color: #1b4dff;
+  color: #ffffff;
+
+  &:hover:not(:disabled) {
+    color: #ffffff;
+    border-color: #1b4dff;
+  }
+}
+
+.catCount {
+  font-size: 11px;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.catActive .catCount {
+  color: #ffffff;
+  opacity: 0.9;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+
+  @media (min-width: 768px) {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+}
+
+.empty {
+  padding: 32px 0;
+  text-align: center;
+  font-size: 14px;
+  color: #64748b;
+}
+
+.loadMoreRow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.loadMore {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 16px;
+  background: #ffffff;
+  border: 1px solid rgba(27, 56, 96, 0.16);
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  color: #0a0c11;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease;
+
+  &:hover {
+    border-color: rgba(27, 56, 96, 0.32);
+    background: #fafbfc;
+  }
+}
+
+.loadCount {
+  font-size: 12px;
+  color: #94a3b8;
+  letter-spacing: -0.1px;
+}

--- a/components/page/home/TeamNews/TeamNews.module.scss
+++ b/components/page/home/TeamNews/TeamNews.module.scss
@@ -22,7 +22,7 @@
   color: #0a0c11;
   margin: 0;
 
-  @media (min-width: 1024px) {
+  @include breakpoint-1024 {
     font-size: 32px;
     line-height: 42px;
     letter-spacing: -0.75px;
@@ -178,7 +178,7 @@
   grid-template-columns: 1fr;
   gap: 12px;
 
-  @media (min-width: 768px) {
+  @include tablet-portrait {
     grid-template-columns: 1fr 1fr;
     gap: 16px;
   }

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -51,7 +51,7 @@ export const TeamNews = ({ groups, pageSize = 6 }: TeamNewsProps) => {
       { id: ALL_TAB, label: 'All', count: allItems.length },
     ];
     for (const g of groups) {
-      tabs.push({ id: g.focusArea.title, label: g.focusArea.title, count: g.items.length });
+      tabs.push({ id: g.focusArea.title, label: g.focusArea.title, count: g.total });
     }
     return tabs;
   }, [groups, allItems]);

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { NewsCard } from './components/NewsCard';
+import type {
+  ITeamNewsGroup,
+  ITeamNewsItem,
+  TeamNewsEventType,
+} from '@/types/team-news.types';
+import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import styles from './TeamNews.module.scss';
+
+interface TeamNewsProps {
+  groups: ITeamNewsGroup[];
+  pageSize?: number;
+}
+
+const ALL_TAB = 'All';
+const ALL_CAT = 'all';
+
+const CATEGORIES: Array<{ id: TeamNewsEventType | typeof ALL_CAT; label: string }> = [
+  { id: ALL_CAT, label: 'All categories' },
+  { id: 'FUNDING', label: 'Funding' },
+  { id: 'LAUNCH', label: 'Launch' },
+  { id: 'PARTNERSHIP', label: 'Partnership' },
+  { id: 'MILESTONE', label: 'Milestone' },
+  { id: 'ANNOUNCEMENT', label: 'Announcement' },
+];
+
+const dedupeByUid = (items: ITeamNewsItem[]): ITeamNewsItem[] => {
+  const seen = new Set<string>();
+  const out: ITeamNewsItem[] = [];
+  for (const item of items) {
+    if (seen.has(item.uid)) continue;
+    seen.add(item.uid);
+    out.push(item);
+  }
+  return out;
+};
+
+export const TeamNews = ({ groups, pageSize = 6 }: TeamNewsProps) => {
+  const [activeTab, setActiveTab] = useState<string>(ALL_TAB);
+  const [activeCategory, setActiveCategory] = useState<TeamNewsEventType | typeof ALL_CAT>(ALL_CAT);
+  const [page, setPage] = useState<number>(1);
+  const analytics = useTeamNewsAnalytics();
+
+  const allItems = useMemo(() => dedupeByUid(groups.flatMap((g) => g.items)), [groups]);
+
+  const tabsWithCounts = useMemo(() => {
+    const tabs: Array<{ id: string; label: string; count: number }> = [
+      { id: ALL_TAB, label: 'All', count: allItems.length },
+    ];
+    for (const g of groups) {
+      tabs.push({ id: g.focusArea.title, label: g.focusArea.title, count: g.items.length });
+    }
+    return tabs;
+  }, [groups, allItems]);
+
+  const itemsForActiveTab = useMemo(() => {
+    if (activeTab === ALL_TAB) return allItems;
+    const group = groups.find((g) => g.focusArea.title === activeTab);
+    return group?.items ?? [];
+  }, [activeTab, allItems, groups]);
+
+  const categoriesWithCounts = useMemo(() => {
+    return CATEGORIES.map((c) => ({
+      ...c,
+      count:
+        c.id === ALL_CAT
+          ? itemsForActiveTab.length
+          : itemsForActiveTab.filter((i) => i.eventType === c.id).length,
+    }));
+  }, [itemsForActiveTab]);
+
+  const filteredItems = useMemo(() => {
+    if (activeCategory === ALL_CAT) return itemsForActiveTab;
+    return itemsForActiveTab.filter((i) => i.eventType === activeCategory);
+  }, [activeCategory, itemsForActiveTab]);
+
+  const visibleItems = filteredItems.slice(0, page * pageSize);
+  const hasMore = visibleItems.length < filteredItems.length;
+  const newCount = allItems.length;
+
+  const handleTab = (id: string) => {
+    const nextItems = id === ALL_TAB ? allItems : groups.find((g) => g.focusArea.title === id)?.items ?? [];
+    analytics.onTeamNewsTabClicked(id, nextItems.length);
+    setActiveTab(id);
+    setActiveCategory(ALL_CAT);
+    setPage(1);
+  };
+
+  const handleCategory = (id: TeamNewsEventType | typeof ALL_CAT) => {
+    const nextCount =
+      id === ALL_CAT ? itemsForActiveTab.length : itemsForActiveTab.filter((i) => i.eventType === id).length;
+    analytics.onTeamNewsCategoryClicked(String(id), nextCount, activeTab);
+    setActiveCategory(id);
+    setPage(1);
+  };
+
+  const handleLoadMore = () => {
+    analytics.onTeamNewsLoadMoreClicked(visibleItems.length, filteredItems.length, activeTab, String(activeCategory));
+    setPage((p) => p + 1);
+  };
+
+  const handleCardClick = (item: ITeamNewsItem) => {
+    const position = visibleItems.findIndex((v) => v.uid === item.uid);
+    analytics.onTeamNewsCardClicked(item, position >= 0 ? position : 0);
+  };
+
+  if (allItems.length === 0) {
+    return (
+      <section className={styles.section}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>News from the network</h2>
+        </div>
+        <p className={styles.sub}>Recent shipping, raises, partnerships, and milestones from across the network.</p>
+        <div className={styles.empty}>No network news in the last 14 days yet. Check back soon.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>News from the network</h2>
+        {newCount > 0 && <span className={styles.unreadBadge}>{newCount} new</span>}
+      </div>
+      <p className={styles.sub}>Recent shipping, raises, partnerships, and milestones from across the network.</p>
+
+      <div className={styles.tabsRow} role="tablist" aria-label="Filter team news by focus area">
+        {tabsWithCounts.map((t) => {
+          const isActive = activeTab === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ''}`}
+              onClick={() => handleTab(t.id)}
+            >
+              {t.label}
+              {t.count > 0 && <span className={styles.tabCount}>{t.count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.catRow}>
+        {categoriesWithCounts.map((c) => {
+          const isActive = activeCategory === c.id;
+          const isDisabled = c.count === 0 && c.id !== ALL_CAT;
+          return (
+            <button
+              key={c.id}
+              type="button"
+              className={`${styles.cat} ${isActive ? styles.catActive : ''}`}
+              onClick={() => handleCategory(c.id)}
+              disabled={isDisabled}
+            >
+              {c.label}
+              {c.count > 0 && <span className={styles.catCount}>{c.count}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {filteredItems.length === 0 ? (
+        <div className={styles.empty}>No network news in this filter.</div>
+      ) : (
+        <>
+          <div className={styles.grid}>
+            {visibleItems.map((item) => (
+              <NewsCard key={item.uid} item={item} onClick={handleCardClick} />
+            ))}
+          </div>
+          {hasMore && (
+            <div className={styles.loadMoreRow}>
+              <button type="button" className={styles.loadMore} onClick={handleLoadMore}>
+                Load {Math.min(pageSize, filteredItems.length - visibleItems.length)} more
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </button>
+              <span className={styles.loadCount}>
+                Showing {visibleItems.length} of {filteredItems.length}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+};

--- a/components/page/home/TeamNews/components/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard.module.scss
@@ -96,7 +96,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 
-  @media (min-width: 1024px) {
+  @include breakpoint-1024 {
     font-size: 16px;
     line-height: 22px;
   }

--- a/components/page/home/TeamNews/components/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard.module.scss
@@ -1,0 +1,170 @@
+@import 'styles/media.scss';
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid rgba(27, 56, 96, 0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+
+  &:hover {
+    border-color: rgba(27, 56, 96, 0.18);
+    box-shadow: 0px 1px 4px 0px rgba(14, 15, 17, 0.06);
+    text-decoration: none;
+    color: inherit;
+  }
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.logo,
+.logoFallback {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.logoFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1b4dff;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+}
+
+.headText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.teamName {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0a0c11;
+  letter-spacing: -0.1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metaLine {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #64748b;
+  letter-spacing: -0.1px;
+  min-width: 0;
+}
+
+.dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+.headline {
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: #0a0c11;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  @media (min-width: 1024px) {
+    font-size: 16px;
+    line-height: 22px;
+  }
+}
+
+.summary {
+  font-size: 13px;
+  line-height: 19px;
+  color: #455468;
+  letter-spacing: -0.1px;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  border: 1px solid transparent;
+}
+
+.chipFunding {
+  background: #ecfdf3;
+  color: #027a48;
+  border-color: #abefc6;
+}
+
+.chipLaunch {
+  background: #eff4ff;
+  color: #1849a9;
+  border-color: #b2ccff;
+}
+
+.chipPartnership {
+  background: #f4f0ff;
+  color: #5925dc;
+  border-color: #d9c8ff;
+}
+
+.chipAnnouncement {
+  background: #f2f4f7;
+  color: #344054;
+  border-color: #d0d5dd;
+}
+
+.chipMilestone {
+  background: #fef6e7;
+  color: #b54708;
+  border-color: #fcd9a8;
+}
+
+.chipOther {
+  background: #f9fafb;
+  color: #475467;
+  border-color: #e4e7ec;
+}

--- a/components/page/home/TeamNews/components/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard.tsx
@@ -1,0 +1,76 @@
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import type { ITeamNewsItem, TeamNewsEventType } from '@/types/team-news.types';
+import styles from './NewsCard.module.scss';
+
+interface NewsCardProps {
+  item: ITeamNewsItem;
+  onClick?: (item: ITeamNewsItem) => void;
+}
+
+const EVENT_TYPE_LABEL: Record<TeamNewsEventType, string> = {
+  FUNDING: 'Funding',
+  LAUNCH: 'Launch',
+  PARTNERSHIP: 'Partnership',
+  ANNOUNCEMENT: 'Announcement',
+  MILESTONE: 'Milestone',
+  OTHER: 'Other',
+};
+
+const EVENT_TYPE_CLASS: Record<TeamNewsEventType, string> = {
+  FUNDING: styles.chipFunding,
+  LAUNCH: styles.chipLaunch,
+  PARTNERSHIP: styles.chipPartnership,
+  ANNOUNCEMENT: styles.chipAnnouncement,
+  MILESTONE: styles.chipMilestone,
+  OTHER: styles.chipOther,
+};
+
+const teamLogoFallback = (name: string) =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s[0])
+    .join('')
+    .toUpperCase() || '?';
+
+export const NewsCard = ({ item, onClick }: NewsCardProps) => {
+  const handleClick = () => onClick?.(item);
+
+  return (
+    <a
+      href={item.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.card}
+      onClick={handleClick}
+    >
+      <div className={styles.head}>
+        {item.teamLogoUrl ? (
+          <img className={styles.logo} src={item.teamLogoUrl} alt="" loading="lazy" />
+        ) : (
+          <div className={styles.logoFallback}>{teamLogoFallback(item.teamName)}</div>
+        )}
+        <div className={styles.headText}>
+          <div className={styles.teamName}>{item.teamName}</div>
+          <div className={styles.metaLine}>
+            {item.sourceDomain && (
+              <>
+                <span>{item.sourceDomain}</span>
+                <span className={styles.dot} aria-hidden="true" />
+              </>
+            )}
+            <span>{formatTimeAgo(item.eventDate)}</span>
+          </div>
+        </div>
+      </div>
+      <h3 className={styles.headline}>{item.title}</h3>
+      {item.summary && <p className={styles.summary}>{item.summary}</p>}
+      <div className={styles.foot}>
+        <span className={`${styles.chip} ${EVENT_TYPE_CLASS[item.eventType]}`}>
+          {EVENT_TYPE_LABEL[item.eventType]}
+        </span>
+      </div>
+    </a>
+  );
+};

--- a/components/page/home/TeamNews/index.ts
+++ b/components/page/home/TeamNews/index.ts
@@ -1,0 +1,1 @@
+export { TeamNews } from './TeamNews';

--- a/components/page/home/Welcome/Welcome.module.scss
+++ b/components/page/home/Welcome/Welcome.module.scss
@@ -38,7 +38,7 @@
   color: #0a0c11;
   margin: 0;
 
-  @media (min-width: 1024px) {
+  @include breakpoint-1024 {
     font-size: 28px;
     line-height: 36px;
     letter-spacing: -0.6px;
@@ -60,7 +60,7 @@
   flex-wrap: wrap;
   justify-content: flex-end;
 
-  @media (max-width: 639px) {
+  @include mobile-only {
     width: 100%;
     justify-content: flex-start;
   }
@@ -74,7 +74,7 @@
   text-align: right;
   max-width: 220px;
 
-  @media (max-width: 639px) {
+  @include mobile-only {
     text-align: left;
     max-width: none;
   }
@@ -85,6 +85,7 @@
   align-items: center;
   gap: 6px;
   height: 38px;
+  line-height: 1;
   padding: 0 18px;
   border-radius: 9999px;
   background: #1b4dff;
@@ -105,7 +106,7 @@
     text-decoration: none;
   }
 
-  @media (max-width: 639px) {
+  @include mobile-only {
     width: 100%;
     justify-content: center;
   }

--- a/components/page/home/Welcome/Welcome.module.scss
+++ b/components/page/home/Welcome/Welcome.module.scss
@@ -1,0 +1,112 @@
+@import 'styles/media.scss';
+
+.welcome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 24px;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid rgba(27, 56, 96, 0.06);
+  box-shadow: 0px 1px 2px 0px rgba(14, 15, 17, 0.06);
+  flex-wrap: wrap;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #4174ff;
+  line-height: 16px;
+}
+
+.title {
+  font-size: 24px;
+  line-height: 30px;
+  font-weight: 600;
+  letter-spacing: -0.5px;
+  color: #0a0c11;
+  margin: 0;
+
+  @media (min-width: 1024px) {
+    font-size: 28px;
+    line-height: 36px;
+    letter-spacing: -0.6px;
+  }
+}
+
+.sub {
+  font-size: 13px;
+  line-height: 18px;
+  color: #455468;
+  margin: 2px 0 0;
+  max-width: 720px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  @media (max-width: 639px) {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+.pitch {
+  font-size: 13px;
+  line-height: 18px;
+  color: #455468;
+  letter-spacing: -0.1px;
+  text-align: right;
+  max-width: 220px;
+
+  @media (max-width: 639px) {
+    text-align: left;
+    max-width: none;
+  }
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 38px;
+  padding: 0 18px;
+  border-radius: 9999px;
+  background: #1b4dff;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  border: 0;
+  cursor: pointer;
+  box-shadow: 0px 1px 2px 0px rgba(14, 15, 17, 0.1);
+  white-space: nowrap;
+  text-decoration: none;
+  transition: background 0.12s ease;
+
+  &:hover {
+    background: #1158c4;
+    color: #ffffff;
+    text-decoration: none;
+  }
+
+  @media (max-width: 639px) {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/components/page/home/Welcome/Welcome.tsx
+++ b/components/page/home/Welcome/Welcome.tsx
@@ -1,0 +1,35 @@
+import LoginBtn from '@/components/core/navbar/login-btn';
+import styles from './Welcome.module.scss';
+
+interface WelcomeProps {
+  firstName?: string | null;
+  isLoggedIn: boolean;
+}
+
+export const Welcome = ({ firstName, isLoggedIn }: WelcomeProps) => {
+  const greeting = firstName?.trim() || 'Welcome back';
+  const authSub = isLoggedIn
+    ? `Hi ${greeting} — here's what's new across the Protocol Labs Network today.`
+    : 'The collaboration platform for the Protocol Labs network. Connect with 3,000+ members driving breakthroughs in computing to push humanity forward.';
+
+  return (
+    <section className={styles.welcome}>
+      <div className={styles.text}>
+        <div className={styles.eyebrow}>Welcome to</div>
+        <h1 className={styles.title}>LabOS</h1>
+        <p className={styles.sub}>{authSub}</p>
+      </div>
+      {!isLoggedIn && (
+        <div className={styles.actions}>
+          <div className={styles.pitch}>Connect, book office hours, and join IRL Gatherings.</div>
+          <LoginBtn className={styles.cta}>
+            Sign in
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </LoginBtn>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/components/page/home/Welcome/index.ts
+++ b/components/page/home/Welcome/index.ts
@@ -1,0 +1,1 @@
+export { Welcome } from './Welcome';

--- a/components/page/team-details/TeamsTagsListSection/TeamMembershipSource.tsx
+++ b/components/page/team-details/TeamsTagsListSection/TeamMembershipSource.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ITeam } from '@/types/teams.types';
-import { IUserInfo } from '@/types/shared.types';
 
 import { isAdminUser } from '@/utils/user/isAdminUser';
 

--- a/services/team-news/constants.ts
+++ b/services/team-news/constants.ts
@@ -1,0 +1,7 @@
+export enum TeamNewsQueryKeys {
+  GROUPED_BY_FOCUS_AREA = 'team-news-grouped-by-focus-area',
+  LIST = 'team-news-list',
+  FILTERS = 'team-news-filters',
+}
+
+export const TEAM_NEWS_DEFAULT_WINDOW_DAYS = 14;

--- a/services/team-news/team-news.service.ts
+++ b/services/team-news/team-news.service.ts
@@ -1,0 +1,26 @@
+import type { ITeamNewsGroupedResponse } from '@/types/team-news.types';
+import { TEAM_NEWS_DEFAULT_WINDOW_DAYS } from './constants';
+
+interface FetchGroupedOptions {
+  windowDays?: number;
+}
+
+export async function getTeamNewsGroupedByFocusArea(
+  options: FetchGroupedOptions = {},
+): Promise<ITeamNewsGroupedResponse | null> {
+  const windowDays = options.windowDays ?? TEAM_NEWS_DEFAULT_WINDOW_DAYS;
+  const url = `${process.env.DIRECTORY_API_URL}/v1/team-news/grouped-by-focus-area?windowDays=${windowDays}`;
+
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as ITeamNewsGroupedResponse;
+  } catch {
+    return null;
+  }
+}

--- a/services/team-news/team-news.service.ts
+++ b/services/team-news/team-news.service.ts
@@ -13,7 +13,7 @@ export async function getTeamNewsGroupedByFocusArea(
 
   try {
     const response = await fetch(url, {
-      cache: 'no-store',
+      next: { tags: ['team-news'], revalidate: 60 },
       headers: { 'Content-Type': 'application/json' },
     });
     if (!response.ok) {

--- a/types/team-news.types.ts
+++ b/types/team-news.types.ts
@@ -1,0 +1,53 @@
+export type TeamNewsEventType =
+  | 'FUNDING'
+  | 'LAUNCH'
+  | 'PARTNERSHIP'
+  | 'ANNOUNCEMENT'
+  | 'MILESTONE'
+  | 'OTHER';
+
+export interface ITeamNewsItem {
+  uid: string;
+  teamUid: string;
+  teamName: string;
+  teamLogoUrl: string | null;
+  eventType: TeamNewsEventType;
+  eventDate: string;
+  title: string;
+  summary: string | null;
+  sourceUrl: string;
+  sourceDomain: string | null;
+  tags: string[];
+  focusAreas: string[];
+  subFocusAreas: string[];
+  createdAt: string;
+}
+
+export interface ITeamNewsFocusArea {
+  uid: string;
+  title: string;
+}
+
+export interface ITeamNewsGroup {
+  focusArea: ITeamNewsFocusArea;
+  total: number;
+  items: ITeamNewsItem[];
+}
+
+export interface ITeamNewsGroupedResponse {
+  windowDays: number;
+  generatedAt: string;
+  groups: ITeamNewsGroup[];
+}
+
+export interface ITeamNewsListResponse {
+  page: number;
+  limit: number;
+  total: number;
+  items: ITeamNewsItem[];
+}
+
+export interface ITeamNewsFiltersResponse {
+  eventType: Array<{ value: string; count: number }>;
+  focus: Array<{ value: string; count: number }>;
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,5 +1,5 @@
 export const PAGE_ROUTES = {
-  HOME: '/',
+  HOME: '/home',
   MEMBERS: '/members',
   TEAMS: '/teams',
   SETTINGS: '/settings',
@@ -568,6 +568,13 @@ export const HOME_ANALYTICS_EVENTS = {
   DISCOVER_CARD_CLICKED: 'discover-card-clicked',
   DISCOVER_HUSKY_AI_CLICKED: 'discover-husky-ai-clicked',
   FEATURED_FILTER_CLICKED: 'home_featured_filter_click',
+};
+
+export const TEAM_NEWS_ANALYTICS_EVENTS = {
+  TEAM_NEWS_TAB_CLICKED: 'team-news-tab-clicked',
+  TEAM_NEWS_CATEGORY_CLICKED: 'team-news-category-clicked',
+  TEAM_NEWS_LOAD_MORE_CLICKED: 'team-news-load-more-clicked',
+  TEAM_NEWS_CARD_CLICKED: 'team-news-card-clicked',
 };
 
 export const EVENTS_ANALYTICS = {


### PR DESCRIPTION
## Summary

- New `/home` composition: **Welcome** (unauth only) → **News from the network** → Focus Areas → Recent Updates
- Root `/` now redirects to `/home` instead of `/members`
- News feed reads the directory backend's `GET /v1/team-news/grouped-by-focus-area` (already shipped on `develop`) and renders focus-area tabs + category chips + a 2-up card grid + Load-more pagination, all client-side over a single server fetch

## What changed

- **Welcome bar (`components/page/home/Welcome/`)** — compact bar shown only to unauthed visitors. Eyebrow "Welcome to" + LabOS title + sub copy; auth users land directly on the news feed (component is omitted, not just hidden). Sign-in CTA reuses the shared `LoginBtn` so it opens the existing Privy login modal.
- **News from the network (`components/page/home/TeamNews/`)** — section title with `{N} new` badge, focus-area tab strip with per-tab counts, category chip row (Funding / Launch / Partnership / Milestone / Announcement) with disabled state for 0-count chips, 2-up card grid (1-up on mobile), "Load N more" + "Showing X of Y" pagination, two empty states (global + per-filter). Items are deduped by `uid` for the All tab.
- **Service + types (`services/team-news/`, `types/team-news.types.ts`)** — small server-side wrapper around the directory endpoint with `cache: 'no-store'`, plus typed contract ported verbatim from `Specs and PRDs/Homepage/TEAM_NEWS_FRONTEND.md`.
- **Analytics (`analytics/team-news.analytics.ts`)** — four PostHog events (`team-news-tab-clicked`, `team-news-category-clicked`, `team-news-load-more-clicked`, `team-news-card-clicked`) plus the existing `auth.login-btn-clicked` from `LoginBtn`.
- **Routing (`app/page.tsx`, `utils/constants.ts`)** — root redirect target swapped to `PAGE_ROUTES.HOME`, which is now `/home` (was `/`).
- **Tests (`__tests__/page/home/`)** — 14 specs across Welcome (auth/unauth render, name greeting + trim, fallback, hidden CTA on auth) and TeamNews (global empty, populated render, tab switch, category filter, disabled chips, pagination, page reset on tab/category change, per-filter empty, card click analytics). All passing.

Out of scope for v0: client search, sub-focus-area filtering, non-team news (Builders / Cofunders / etc.), additional card variants, score-based "Top" sort. Tracked in `Specs and PRDs/Homepage/home_news_feed_v0_prd.html`.

## Test plan

- [ ] `npx jest __tests__/page/home/welcome.test.tsx __tests__/page/home/team-news.test.tsx` — 14/14 pass locally
- [ ] Visit `/` signed out and signed in — redirects to `/home` in both cases
- [ ] Visit `/home` signed out — Welcome bar visible above the news feed; News from the network populated; Focus Areas + Recent Updates render below; Recent Updates shows the sign-in pitch state
- [ ] Visit `/home` signed in — Welcome bar omitted (no whitespace); News from the network identical; Recent Updates shows the auth notification list (or its empty state)
- [ ] News feed: switch focus-area tabs (counts update, page resets, category resets), switch category chips (counts update, page resets, tab preserved), Load more (counter advances, button hides at end), per-filter empty state when an FA tab has zero items
- [ ] Click a news card — opens the source URL in a new tab with `rel="noopener noreferrer"`
- [ ] Welcome Sign-in button — opens the Privy login modal (same as the navbar)
- [ ] Mobile (<640 px): Welcome wraps stacked, news grid collapses to one column, tab strip horizontally scrolls, chip row wraps
- [ ] PostHog events fire on tab / category / Load-more / card click with the expected properties