### PR TITLE
feat(team-news): add auto-mark notifications and refine NewsCard links

### DIFF
--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -167,11 +167,9 @@ describe('TeamNews', () => {
 
   it('reports analytics when a card is clicked', () => {
     render(<TeamNews groups={groups} />);
-    const card = screen.getByText(/Headline ai-1/).closest('a');
-    expect(card).toHaveAttribute('href', 'https://example.com/ai-1');
-    expect(card).toHaveAttribute('target', '_blank');
-    expect(card).toHaveAttribute('rel', 'noopener noreferrer');
-    fireEvent.click(within(card!).getByText(/Headline ai-1/));
+    const card = screen.getByText(/Headline ai-1/).closest('[role="link"]');
+    expect(card).toBeInTheDocument();
+    fireEvent.click(within(card! as HTMLElement).getByText(/Headline ai-1/));
     expect(mockOnCardClicked).toHaveBeenCalledTimes(1);
     const [item, position] = mockOnCardClicked.mock.calls[0];
     expect(item.uid).toBe('ai-1');

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -16,7 +16,7 @@ import { getFeaturedData } from '@/services/featured.service';
 import { formatFeaturedData } from '@/utils/home.utils';
 import { isAdminUser } from '@/utils/user/isAdminUser';
 import { Welcome } from '@/components/page/home/Welcome';
-import { NewsLoginRedirect, TeamNews } from '@/components/page/home/TeamNews';
+import { NewsLoginRedirect, TeamNews, AutoMarkNewsNotification } from '@/components/page/home/TeamNews';
 import { getTeamNewsGroupedByFocusArea } from '@/services/team-news/team-news.service';
 import type { ITeamNewsGroup } from '@/types/team-news.types';
 
@@ -48,6 +48,7 @@ export default async function Home() {
       <HuskyDialog isLoggedIn={isLoggedIn} />
       <HuskyDiscover isLoggedIn={isLoggedIn} />
       <NewsLoginRedirect />
+      <AutoMarkNewsNotification />
     </>
   );
 }

--- a/components/page/home/TeamNews/AutoMarkNewsNotification.tsx
+++ b/components/page/home/TeamNews/AutoMarkNewsNotification.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { usePushNotificationsContext } from '@/providers/PushNotificationsProvider';
+
+/**
+ * Marks any unread NEW_FEATURE notifications as read on mount.
+ * Only rendered on /home, so no URL comparison is needed.
+ */
+export function AutoMarkNewsNotification() {
+  const { notifications, markAsRead } = usePushNotificationsContext();
+  // Track UIDs we've already attempted so an API failure revert doesn't re-trigger.
+  const attemptedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const toMark = notifications.filter(
+      (n) => !n.isRead && n.category === 'NEW_FEATURE' && !attemptedRef.current.has(n.id),
+    );
+    if (toMark.length === 0) return;
+    toMark.forEach((n) => {
+      attemptedRef.current.add(n.id);
+      markAsRead(n.id);
+    });
+  }, [notifications, markAsRead]);
+
+  return null;
+}

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
@@ -12,6 +12,7 @@
   color: inherit;
   transition: box-shadow 0.12s ease;
   overflow: hidden;
+  cursor: pointer;
 
   &:hover {
     box-shadow: 0px 0px 1px 0px rgba(15, 23, 42, 0.16), 0px 6px 8px 0px rgba(15, 23, 42, 0.06);

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
@@ -33,10 +33,20 @@ const EVENT_TYPE_DOT_CLASS: Record<TeamNewsEventType, string> = {
 };
 
 export const NewsCard = ({ item, position = 0, onClick }: NewsCardProps) => {
-  const handleClick = () => onClick?.(item);
+  const handleClick = () => {
+    onClick?.(item);
+    window.open(item.sourceUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
 
   return (
-    <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer" className={s.card} onClick={handleClick}>
+    <div role="link" tabIndex={0} className={s.card} onClick={handleClick} onKeyDown={handleKeyDown}>
       <div className={s.head}>
         {item.teamLogoUrl ? (
           <img className={s.logo} src={item.teamLogoUrl} alt="" loading="lazy" />
@@ -69,6 +79,6 @@ export const NewsCard = ({ item, position = 0, onClick }: NewsCardProps) => {
         <span className={s.time}>{formatTimeAgo(item.eventDate)}</span>
         <StartConversationButton item={item} position={position} />
       </div>
-    </a>
+    </div>
   );
 };

--- a/components/page/home/TeamNews/index.ts
+++ b/components/page/home/TeamNews/index.ts
@@ -1,2 +1,3 @@
 export { TeamNews } from './TeamNews';
 export { NewsLoginRedirect } from './NewsLoginRedirect';
+export { AutoMarkNewsNotification } from './AutoMarkNewsNotification';

--- a/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
+++ b/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
@@ -82,6 +82,17 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
       await fetchUnreadLinks();
 
       const data = await getNotifications(authToken, { limit: 50 });
+
+      // Seed the map from the notification list itself.
+      // getUnreadLinks may omit public/broadcast notifications (e.g. NEW_FEATURE),
+      // so augmenting here ensures every unread notification with a link is auto-markable.
+      for (const n of data.notifications) {
+        const uid = n.uid ?? n.id;
+        if (!n.isRead && uid && n.link) {
+          addUnreadLinkEntry({ uid, link: n.link }, unreadLinksMapRef.current);
+        }
+      }
+
       setNotifications(
         data.notifications.map((n) =>
           sanitizeNotification({
@@ -239,6 +250,29 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
     wsMarkAsReadRef,
     onMarkedAsRead,
   });
+
+  // Direct scan: mark unread notifications as read when their link matches the current page.
+  // Covers broadcast/public notifications (e.g. NEW_FEATURE) that getUnreadLinks may omit.
+  useEffect(() => {
+    if (!authToken || !pathToCompareNotyLink) return;
+
+    const matching = notifications.filter(
+      (n) => !n.isRead && n.link && normalizeLink(n.link) === pathToCompareNotyLink,
+    );
+
+    if (matching.length === 0) return;
+
+    const uids = matching.map((n) => n.id);
+    onMarkedAsRead(uids);
+
+    uids.forEach((uid) => {
+      markNotificationAsRead(authToken, uid).catch((err) =>
+        console.error('[auto-mark] Failed to mark notification as read:', err),
+      );
+      wsMarkAsReadRef.current?.(uid);
+      removeUnreadLinkUid(uid, unreadLinksMapRef.current);
+    });
+  }, [notifications, pathToCompareNotyLink, authToken, onMarkedAsRead]);
 
   // Mark single notification as read
   const markAsRead = useCallback(

--- a/providers/PushNotificationsProvider/hooks/useAutoMarkOnNavigation.ts
+++ b/providers/PushNotificationsProvider/hooks/useAutoMarkOnNavigation.ts
@@ -53,5 +53,9 @@ export function useAutoMarkOnNavigation(input: UseAutoMarkOnNavigationOptions) {
     };
 
     markAll();
-  }, [authToken, wsMarkAsReadRef, unreadMap.size, unreadLinksMapRef, onMarkedAsRead, pathToCompareNotyLink]);
+  // unreadMap is included alongside unreadMap.size:
+  // - unreadMap.size detects in-place mutations (addUnreadLinkEntry)
+  // - unreadMap detects reference replacement (fetchUnreadLinks creates a new Map)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authToken, wsMarkAsReadRef, unreadMap, unreadMap.size, onMarkedAsRead, pathToCompareNotyLink]);
 }

--- a/providers/PushNotificationsProvider/utils/addUnreadLinkEntry.ts
+++ b/providers/PushNotificationsProvider/utils/addUnreadLinkEntry.ts
@@ -7,7 +7,23 @@ import { IRL_GATHERING_ROUTE } from '@/constants/routes';
 export function addUnreadLinkEntry(entry: UnreadLink, map: UnreadLinksMap) {
   const { uid, link } = entry;
 
-  const normalized = link.includes(IRL_GATHERING_ROUTE) ? link : normalizeLink(link);
+  let normalized: string;
+  if (link.includes(IRL_GATHERING_ROUTE)) {
+    // IRL routes need query params preserved; handle both absolute and relative links
+    if (/^https?:\/\//i.test(link)) {
+      try {
+        const url = new URL(link);
+        normalized = `${url.pathname}?${url.searchParams.toString()}`;
+      } catch {
+        normalized = link.split('#')[0];
+      }
+    } else {
+      normalized = link.split('#')[0];
+    }
+  } else {
+    normalized = normalizeLink(link);
+  }
+
   const existing = map.get(normalized);
 
   if (existing) {

--- a/providers/PushNotificationsProvider/utils/normalizeLink.ts
+++ b/providers/PushNotificationsProvider/utils/normalizeLink.ts
@@ -1,11 +1,17 @@
 /**
  * Normalizes a notification link for comparison with the current pathname.
+ * - Handles absolute URLs (https://example.com/path → /path)
  * - Strips query parameters and hash fragments
  * - Ensures a leading `/`
  */
 export function normalizeLink(link: string): string {
-  // Strip query params and hash
+  try {
+    if (/^https?:\/\//i.test(link)) {
+      return new URL(link).pathname;
+    }
+  } catch {
+    // fall through to path-only handling
+  }
   const pathOnly = link.split('?')[0].split('#')[0];
-  // Ensure leading slash
   return pathOnly.startsWith('/') ? pathOnly : `/${pathOnly}`;
 }


### PR DESCRIPTION
- Implement `AutoMarkNewsNotification` component for marking notifications as read based on the current page.
- Update `NewsCard` to use accessible `<div>` with keyboard navigation support and open links in a new tab.
- Enhance `normalizeLink` utility to handle absolute URLs while preserving path normalization.
- Refactor push notifications provider to auto-mark unread links and improve link entry handling logic.
- Add cursor pointer style to `NewsCard` for better user experience.