### PR TITLE
feat(founders): add score explanation drawer to Founders DB

### DIFF
--- a/components/page/founders/FounderDrawer/FounderDrawer.module.scss
+++ b/components/page/founders/FounderDrawer/FounderDrawer.module.scss
@@ -357,3 +357,152 @@
   font-family: 'Inter', sans-serif;
   font-size: 14px;
 }
+
+// ── Scores section header row ─────────────────────────────────────────────────
+
+.sectionHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+
+  // override the sectionTitle margin when inside this row
+  .sectionTitle { margin-bottom: 0; }
+}
+
+.howScoredLink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: #1b4dff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover { color: #1a3fd9; }
+}
+
+// ── Scoring methodology modal ─────────────────────────────────────────────────
+
+.scoringBody {
+  padding: 24px 28px 32px;
+  overflow-y: auto;
+  height: 100%;
+  font-family: 'Inter', sans-serif;
+}
+
+.scoringHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.scoringTitle {
+  font-size: 20px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.scoringClose {
+  background: none;
+  border: none;
+  padding: 4px;
+  min-width: 40px;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 18px;
+  color: #6b7280;
+  line-height: 1;
+  flex-shrink: 0;
+
+  &:hover { color: #111827; }
+}
+
+.scoringSection {
+  margin-bottom: 28px;
+  padding-bottom: 28px;
+  border-bottom: 1px solid #e5e7eb;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}
+
+.scoringH3 {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+  margin: 0 0 8px;
+}
+
+.scoringLead {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #455468;
+  margin: 0 0 12px;
+}
+
+.scoringTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+
+  th,
+  td {
+    padding: 8px 10px;
+    text-align: left;
+    border-bottom: 1px solid #f3f4f6;
+    vertical-align: top;
+  }
+
+  thead th {
+    background: #f3f4f6;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
+  }
+
+  tbody tr:nth-child(even) td { background: #f9fafb; }
+
+  tbody tr:last-child td { border-bottom: none; }
+
+  td:first-child {
+    font-weight: 500;
+    color: #374151;
+    white-space: nowrap;
+  }
+}
+
+.scoringRight {
+  text-align: right !important;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.scoringNote {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #6b7280;
+  margin-top: 12px;
+}

--- a/components/page/founders/FounderDrawer/FounderDrawer.tsx
+++ b/components/page/founders/FounderDrawer/FounderDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Drawer } from '@/components/common/Drawer/Drawer';
 import { useGetFounderById } from '@/services/founders/hooks/useGetFounderById';
 import { LabOsBadge } from '@/components/page/investors/LabOsBadge/LabOsBadge';
@@ -62,7 +62,112 @@ function PlvsFeatureGrid({ features }: { features: PlvsFeatures }) {
   );
 }
 
+function FounderScoringModal({ open, onClose, triggerRef }: {
+  open: boolean;
+  onClose: () => void;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+}) {
+  if (!open) return null;
+
+  const handleClose = () => {
+    onClose();
+    triggerRef.current?.focus();
+  };
+
+  return (
+    <Drawer isOpen={open} onClose={handleClose} width={520} noBlur>
+      <div
+        className={s.scoringBody}
+        id="founder-scoring-panel"
+        aria-labelledby="founder-scoring-title"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.stopPropagation();
+            handleClose();
+          }
+        }}
+      >
+        <header className={s.scoringHeader}>
+          <h2 id="founder-scoring-title" className={s.scoringTitle}>Score methodology</h2>
+          <button type="button" className={s.scoringClose} onClick={handleClose} aria-label="Close">✕</button>
+        </header>
+
+        <section className={s.scoringSection}>
+          <h3 className={s.scoringH3}>Alignment Score</h3>
+          <p className={s.scoringLead}>
+            A 0–100% confidence score showing how strongly this founder matches the thesis of their
+            best-matched fund (PLVS, Neuro Tech, or Crypto). The classifier reads the founder&apos;s bio,
+            extracted topics, and signal keywords against each fund&apos;s thesis vocabulary. Alignment
+            shows the highest confidence across all fund tags assigned to this person.
+          </p>
+          <div className={s.scoringNote}>
+            Alignment is not PLN proximity. PLN proximity (shown as a badge) measures graph-distance
+            to the Protocol Labs network — these are separate signals.
+          </div>
+        </section>
+
+        <section className={s.scoringSection}>
+          <h3 className={s.scoringH3}>PLVS Score</h3>
+          <p className={s.scoringLead}>
+            A deterministic, weight-pinned 0–100 investment score computed only for founders tagged
+            to the PLVS fund. Same inputs always produce the same score — no model drift, fully
+            auditable. Each component contributes up to its cap; caps sum to 100.
+          </p>
+          <table className={s.scoringTable}>
+            <thead>
+              <tr>
+                <th>Component</th>
+                <th className={s.scoringRight}>Max pts</th>
+                <th>What it measures</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Domain Match</td>
+                <td className={s.scoringRight}>30</td>
+                <td>Overlap with PLVS thesis vocabulary (agent, llm-infra, ai-native, etc.). The single biggest driver.</td>
+              </tr>
+              <tr>
+                <td>Technical Depth</td>
+                <td className={s.scoringRight}>20</td>
+                <td>Engineering-rigor proxies: GitHub followers, stargazers, h-index, repo count</td>
+              </tr>
+              <tr>
+                <td>Stage Fit</td>
+                <td className={s.scoringRight}>15</td>
+                <td>Intent ladder — just-shipped / stealth-launching scores highest; default (no signal) scores lowest</td>
+              </tr>
+              <tr>
+                <td>Corroboration</td>
+                <td className={s.scoringRight}>15</td>
+                <td>Distinct sources that independently surfaced this founder — more sources, more trust</td>
+              </tr>
+              <tr>
+                <td>Recency</td>
+                <td className={s.scoringRight}>10</td>
+                <td>Exponential decay, 24-month half-life. Academic-to-founder paths remain scorable longer.</td>
+              </tr>
+              <tr>
+                <td>Trajectory</td>
+                <td className={s.scoringRight}>10</td>
+                <td>Growth velocity in followers, commits, and citations</td>
+              </tr>
+            </tbody>
+          </table>
+          <div className={s.scoringNote}>
+            Network signals — PLN proximity and PL alignment — are not part of this score. They
+            appear as separate badges on the founder card and act as tie-breakers only.
+          </div>
+        </section>
+      </div>
+    </Drawer>
+  );
+}
+
 function DrawerBody({ founder, canEdit, onClose }: { founder: FounderDetail; canEdit: boolean; onClose: () => void }) {
+  const [scoringOpen, setScoringOpen] = useState(false);
+  const scoringTriggerRef = useRef<HTMLButtonElement>(null);
+
   const raw = founder.rawPayload;
   const fundTags = raw?.fund_tags ?? [];
   const provenance = raw?.provenance ?? [];
@@ -134,7 +239,20 @@ function DrawerBody({ founder, canEdit, onClose }: { founder: FounderDetail; can
       )}
 
       {/* Scores */}
-      <Section title="Scores">
+      <div className={s.section}>
+        <div className={s.sectionHeaderRow}>
+          <h3 className={s.sectionTitle}>Scores</h3>
+          <button
+            ref={scoringTriggerRef}
+            type="button"
+            className={s.howScoredLink}
+            onClick={() => setScoringOpen(true)}
+            aria-expanded={scoringOpen}
+            aria-controls="founder-scoring-panel"
+          >
+            How are scores calculated?
+          </button>
+        </div>
         <dl className={s.kv}>
           <dt>Alignment</dt>
           <dd>{founder.alignmentMax !== undefined && founder.alignmentMax !== null
@@ -153,7 +271,7 @@ function DrawerBody({ founder, canEdit, onClose }: { founder: FounderDetail; can
           </dd>
         </dl>
         {plvsFeatures && <PlvsFeatureGrid features={plvsFeatures} />}
-      </Section>
+      </div>
 
       {/* Warm intros */}
       {warmIntros.length > 0 && (
@@ -237,6 +355,12 @@ function DrawerBody({ founder, canEdit, onClose }: { founder: FounderDetail; can
           />
         </Section>
       )}
+
+      <FounderScoringModal
+        open={scoringOpen}
+        onClose={() => setScoringOpen(false)}
+        triggerRef={scoringTriggerRef}
+      />
     </div>
   );
 }
@@ -248,7 +372,7 @@ export default function FounderDrawer({ founderId, onClose, canEdit }: Props) {
     <Drawer isOpen={!!founderId} onClose={onClose} width={720}>
       {isLoading && <div className={s.loading}>Loading…</div>}
       {!isLoading && !founder && founderId && <div className={s.loading}>Founder not found.</div>}
-      {founder && <DrawerBody founder={founder as FounderDetail} canEdit={canEdit} onClose={onClose} />}
+      {founder && <DrawerBody key={founderId} founder={founder as FounderDetail} canEdit={canEdit} onClose={onClose} />}
     </Drawer>
   );
 }

--- a/components/page/founders/FounderDrawer/FounderDrawer.tsx
+++ b/components/page/founders/FounderDrawer/FounderDrawer.tsx
@@ -256,7 +256,7 @@ function DrawerBody({ founder, canEdit, onClose }: { founder: FounderDetail; can
         <dl className={s.kv}>
           <dt>Alignment</dt>
           <dd>{founder.alignmentMax !== undefined && founder.alignmentMax !== null
-            ? founder.alignmentMax.toFixed(2)
+            ? `${Math.round(founder.alignmentMax * 100)}%`
             : <span className={s.muted}>—</span>}
           </dd>
           <dt>PLVS Score</dt>

--- a/components/page/founders/FounderTable/FounderTable.tsx
+++ b/components/page/founders/FounderTable/FounderTable.tsx
@@ -91,7 +91,7 @@ export function FounderTable({ founders, selectedFounderId, onRowClick, isLoadin
         header: 'Alignment',
         cell: ({ row }) => {
           const v = row.original.alignmentMax;
-          return v !== undefined && v !== null ? <span>{v.toFixed(2)}</span> : <span className={s.muted}>—</span>;
+          return v !== undefined && v !== null ? <span>{Math.round(v * 100)}%</span> : <span className={s.muted}>—</span>;
         },
       },
       {


### PR DESCRIPTION
## Summary

- Adds a **"How are scores calculated?"** link inline with the Scores section heading in the Founder Drawer
- Opens a 520px right-side explanation drawer (Score methodology) with two sections:
  - **Alignment Score** — explains the 0–100% fund thesis confidence score and distinguishes it from PLN proximity
  - **PLVS Score** — explains the deterministic 0–100 investment score with a 6-component breakdown table (Domain Match/30, Technical Depth/20, Stage Fit/15, Corroboration/15, Recency/10, Trajectory/10)
- Mirrors the existing "How is the Fit score calculated?" pattern already in the Investor DB (`WarmIntrosWorkspace` → `ScoringMethodologyModal`)

## Key decisions

- **Zero new files** — `FounderScoringModal` is defined as a module-private function in the existing `FounderDrawer.tsx`, consistent with how `Section`, `PlvsFeatureGrid`, etc. are already structured there
- **`key={founderId}` on `DrawerBody`** — prevents stale `scoringOpen` state from leaking when navigating between founders
- **`noBlur`** on the scoring drawer — prevents double-blur when two `Drawer` portals are stacked
- **Escape with `stopPropagation`** — closes only the scoring modal, not the parent founder drawer
- **`aria-expanded` + `aria-controls`** on the trigger button; focus returns to trigger on close

## Files changed

| File | Change |
|------|--------|
| `components/page/founders/FounderDrawer/FounderDrawer.tsx` | Add `FounderScoringModal` private component, scoring state + ref, flex-row Scores header, `key={founderId}` on `DrawerBody` |
| `components/page/founders/FounderDrawer/FounderDrawer.module.scss` | Add `.sectionHeaderRow`, `.howScoredLink`, and all `.scoring*` styles |

## Testing

- [ ] Open a founder drawer → Scores section shows "How are scores calculated?" link inline with the heading
- [ ] Click the link → Score methodology drawer opens at 520px on top of the parent drawer (no double-blur)
- [ ] ✕ button closes scoring modal, focus returns to trigger
- [ ] Escape closes scoring modal only (parent drawer stays open)
- [ ] Navigate to a different founder → scoring modal does not persist
- [ ] PLN Proximity shown in drawer and the note in the modal correctly distinguishes it from Alignment

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)