### PR TITLE
feat(gantry): add item type field with filter support

### DIFF
--- a/analytics/gantry.analytics.ts
+++ b/analytics/gantry.analytics.ts
@@ -14,6 +14,7 @@ export const GANTRY_EVENTS = {
   ROADMAP_VIEWED: 'gantry_roadmap_viewed',
   BUILD_BUTTON_CLICKED: 'gantry_build_button_clicked',
   TAGS_FILTERED: 'gantry_tags_filtered',
+  TYPE_FILTERED: 'gantry_type_filtered',
 } as const;
 
 export function useGantryAnalytics() {
@@ -29,10 +30,11 @@ export function useGantryAnalytics() {
   return {
     onIdeasViewed: () => capture(GANTRY_EVENTS.IDEAS_VIEWED),
     onRoadmapViewed: () => capture(GANTRY_EVENTS.ROADMAP_VIEWED),
-    onIdeaCreated: (itemUid: string, tags: string[] = []) =>
-      capture(GANTRY_EVENTS.IDEA_CREATED, { itemUid, tags, tag_count: tags.length }),
+    onIdeaCreated: (itemUid: string, tags: string[] = [], itemType?: string) =>
+      capture(GANTRY_EVENTS.IDEA_CREATED, { itemUid, tags, tag_count: tags.length, ...(itemType ? { type: itemType } : {}) }),
     onItemUpvoted: (itemUid: string) => capture(GANTRY_EVENTS.ITEM_UPVOTED, { itemUid }),
     onBuildButtonClicked: (itemUid: string) => capture(GANTRY_EVENTS.BUILD_BUTTON_CLICKED, { itemUid }),
     onTagsFiltered: (tags: string[]) => capture(GANTRY_EVENTS.TAGS_FILTERED, { tags, tag_count: tags.length }),
+    onTypeFiltered: (types: string[]) => capture(GANTRY_EVENTS.TYPE_FILTERED, { types, type_count: types.length }),
   };
 }

--- a/components/page/gantry/GantryDetailPage.tsx
+++ b/components/page/gantry/GantryDetailPage.tsx
@@ -192,6 +192,15 @@ export function GantryDetailPage({ uid }: Props) {
               </div>
             )}
 
