### PR TITLE
fix(home): don't collapse TeamNews list when switching category tag

### DIFF
--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -68,7 +68,6 @@ export const TeamNews = ({ groups, pageSize = 6 }: TeamNewsProps) => {
       id === ALL_CAT ? itemsForActiveTab.length : itemsForActiveTab.filter((i) => i.eventType === id).length;
     analytics.onTeamNewsCategoryClicked(String(id), nextCount, activeTab);
     setActiveCategory(id);
-    setExpanded(false);
   };
 
   const handleToggleAll = () => {


### PR DESCRIPTION
## Bug

Clicking a category tag in the TeamNews section collapsed the expanded list back to the default `pageSize`.

## Root cause

`handleCategory` called `setExpanded(false)` unconditionally. Changing a category filter has no reason to reset the expansion state — if the user clicked "Show All", they want to see all items regardless of which filter they switch to.

## Fix

Remove `setExpanded(false)` from `handleCategory`. The "Show All" / "Show Less" button is already conditionally rendered only when `filteredItems.length > pageSize`, so if the new category yields fewer items than the page size, the button naturally disappears — no need to force a collapse.

1 line deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)