### PR TITLE
feat(filter-rail): add clear button to search input

### DIFF
--- a/components/page/investors/InvestorsFilterRail/InvestorsFilterRail.module.scss
+++ b/components/page/investors/InvestorsFilterRail/InvestorsFilterRail.module.scss
@@ -19,6 +19,26 @@
   display: flex;
 }
 
+.inputIconBtn {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  color: #9ca3af;
+  padding: 0 2px;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: #374151;
+  }
+}
+
 .input {
   width: 100%;
   padding: 6px 30px 6px 10px;
@@ -32,6 +52,10 @@
   &:focus {
     border-color: #1b4dff;
     box-shadow: 0 0 0 3px rgba(27, 77, 255, 0.12);
+  }
+
+  &::-webkit-search-cancel-button {
+    display: none;
   }
 }
 

--- a/components/page/investors/InvestorsFilterRail/InvestorsFilterRail.tsx
+++ b/components/page/investors/InvestorsFilterRail/InvestorsFilterRail.tsx
@@ -62,11 +62,21 @@ function CheckboxOptions<T extends string>({
 }
 
 function SearchInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const hasValue = !!props.value;
+  const clearInput = () => {
+    props.onChange?.({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>);
+  };
   return (
     <div className={s.inputWrap}>
-      <span className={s.inputIcon}>
-        <SearchIcon />
-      </span>
+      {hasValue ? (
+        <button type="button" className={s.inputIconBtn} onClick={clearInput} aria-label="Clear">
+          ×
+        </button>
+      ) : (
+        <span className={s.inputIcon}>
+          <SearchIcon />
+        </span>
+      )}
       <input {...props} className={s.input} />
     </div>
   );


### PR DESCRIPTION
- Introduced a clear (×) button for the search input field when it has a value.
- Updated styles for the clear button and suppressed the default search cancel button.