+            {item.type && !isEditMode && (
+              <div className={s.tagsRow}>
+                <span className={s.tagsLabel}>Type</span>
+                <div className={s.tagsList}>
+                  <span className={s.tagChip}>{item.type}</span>
+                </div>
+              </div>
+            )}
+
             <div className={s.mobileDivider} />
 
             {isEditMode ? (

--- a/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.tsx
+++ b/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.tsx
@@ -12,7 +12,7 @@ import { IdeaFormFields } from '@/components/page/gantry/shared/IdeaFormFields';
 import { useSubmitIdeaModalStore } from '@/services/gantry/store';
 import { useCreateGantryItem } from '@/services/gantry/hooks/useCreateGantryItem';
 import { useGantryAccess } from '@/services/rbac/hooks/useGantryAccess';
-import type { GantryStage } from '@/services/gantry/types';
+import type { GantryItemType, GantryStage } from '@/services/gantry/types';
 import {
   getSubmitIdeaFormDefaults,
   SUBMIT_IDEA_MODAL_COPY,
@@ -58,6 +58,7 @@ export function SubmitIdeaModal() {
     const stageValue = data.stage?.value as GantryStage | undefined;
 
     const tags = data.tags?.map((o) => o.value) ?? [];
+    const itemType = data.type?.value as GantryItemType | undefined;
 
     mutate(
       {
@@ -65,11 +66,12 @@ export function SubmitIdeaModal() {
         description: hasRichTextContent(data.description) ? data.description : '',
         externalTrackerUrl: null,
         tags,
+        ...(itemType ? { type: itemType } : {}),
         ...(canSetStageOnCreate && stageValue ? { stage: stageValue } : {}),
       },
       {
         onSuccess: (created) => {
-          analytics.onIdeaCreated(created.uid, tags);
+          analytics.onIdeaCreated(created.uid, tags, itemType);
           reset(getSubmitIdeaFormDefaults('idea'));
           actions.closeModal();
           router.push(`/gantry/${created.uid}`);

--- a/components/page/gantry/ideas/SubmitIdeaModal/helpers.ts
+++ b/components/page/gantry/ideas/SubmitIdeaModal/helpers.ts
@@ -16,6 +16,11 @@ const tagsSchema = yup
   .of(yup.object({ label: yup.string().required(), value: yup.string().required() }))
   .optional();
 
+const typeSchema = yup
+  .object({ label: yup.string().required(), value: yup.string().required() })
+  .nullable()
+  .optional();
+
 export const submitIdeaSchema = yup.object().shape({
   title: yup
     .string()
@@ -37,6 +42,7 @@ export const submitIdeaSchema = yup.object().shape({
     .nullable()
     .optional(),
   tags: tagsSchema,
+  type: typeSchema,
 });
 
 export const editIdeaSchema = yup.object().shape({
@@ -46,6 +52,7 @@ export const editIdeaSchema = yup.object().shape({
     .max(TITLE_MAX_LENGTH, `Max ${TITLE_MAX_LENGTH} characters`),
   description: yup.string().optional(),
   tags: tagsSchema,
+  type: typeSchema,
 });
 
 export interface SubmitIdeaFormData {
@@ -53,6 +60,7 @@ export interface SubmitIdeaFormData {
   description: string;
   stage?: Option | null;
   tags?: Option[];
+  type?: Option | null;
 }
 
 /** True when the rich-text value has visible content (ignores empty Quill markup). */

--- a/components/page/gantry/roadmap/Roadmap.module.scss
+++ b/components/page/gantry/roadmap/Roadmap.module.scss
@@ -242,6 +242,20 @@
   white-space: nowrap;
 }
 
+.cardTypeBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  border: 1px solid rgba(14, 15, 17, 0.12);
+  background: #fff;
+  font-size: 11px;
+  line-height: 16px;
+  color: #374151;
+  white-space: nowrap;
+  margin-bottom: 8px;
+}
+
 .meta {
   display: flex;
   align-items: center;

--- a/components/page/gantry/roadmap/RoadmapCard.tsx
+++ b/components/page/gantry/roadmap/RoadmapCard.tsx
@@ -53,6 +53,11 @@ function RoadmapCardContent({ item, canUpvote, onUpvoteToggle }: CardContentProp
           ))}
         </div>
       )}
+      {item.type && (
+        <div className={s.cardTypeBadge} aria-label={`Type: ${item.type}`}>
+          {item.type}
+        </div>
+      )}
       <div className={s.meta}>
         <GantryItemAuthor author={item.createdBy} backTo={`/gantry/${item.uid}`} />
       </div>

--- a/components/page/gantry/roadmap/RoadmapFilters.tsx
+++ b/components/page/gantry/roadmap/RoadmapFilters.tsx
@@ -12,18 +12,21 @@ interface Props {
   readonly onVisibleColumnsChange: (columns: RoadmapColumnStage[]) => void;
   readonly selectedTags: string[];
   readonly onSelectedTagsChange: (tags: string[]) => void;
+  readonly selectedTypes: string[];
+  readonly onSelectedTypesChange: (types: string[]) => void;
 }
 
-export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange }: Props) {
+export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange }: Props) {
   const clearParams = () => {
     onVisibleColumnsChange([...DEFAULT_ROADMAP_VISIBLE_COLUMNS]);
     onSelectedTagsChange([]);
+    onSelectedTypesChange([]);
   };
 
   return (
     <FiltersSidePanel
       clearParams={clearParams}
-      appliedFiltersCount={visibleColumns.length + selectedTags.length}
+      appliedFiltersCount={visibleColumns.length + selectedTags.length + selectedTypes.length}
       className={filterStyles.filterRail}
       hideFooter
     >
@@ -32,6 +35,8 @@ export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selecte
         onVisibleColumnsChange={onVisibleColumnsChange}
         selectedTags={selectedTags}
         onSelectedTagsChange={onSelectedTagsChange}
+        selectedTypes={selectedTypes}
+        onSelectedTypesChange={onSelectedTypesChange}
       />
     </FiltersSidePanel>
   );

--- a/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
+++ b/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
@@ -5,6 +5,7 @@ import { FilterSection } from '@/components/common/filters/FilterSection';
 import { CheckboxListItemRepresentation } from '@/components/common/filters/GenericCheckboxList/components/CheckboxListItemRepresentation';
 import { FilterMultiSelect } from '@/components/common/filters/FilterSelect/FilterMultiSelect';
 import {
+  GANTRY_ITEM_TYPE_OPTIONS,
   GANTRY_ROADMAP_COLUMN_STAGES,
   GANTRY_STAGE_LABELS,
   GANTRY_TAG_OPTIONS,
@@ -18,9 +19,11 @@ interface Props {
   readonly onVisibleColumnsChange: (columns: RoadmapColumnStage[]) => void;
   readonly selectedTags: string[];
   readonly onSelectedTagsChange: (tags: string[]) => void;
+  readonly selectedTypes: string[];
+  readonly onSelectedTypesChange: (types: string[]) => void;
 }
 
-export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange }: Props) {
+export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange }: Props) {
   const toggleColumn = (stage: RoadmapColumnStage) => {
     if (visibleColumns.includes(stage)) {
       onVisibleColumnsChange(visibleColumns.filter((s) => s !== stage));
@@ -60,6 +63,16 @@ export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, 
           placeholder="Filter by tag..."
           isSearchable
           aria-label="Filter by tags"
+        />
+      </FilterSection>
+
+      <FilterSection title="Type">
+        <FilterMultiSelect
+          options={GANTRY_ITEM_TYPE_OPTIONS}
+          value={GANTRY_ITEM_TYPE_OPTIONS.filter((o) => selectedTypes.includes(o.value))}
+          onChange={(opts) => onSelectedTypesChange(opts.map((o) => o.value))}
+          placeholder="Filter by type..."
+          aria-label="Filter by type"
         />
       </FilterSection>
     </>

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -76,6 +76,11 @@ export function RoadmapView() {
     setSelectedTags(tags);
     if (tags.length > 0) analytics.onTagsFiltered(tags);
   };
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const handleSelectedTypesChange = (types: string[]) => {
+    setSelectedTypes(types);
+    if (types.length > 0) analytics.onTypeFiltered(types);
+  };
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
@@ -95,8 +100,9 @@ export function RoadmapView() {
     () => ({
       stage: orderedVisibleColumns.length > 0 ? orderedVisibleColumns : undefined,
       tags: selectedTags.length > 0 ? selectedTags : undefined,
+      type: selectedTypes.length > 0 ? selectedTypes : undefined,
     }),
-    [orderedVisibleColumns, selectedTags],
+    [orderedVisibleColumns, selectedTags, selectedTypes],
   );
 
   const { data, isLoading, isError } = useGantryItems(params, !!currentUser && orderedVisibleColumns.length > 0);
@@ -279,8 +285,8 @@ export function RoadmapView() {
                         />
                       </svg>
                       Filters
-                      {visibleColumns.length + selectedTags.length > 0 && (
-                        <span className={s.filtersButtonBadge}>{visibleColumns.length + selectedTags.length}</span>
+                      {visibleColumns.length + selectedTags.length + selectedTypes.length > 0 && (
+                        <span className={s.filtersButtonBadge}>{visibleColumns.length + selectedTags.length + selectedTypes.length}</span>
                       )}
                     </button>
                     {canCreate && (
@@ -363,6 +369,8 @@ export function RoadmapView() {
             onVisibleColumnsChange={setVisibleColumns}
             selectedTags={selectedTags}
             onSelectedTagsChange={handleSelectedTagsChange}
+            selectedTypes={selectedTypes}
+            onSelectedTypesChange={handleSelectedTypesChange}
           />
         </MobileDrawer>
 
@@ -386,6 +394,8 @@ export function RoadmapView() {
             onVisibleColumnsChange={setVisibleColumns}
             selectedTags={selectedTags}
             onSelectedTagsChange={handleSelectedTagsChange}
+            selectedTypes={selectedTypes}
+            onSelectedTypesChange={handleSelectedTypesChange}
           />
         }
         content={

--- a/components/page/gantry/shared/EditIdeaForm.tsx
+++ b/components/page/gantry/shared/EditIdeaForm.tsx
@@ -5,7 +5,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button } from '@/components/common/Button';
 import { useUpdateGantryItem } from '@/services/gantry/hooks/useUpdateGantryItem';
 import { isPreRoadmapStage, tagsToOptions } from '@/services/gantry/constants';
-import type { GantryItem } from '@/services/gantry/types';
+import type { GantryItem, GantryItemType } from '@/services/gantry/types';
 import {
   editIdeaSchema,
   hasRichTextContent,
@@ -29,6 +29,7 @@ export function EditIdeaForm({ item, onCancel, onSaved }: Props) {
       title: item.title,
       description: item.description,
       tags: tagsToOptions(item.tags),
+      type: item.type ? { label: item.type, value: item.type } : null,
     },
     mode: 'onChange',
   });
@@ -40,6 +41,7 @@ export function EditIdeaForm({ item, onCancel, onSaved }: Props) {
       title: data.title.trim(),
       description: hasRichTextContent(data.description) ? data.description : '',
       tags: data.tags?.map((o) => o.value) ?? [],
+      type: (data.type?.value as GantryItemType) ?? null,
     });
     onSaved();
   };

--- a/components/page/gantry/shared/IdeaFormFields.tsx
+++ b/components/page/gantry/shared/IdeaFormFields.tsx
@@ -5,7 +5,7 @@ import { FormField } from '@/components/form/FormField';
 import { FormEditor } from '@/components/form/FormEditor/FormEditor';
 import { FormSelect } from '@/components/form/FormSelect';
 import { FormMultiSelect } from '@/components/form/FormMultiSelect/FormMultiSelect';
-import { GANTRY_CREATE_STAGE_OPTIONS, GANTRY_TAG_OPTIONS } from '@/services/gantry/constants';
+import { GANTRY_CREATE_STAGE_OPTIONS, GANTRY_ITEM_TYPE_OPTIONS, GANTRY_TAG_OPTIONS } from '@/services/gantry/constants';
 import type { GantryStage } from '@/services/gantry/types';
 import { DESCRIPTION_MAX_LENGTH, TITLE_MAX_LENGTH } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
 import { GantryStageOptionLabel } from './GantryStageOptionLabel';
@@ -79,6 +79,13 @@ export function IdeaFormFields({ canSetStageOnCreate = false }: Props) {
         label="Tags"
         placeholder="Select tags..."
         options={GANTRY_TAG_OPTIONS}
+      />
+
+      <FormSelect
+        name="type"
+        label="Type"
+        placeholder="Select a type"
+        options={GANTRY_ITEM_TYPE_OPTIONS}
       />
     </div>
   );

--- a/services/gantry/constants.ts
+++ b/services/gantry/constants.ts
@@ -104,3 +104,9 @@ export const GANTRY_TAG_OPTIONS: Option[] = GANTRY_TAG_LABELS.map((label) => ({ 
 export function tagsToOptions(tags: string[] | null | undefined): Option[] {
   return GANTRY_TAG_OPTIONS.filter((o) => tags?.includes(o.value) ?? false);
 }
+
+export const GANTRY_ITEM_TYPE_OPTIONS: Option[] = [
+  { label: 'Bug', value: 'Bug' },
+  { label: 'Improvement', value: 'Improvement' },
+  { label: 'Feature Request', value: 'Feature Request' },
+];

--- a/services/gantry/gantry.service.ts
+++ b/services/gantry/gantry.service.ts
@@ -22,6 +22,9 @@ function buildQuery(params: GantryListParams): string {
   if (params.tags?.length) {
     search.set('tags', params.tags.join(','));
   }
+  if (params.type?.length) {
+    search.set('type', params.type.join(','));
+  }
   return search.toString();
 }
 

--- a/services/gantry/schemas.ts
+++ b/services/gantry/schemas.ts
@@ -17,6 +17,7 @@ export const gantryItemFormSchema = z.object({
   focusAreaUid: z.string().optional().nullable(),
   externalTrackerUrl: z.string().max(2000).optional().nullable(),
   tags: z.array(z.string()).optional(),
+  type: z.enum(['Bug', 'Improvement', 'Feature Request']).optional().nullable(),
 });
 
 export type GantryItemFormValues = z.infer<typeof gantryItemFormSchema>;

--- a/services/gantry/submitIdeaModal.ts
+++ b/services/gantry/submitIdeaModal.ts
@@ -41,5 +41,6 @@ export function getSubmitIdeaFormDefaults(variant: SubmitIdeaModalVariant): Subm
     description: '',
     stage,
     tags: [],
+    type: null,
   };
 }

--- a/services/gantry/types.ts
+++ b/services/gantry/types.ts
@@ -1,5 +1,7 @@
 export type GantryStage = 'IDEA' | 'BACKLOG' | 'PLANNED' | 'IN_PROGRESS' | 'SHIPPED' | 'DECLINED';
 
+export type GantryItemType = 'Bug' | 'Improvement' | 'Feature Request';
+
 export interface GantryMemberSummary {
   uid: string;
   name: string;
@@ -14,6 +16,7 @@ export interface GantryItem {
   stage: GantryStage;
   focusArea: string | null;
   tags: string[] | null;
+  type: GantryItemType | null;
   createdByUid: string;
   createdBy: GantryMemberSummary;
   promotedAt: string | null;
@@ -36,6 +39,7 @@ export interface GantryListParams {
   stage?: GantryStage[];
   focusArea?: string;
   tags?: string[];
+  type?: string[];
   mine?: boolean;
   includeDeclined?: boolean;
   includeArchived?: boolean;
@@ -49,6 +53,7 @@ export interface CreateGantryItemPayload {
   externalTrackerUrl?: string | null;
   stage?: GantryStage;
   tags?: string[];
+  type?: GantryItemType;
 }
 
 export interface UpdateGantryItemPayload {
@@ -58,4 +63,5 @@ export interface UpdateGantryItemPayload {
   focusArea?: string | null;
   externalTrackerUrl?: string | null;
   tags?: string[];
+  type?: GantryItemType | null;
 }


### PR DESCRIPTION
## Summary

- Adds a `type` field to Gantry items with three options: **Bug**, **Improvement**, **Feature Request**
- Single-select dropdown in both the create modal and edit form
- Neutral pill badge on Kanban roadmap cards (outlined style to distinguish from tag chips)
- Type row on the detail page, reusing the existing tags row styles
- Multi-select type filter in the desktop filter sidebar and mobile filter drawer
- Filter badge count and "Clear All" both account for type selections
- `buildQuery()` serialises selected types as a comma-joined `type=` query param
- PostHog analytics: `onIdeaCreated` now forwards `itemType`; new `onTypeFiltered` event

## Files changed

| Layer | Files |
|---|---|
| Types & service | `services/gantry/types.ts`, `gantry.service.ts`, `constants.ts`, `schemas.ts`, `submitIdeaModal.ts` |
| Forms | `IdeaFormFields.tsx`, `SubmitIdeaModal.tsx`, `EditIdeaForm.tsx`, `helpers.ts` |
| Display | `RoadmapCard.tsx`, `Roadmap.module.scss`, `GantryDetailPage.tsx` |
| Filters | `RoadmapFiltersContent.tsx`, `RoadmapFilters.tsx`, `RoadmapView.tsx` |
| Analytics | `gantry.analytics.ts` |

## Test plan

- [ ] Create a new roadmap item — Type dropdown appears after Tags, selection persists on the card and detail page
- [ ] Edit an existing item — Type field is pre-populated correctly; saving updates it
- [ ] Roadmap cards: type pill renders below tag chips; items without a type show no badge
- [ ] Detail page: Type row appears between Tags row and the description when set
- [ ] Desktop filters: Type multi-select filters cards correctly; Clear All resets type
- [ ] Mobile filters: same behaviour in the drawer
- [ ] Filter badge count reflects selected type(s)

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)