### PR TITLE
feat(home): add role-based Quick Actions section

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -16,6 +16,7 @@ import { getFeaturedData } from '@/services/featured.service';
 import { formatFeaturedData } from '@/utils/home.utils';
 import { isAdminUser } from '@/utils/user/isAdminUser';
 import { Welcome } from '@/components/page/home/Welcome';
+import { QuickActions } from '@/components/page/home/QuickActions/QuickActions';
 import { NewsLoginRedirect, TeamNews, AutoMarkNewsNotification } from '@/components/page/home/TeamNews';
 import { getTeamNewsGroupedByFocusArea } from '@/services/team-news/team-news.service';
 import type { ITeamNewsGroup } from '@/types/team-news.types';
@@ -36,6 +37,7 @@ export default async function Home() {
               <Welcome />
             </div>
           )}
+          {isLoggedIn && <QuickActions userInfo={userInfo} />}
           <div className={styles.home__cn__teamnews}>
             <TeamNews groups={teamNewsGroups} />
           </div>

--- a/components/page/home/QuickActions/ActionCard.tsx
+++ b/components/page/home/QuickActions/ActionCard.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { CaretRightIcon } from '@/components/icons';
+import styles from './QuickActions.module.scss';
+
+interface ActionCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  href: string;
+  isExternal?: boolean;
+}
+
+export function ActionCard({ icon, title, description, href, isExternal }: ActionCardProps) {
+  const inner = (
+    <span className={styles.card}>
+      <span className={styles.card__icon}>{icon}</span>
+      <span className={styles.card__text}>
+        <span className={styles.card__title}>{title}</span>
+        <span className={styles.card__description}>{description}</span>
+      </span>
+      <CaretRightIcon className={styles.card__arrow} />
+    </span>
+  );
+
+  if (isExternal) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={styles.card__link}>
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={styles.card__link}>
+      {inner}
+    </Link>
+  );
+}

--- a/components/page/home/QuickActions/QuickActions.module.scss
+++ b/components/page/home/QuickActions/QuickActions.module.scss
@@ -63,12 +63,14 @@
 
 .card__icon {
   flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--Neutral-Slate-600);
+  background: #eef0ff;
+  border-radius: 50%;
+  color: #3b5cf6;
 }
 
 .card__text {

--- a/components/page/home/QuickActions/QuickActions.module.scss
+++ b/components/page/home/QuickActions/QuickActions.module.scss
@@ -1,0 +1,105 @@
+@import 'styles/media.scss';
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--Neutral-Slate-900);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: var(--Neutral-Slate-600);
+  margin: 0 0 12px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+
+  @include tablet-portrait-only {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include mobile-only {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card__link {
+  text-decoration: none;
+  display: block;
+  border-radius: 12px;
+
+  &:hover .card {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--Neutral-Slate-900);
+    outline-offset: 2px;
+  }
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  background: var(--Neutral-White);
+  border-radius: 12px;
+  border: 1px solid var(--Neutral-Slate-200);
+  transition: box-shadow 0.15s ease;
+  height: 100%;
+}
+
+.card__icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--Neutral-Slate-600);
+}
+
+.card__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card__title {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--Neutral-Slate-900);
+  line-height: 1.4;
+}
+
+.card__description {
+  display: block;
+  font-size: 12px;
+  color: var(--Neutral-Slate-600);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+}
+
+.card__arrow {
+  flex-shrink: 0;
+  color: var(--Neutral-Slate-600);
+  width: 16px;
+  height: 16px;
+}

--- a/components/page/home/QuickActions/QuickActions.tsx
+++ b/components/page/home/QuickActions/QuickActions.tsx
@@ -14,7 +14,7 @@ import { ActionCard } from './ActionCard';
 import styles from './QuickActions.module.scss';
 
 // TODO: Replace with the confirmed external Office Hours scheduling URL
-const OH_HREF = 'https://office-hours.protocol.ai';
+const OH_HREF = '/members?hasOfficeHours=true';
 
 type UserGroup = 'pl-infra' | 'founder' | 'others';
 
@@ -44,7 +44,6 @@ export function QuickActions({ userInfo }: QuickActionsProps) {
       title="Book Office Hours"
       description="Connect with experts across the network"
       href={OH_HREF}
-      isExternal
     />
   );
 
@@ -74,12 +73,7 @@ export function QuickActions({ userInfo }: QuickActionsProps) {
               description="Resources curated for network founders"
               href="/founder-guides"
             />
-            <ActionCard
-              icon={<JobsIcon />}
-              title="Job Board"
-              description="Find your next role"
-              href="/jobs"
-            />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
           </>
         )}
 
@@ -98,12 +92,7 @@ export function QuickActions({ userInfo }: QuickActionsProps) {
               description="Exclusive offers for network members"
               href="/deals"
             />
-            <ActionCard
-              icon={<JobsIcon />}
-              title="Job Board"
-              description="Find your next role"
-              href="/jobs"
-            />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
           </>
         )}
 
@@ -119,12 +108,7 @@ export function QuickActions({ userInfo }: QuickActionsProps) {
                 href="/members"
               />
             )}
-            <ActionCard
-              icon={<JobsIcon />}
-              title="Job Board"
-              description="Find your next role"
-              href="/jobs"
-            />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
           </>
         )}
       </div>

