### PR TITLE
fix(teams): clear filter store when 'clear all criteria' is clicked

### DIFF
--- a/app/teams/(teams-page)/@content/TeamsContent.tsx
+++ b/app/teams/(teams-page)/@content/TeamsContent.tsx
@@ -14,6 +14,7 @@ import { triggerLoader } from '@/utils/common.utils';
 import { ContentPanelSkeletonLoader } from '@/components/core/dashboard-pages-layout/ContentPanelSkeletonLoader';
 import { useTeamsFilters } from '../hooks/useGetTeamsFilterValues';
 import { useGetTeamsFilterAsObjectFromStore } from '@/hooks/teams/useGetTeamsFilterAsObjectFromStore';
+import { useTeamFilterStore } from '@/services/teams';
 
 interface TeamsContentProps {
   userInfo: IUserInfo | undefined;
@@ -23,6 +24,7 @@ export default function TeamsContent(props: TeamsContentProps) {
   const { userInfo } = props;
 
   const searchParams = useGetTeamsFilterAsObjectFromStore();
+  const clearParams = useTeamFilterStore((s) => s.clearParams);
 
   // Use the shared hook for filters
   const { filterValues, isLoading: isLoadingFilters, isError: isFiltersError } = useTeamsFilters(searchParams);
@@ -77,7 +79,7 @@ export default function TeamsContent(props: TeamsContentProps) {
             filterValues={filterValues}
           />
         ) : (
-          <EmptyResult />
+          <EmptyResult onClearAll={clearParams} />
         )}
       </div>
     </div>

--- a/components/core/empty-result.tsx
+++ b/components/core/empty-result.tsx
@@ -12,7 +12,11 @@ const EmptyResult = (props: any) => {
   const authAnalytics = useAuthAnalytics();
 
   const onClearAllClickHandler = () => {
-    router.push(pathname);
+    if (props?.onClearAll) {
+      props.onClearAll();
+    } else {
+      router.push(pathname);
+    }
   };
 
   const onLoginClickHandler = () => {


### PR DESCRIPTION
## Bug

Clicking **clear all criteria** in the empty results state on Teams:
- Removed query params from the URL ✅
- Did **not** clear the Zustand filter store ❌
- `TeamsContent` reads filters from `useGetTeamsFilterAsObjectFromStore` (the store, not the URL), so it kept fetching with the old params → no results
- Sidebar filters stayed visually active

## Root cause

`EmptyResult.onClearAllClickHandler` called `router.push(pathname)` which only clears the URL. The `useTeamFilterStore` Zustand store was never reset, so `TeamsContent` continued to query with stale filter params.

## Fix

- `EmptyResult` now accepts an optional `onClearAll` prop. When provided, it's called instead of `router.push(pathname)`.
- `TeamsContent` passes `clearParams` from `useTeamFilterStore` as `onClearAll`.
- `clearParams()` sets `_clearImmediate: true` on the store, which causes `SyncTeamsParamsToUrl` to immediately flush the empty params back to the URL — no separate `router.push` needed.
- All other pages that render `EmptyResult` without `onClearAll` are unaffected (fall through to the original `router.push` behaviour).

## Files changed

| File | Change |
|------|--------|
| `components/core/empty-result.tsx` | Accept `onClearAll` prop; call it when provided |
| `app/teams/(teams-page)/@content/TeamsContent.tsx` | Pass `clearParams` from `useTeamFilterStore` as `onClearAll` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)