### PR TITLE
fix(demo-day): fix scrollbar appearing outside ReferCompanyModal rounded corners

### DIFF
--- a/components/page/demo-day/ActiveView/components/TeamsList/components/ReferCompanyModal/ReferCompanyModal.module.scss
+++ b/components/page/demo-day/ActiveView/components/TeamsList/components/ReferCompanyModal/ReferCompanyModal.module.scss
@@ -5,11 +5,11 @@
   inset: 0;
   background: rgba(14, 15, 17, 0.5);
   display: flex;
-  align-items: center;
   justify-content: center;
   z-index: 1000;
   padding: 20px;
   backdrop-filter: blur(15px);
+  overflow-y: auto;
 }
 
 .modal {
@@ -18,8 +18,6 @@
   padding: 20px;
   width: 100%;
   max-width: 400px;
-  max-height: 90vh;
-  overflow-y: auto;
   position: relative;
   box-shadow:
     0px 10px 20px -5px rgba(14, 15, 17, 0.06),
@@ -27,10 +25,10 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  margin: auto;
 
   @include media.mobile-only {
     max-width: 100%;
-    max-height: 95vh;
   }
 }
 


### PR DESCRIPTION
## Bug

When the `ReferCompanyModal` content exceeded the viewport, a native scrollbar appeared visually **outside** the modal's `border-radius: 24px` rounded corners — the scrollbar track rendered along the raw box edge, not inside the visual white pill shape.

## Root cause

`.modal` had `overflow-y: auto` + `max-height: 90vh`. The browser draws the native scrollbar track inside the element's box but against the edge, which ignores `border-radius` visually — the track ends up outside the rounded corners.

## Fix

Move scrolling to the **overlay** instead of the modal:

- `overflow-y: auto` moved to `.overlay` (the full-screen fixed backdrop — no border-radius, so no visual issue)
- `max-height` and `overflow-y: auto` removed from `.modal`
- `margin: auto` added to `.modal` so it stays vertically centered when shorter than the viewport (flex + `margin: auto` absorbs free space)

1 file, 6 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)