--- a/components/page/home/QuickActions/QuickActions.tsx
+++ b/components/page/home/QuickActions/QuickActions.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { CalendarBlankIcon } from '@/components/icons';
+import {
+  TeamsIcon,
+  DealsIcon,
+  FounderGuidesIcon,
+  JobsIcon,
+  MembersIcon,
+} from '@/components/core/navbar/components/icons';
+import { useOfficeHoursAccess } from '@/services/access-control/hooks/useOfficeHoursAccess';
+import type { IUserInfo } from '@/types/shared.types';
+import { ActionCard } from './ActionCard';
+import styles from './QuickActions.module.scss';
+
+// TODO: Replace with the confirmed external Office Hours scheduling URL
+const OH_HREF = 'https://office-hours.protocol.ai';
+
+type UserGroup = 'pl-infra' | 'founder' | 'others';
+
+function detectUserGroup(policies: NonNullable<IUserInfo['rbac']>['policies'] | undefined): UserGroup {
+  if (!policies?.length) return 'others';
+  if (policies.some((p) => p.code === 'pl_infra_team_pl_internal')) return 'pl-infra';
+  if (policies.some((p) => p.code.startsWith('founder_plc_'))) return 'founder';
+  return 'others';
+}
+
+interface QuickActionsProps {
+  userInfo: IUserInfo | null;
+}
+
+export function QuickActions({ userInfo }: QuickActionsProps) {
+  const group = detectUserGroup(userInfo?.rbac?.policies);
+  const { canViewSupply, canSupply, canViewDemand, canRequestDemand, isLoading: ohLoading } = useOfficeHoursAccess();
+
+  // For 'others' we defer until OH access resolves to prevent a card swap flicker
+  if (group === 'others' && ohLoading) return null;
+
+  const hasOhAccess = canViewSupply || canSupply || canViewDemand || canRequestDemand;
+
+  const ohCard = (
+    <ActionCard
+      icon={<CalendarBlankIcon />}
+      title="Book Office Hours"
+      description="Connect with experts across the network"
+      href={OH_HREF}
+      isExternal
+    />
+  );
+
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.title}>Quick Actions</h2>
+      <p className={styles.subtitle}>Quick actions to get the most from your network.</p>
+      <div className={styles.grid}>
+        {group === 'pl-infra' && (
+          <>
+            <ActionCard
+              icon={<TeamsIcon />}
+              title="Teams"
+              description="Explore active teams across the network"
+              href="/teams?priorities=P1%7CP2%7CP3"
+            />
+            {ohCard}
+            <ActionCard
+              icon={<DealsIcon />}
+              title="Network Deals"
+              description="Exclusive offers for network members"
+              href="/deals"
+            />
+            <ActionCard
+              icon={<FounderGuidesIcon />}
+              title="Founder Guides"
+              description="Resources curated for network founders"
+              href="/founder-guides"
+            />
+            <ActionCard
+              icon={<JobsIcon />}
+              title="Job Board"
+              description="Find your next role"
+              href="/jobs"
+            />
+          </>
+        )}
+
+        {group === 'founder' && (
+          <>
+            {ohCard}
+            <ActionCard
+              icon={<FounderGuidesIcon />}
+              title="Founder Guides"
+              description="Resources curated for network founders"
+              href="/founder-guides"
+            />
+            <ActionCard
+              icon={<DealsIcon />}
+              title="Network Deals"
+              description="Exclusive offers for network members"
+              href="/deals"
+            />
+            <ActionCard
+              icon={<JobsIcon />}
+              title="Job Board"
+              description="Find your next role"
+              href="/jobs"
+            />
+          </>
+        )}
+
+        {group === 'others' && (
+          <>
+            {hasOhAccess ? (
+              ohCard
+            ) : (
+              <ActionCard
+                icon={<MembersIcon />}
+                title="Network Directory"
+                description="Connect with 3,000+ people"
+                href="/members"
+              />
+            )}
+            <ActionCard
+              icon={<JobsIcon />}
+              title="Job Board"
+              description="Find your next role"
+              href="/jobs"
+            />
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -32,10 +32,7 @@ export const TeamNews = ({ groups, pageSize = 6 }: TeamNewsProps) => {
   const [expanded, setExpanded] = useState(false);
   const analytics = useTeamNewsAnalytics();
 
-  const allItems = useMemo(
-    () => sortAllTabItemsByEventDate(dedupeByUid(groups.flatMap((g) => g.items))),
-    [groups],
-  );
+  const allItems = useMemo(() => sortAllTabItemsByEventDate(dedupeByUid(groups.flatMap((g) => g.items))), [groups]);
 
   const itemsForActiveTab = useMemo(() => {
     if (activeTab === ALL_TAB) return allItems;


### PR DESCRIPTION
## Summary

- Adds a **Quick Actions** section at the top of the home page for logged-in users, placed above the Team News feed
- Cards shown are personalized based on the user's RBAC policy group (synchronous detection, zero new API calls)
- Three distinct layouts matching the Figma design

## Card Sets by User Group

| Group | Detection | Cards |
|---|---|---|
| **PL Infra** | `pl_infra_team_pl_internal` policy | Teams (P1–P3 filtered), Office Hours, Network Deals, Founder Guides, Job Board |
| **Founders/PLVS/PLC X** | policy code starts with `founder_plc_` | Office Hours, Founder Guides, Network Deals, Job Board |
| **Others** | everyone else | Network Directory (or Office Hours if access) + Job Board |

## Implementation Notes

- Group detection reads `userInfo.rbac.policies` passed as a prop from the Server Component — **no loading state, no additional API calls** for PL Infra and Founders groups
- "Others" group defers rendering until `useOfficeHoursAccess()` resolves to prevent a card-swap flicker
- All icons reuse existing navbar icon components; all link hrefs reuse navbar link constants
- Teams card links to `/teams?priorities=P1%7CP2%7CP3` (existing pipe-separator URL format)