### PR TITLE
feat(gantry): add client-side text search to filter sidebar

### DIFF
--- a/analytics/gantry.analytics.ts
+++ b/analytics/gantry.analytics.ts
@@ -16,6 +16,8 @@ export const GANTRY_EVENTS = {
   TAGS_FILTERED: 'gantry_tags_filtered',
   TYPE_FILTERED: 'gantry_type_filtered',
   SEARCHED: 'gantry_searched',
+  SORT_CHANGED: 'gantry_sort_changed',
+  ITEM_REORDERED: 'gantry_item_reordered',
 } as const;
 
 export function useGantryAnalytics() {
@@ -38,5 +40,7 @@ export function useGantryAnalytics() {
     onTagsFiltered: (tags: string[]) => capture(GANTRY_EVENTS.TAGS_FILTERED, { tags, tag_count: tags.length }),
     onTypeFiltered: (types: string[]) => capture(GANTRY_EVENTS.TYPE_FILTERED, { types, type_count: types.length }),
     onSearched: (query: string) => capture(GANTRY_EVENTS.SEARCHED, { query, query_length: query.length }),
+    onSortChanged: (sortOption: string) => capture(GANTRY_EVENTS.SORT_CHANGED, { sort_option: sortOption }),
+    onItemReordered: (itemUid: string, stage: string) => capture(GANTRY_EVENTS.ITEM_REORDERED, { itemUid, stage }),
   };
 }

--- a/analytics/gantry.analytics.ts
+++ b/analytics/gantry.analytics.ts
@@ -15,6 +15,7 @@ export const GANTRY_EVENTS = {
   BUILD_BUTTON_CLICKED: 'gantry_build_button_clicked',
   TAGS_FILTERED: 'gantry_tags_filtered',
   TYPE_FILTERED: 'gantry_type_filtered',
+  SEARCHED: 'gantry_searched',
 } as const;
 
 export function useGantryAnalytics() {
@@ -36,5 +37,6 @@ export function useGantryAnalytics() {
     onBuildButtonClicked: (itemUid: string) => capture(GANTRY_EVENTS.BUILD_BUTTON_CLICKED, { itemUid }),
     onTagsFiltered: (tags: string[]) => capture(GANTRY_EVENTS.TAGS_FILTERED, { tags, tag_count: tags.length }),
     onTypeFiltered: (types: string[]) => capture(GANTRY_EVENTS.TYPE_FILTERED, { types, type_count: types.length }),
+    onSearched: (query: string) => capture(GANTRY_EVENTS.SEARCHED, { query, query_length: query.length }),
   };
 }

--- a/components/page/gantry/roadmap/Roadmap.module.scss
+++ b/components/page/gantry/roadmap/Roadmap.module.scss
@@ -188,6 +188,14 @@
   }
 }
 
+.cardPlaceholder {
+  border: 1.5px dashed #d1d5db;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.5);
+  min-height: 64px;
+  flex-shrink: 0;
+}
+
 .cardDragOverlay {
   box-sizing: border-box;
   border: 1px solid #d1d5db;
@@ -202,6 +210,7 @@
 
 .cardHead {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
   margin-bottom: 8px;

--- a/components/page/gantry/roadmap/RoadmapCard.tsx
+++ b/components/page/gantry/roadmap/RoadmapCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useDraggable } from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { GantryItem } from '@/services/gantry/types';
 import { truncateText } from '@/utils/forum';
@@ -69,13 +69,14 @@ interface Props extends CardContentProps {}
 
 export function RoadmapCard({ item, canUpvote, onUpvoteToggle }: Props) {
   const cardNavigate = useGantryCardNavigate(item.uid);
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.uid,
     data: { stage: item.stage },
   });
 
   const style = {
-    transform: isDragging ? undefined : CSS.Translate.toString(transform),
+    transform: isDragging ? undefined : CSS.Transform.toString(transform),
+    transition,
     opacity: isDragging ? 0.35 : 1,
   };
 

--- a/components/page/gantry/roadmap/RoadmapFilters.tsx
+++ b/components/page/gantry/roadmap/RoadmapFilters.tsx
@@ -14,19 +14,22 @@ interface Props {
   readonly onSelectedTagsChange: (tags: string[]) => void;
   readonly selectedTypes: string[];
   readonly onSelectedTypesChange: (types: string[]) => void;
+  readonly searchText: string;
+  readonly onSearchTextChange: (text: string) => void;
 }
 
-export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange }: Props) {
+export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange, searchText, onSearchTextChange }: Props) {
   const clearParams = () => {
     onVisibleColumnsChange([...DEFAULT_ROADMAP_VISIBLE_COLUMNS]);
     onSelectedTagsChange([]);
     onSelectedTypesChange([]);
+    onSearchTextChange('');
   };
 
   return (
     <FiltersSidePanel
       clearParams={clearParams}
-      appliedFiltersCount={visibleColumns.length + selectedTags.length + selectedTypes.length}
+      appliedFiltersCount={visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}
       className={filterStyles.filterRail}
       hideFooter
     >
@@ -37,6 +40,8 @@ export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selecte
         onSelectedTagsChange={onSelectedTagsChange}
         selectedTypes={selectedTypes}
         onSelectedTypesChange={onSelectedTypesChange}
+        searchText={searchText}
+        onSearchTextChange={onSearchTextChange}
       />
     </FiltersSidePanel>
   );

--- a/components/page/gantry/roadmap/RoadmapFilters.tsx
+++ b/components/page/gantry/roadmap/RoadmapFilters.tsx
@@ -29,7 +29,7 @@ export function RoadmapFilters({ visibleColumns, onVisibleColumnsChange, selecte
   return (
     <FiltersSidePanel
       clearParams={clearParams}
-      appliedFiltersCount={visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}
+      appliedFiltersCount={selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}
       className={filterStyles.filterRail}
       hideFooter
     >

--- a/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
+++ b/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
@@ -37,7 +37,9 @@ export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, 
 
   return (
     <>
-      <SearchInput value={searchText} onChange={onSearchTextChange} placeholder="Search items..." />
+      <div>
+        <SearchInput value={searchText} onChange={onSearchTextChange} placeholder="Search items..." />
+      </div>
 
       <FilterSection title="Stages">
         <div>

--- a/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
+++ b/components/page/gantry/roadmap/RoadmapFiltersContent.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 import { FilterSection } from '@/components/common/filters/FilterSection';
 import { CheckboxListItemRepresentation } from '@/components/common/filters/GenericCheckboxList/components/CheckboxListItemRepresentation';
 import { FilterMultiSelect } from '@/components/common/filters/FilterSelect/FilterMultiSelect';
+import { SearchInput } from '@/components/common/filters/SearchInput';
 import {
   GANTRY_ITEM_TYPE_OPTIONS,
   GANTRY_ROADMAP_COLUMN_STAGES,
@@ -21,9 +22,11 @@ interface Props {
   readonly onSelectedTagsChange: (tags: string[]) => void;
   readonly selectedTypes: string[];
   readonly onSelectedTypesChange: (types: string[]) => void;
+  readonly searchText: string;
+  readonly onSearchTextChange: (text: string) => void;
 }
 
-export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange }: Props) {
+export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, selectedTags, onSelectedTagsChange, selectedTypes, onSelectedTypesChange, searchText, onSearchTextChange }: Props) {
   const toggleColumn = (stage: RoadmapColumnStage) => {
     if (visibleColumns.includes(stage)) {
       onVisibleColumnsChange(visibleColumns.filter((s) => s !== stage));
@@ -34,6 +37,8 @@ export function RoadmapFiltersContent({ visibleColumns, onVisibleColumnsChange, 
 
   return (
     <>
+      <SearchInput value={searchText} onChange={onSearchTextChange} placeholder="Search items..." />
+
       <FilterSection title="Stages">
         <div>
           {GANTRY_ROADMAP_COLUMN_STAGES.map((stage) => (

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -28,6 +28,7 @@ import {
   isPreRoadmapStage,
   sortRoadmapColumnStages,
 } from '@/services/gantry/constants';
+import { stripHtml } from '@/utils/forum';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
 import { IdeasSubmitButton } from '@/components/page/gantry/ideas/IdeasSubmitButton';
 import { SubmitIdeaModal } from '@/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal';
@@ -80,6 +81,11 @@ export function RoadmapView() {
   const handleSelectedTypesChange = (types: string[]) => {
     setSelectedTypes(types);
     if (types.length > 0) analytics.onTypeFiltered(types);
+  };
+  const [searchText, setSearchText] = useState<string>('');
+  const handleSearchTextChange = (text: string) => {
+    setSearchText(text);
+    if (text) analytics.onSearched(text);
   };
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
@@ -195,14 +201,21 @@ export function RoadmapView() {
       GantryItem[]
     >;
 
+    const lowerSearch = searchText.trim().toLowerCase();
+
     (data?.items ?? []).forEach((item) => {
-      if (isRoadmapColumnStage(item.stage) && item.stage in map) {
-        map[item.stage].push(item);
+      if (!isRoadmapColumnStage(item.stage) || !(item.stage in map)) return;
+      if (lowerSearch) {
+        const plainDesc = stripHtml(item.description ?? '');
+        const matches =
+          item.title.toLowerCase().includes(lowerSearch) || plainDesc.toLowerCase().includes(lowerSearch);
+        if (!matches) return;
       }
+      map[item.stage].push(item);
     });
 
     return map;
-  }, [data?.items, orderedVisibleColumns]);
+  }, [data?.items, orderedVisibleColumns, searchText]);
 
   const applyStageChange = async (itemUid: string, item: GantryItem, nextStage: GantryStage) => {
     if (nextStage === 'DECLINED') {
@@ -285,8 +298,8 @@ export function RoadmapView() {
                         />
                       </svg>
                       Filters
-                      {visibleColumns.length + selectedTags.length + selectedTypes.length > 0 && (
-                        <span className={s.filtersButtonBadge}>{visibleColumns.length + selectedTags.length + selectedTypes.length}</span>
+                      {visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0) > 0 && (
+                        <span className={s.filtersButtonBadge}>{visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}</span>
                       )}
                     </button>
                     {canCreate && (
@@ -344,7 +357,9 @@ export function RoadmapView() {
                       className={s.mobileColumn}
                     >
                       {itemsByStage[stage].length === 0 ? (
-                        <p className={s.mobileColumnEmpty}>No items in this stage.</p>
+                        <p className={s.mobileColumnEmpty}>
+                          {searchText ? 'No items match your search.' : 'No items in this stage.'}
+                        </p>
                       ) : (
                         itemsByStage[stage].map((item) => (
                           <RoadmapCard
@@ -371,6 +386,8 @@ export function RoadmapView() {
             onSelectedTagsChange={handleSelectedTagsChange}
             selectedTypes={selectedTypes}
             onSelectedTypesChange={handleSelectedTypesChange}
+            searchText={searchText}
+            onSearchTextChange={handleSearchTextChange}
           />
         </MobileDrawer>
 
@@ -396,6 +413,8 @@ export function RoadmapView() {
             onSelectedTagsChange={handleSelectedTagsChange}
             selectedTypes={selectedTypes}
             onSelectedTypesChange={handleSelectedTypesChange}
+            searchText={searchText}
+            onSearchTextChange={handleSearchTextChange}
           />
         }
         content={

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Children, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   DndContext,
   DragEndEvent,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
   PointerSensor,
@@ -12,6 +13,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
+import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import DashboardPagesLayout from '@/components/core/dashboard-pages-layout/DashboardPagesLayout';
 import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
@@ -25,9 +27,16 @@ import {
   DEFAULT_ROADMAP_VISIBLE_COLUMNS,
   GANTRY_ROADMAP_COLUMN_STAGES,
   GANTRY_VISIBLE_COLUMNS_STORAGE_KEY,
+  ROADMAP_SORT_OPTIONS,
   isPreRoadmapStage,
+  sortGantryItems,
+  sortGantryItemsByDate,
+  sortGantryItemsByDefault,
   sortRoadmapColumnStages,
+  type RoadmapSortOption,
 } from '@/services/gantry/constants';
+import { useReorderGantryItem } from '@/services/gantry/hooks/useReorderGantryItem';
+import { SortDropdown } from '@/components/common/filters/SortDropdown';
 import { stripHtml } from '@/utils/forum';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
 import { IdeasSubmitButton } from '@/components/page/gantry/ideas/IdeasSubmitButton';
@@ -43,14 +52,44 @@ import { RoadmapFiltersContent } from './RoadmapFiltersContent';
 import gantryPageStyles from '@/components/page/gantry/GantryPage.module.scss';
 import s from './Roadmap.module.scss';
 
-function RoadmapDropColumn({ stage, children }: { stage: RoadmapColumnStage; children: ReactNode }) {
+function RoadmapDropColumn({
+  stage,
+  children,
+  isAdminOrdering,
+  itemIds,
+  dropPreviewIndex,
+}: {
+  stage: RoadmapColumnStage;
+  children: ReactNode;
+  isAdminOrdering: boolean;
+  itemIds: string[];
+  dropPreviewIndex?: number;
+}) {
   const { isOver, setNodeRef } = useDroppable({ id: stage });
+  const childrenArray = Children.toArray(children);
+  const listItems: ReactNode[] = [];
+  for (let i = 0; i < childrenArray.length; i++) {
+    if (dropPreviewIndex === i) {
+      listItems.push(<div key="__placeholder" className={s.cardPlaceholder} aria-hidden />);
+    }
+    listItems.push(childrenArray[i]);
+  }
+  if (dropPreviewIndex !== undefined && dropPreviewIndex >= childrenArray.length) {
+    listItems.push(<div key="__placeholder" className={s.cardPlaceholder} aria-hidden />);
+  }
+  const list = <div className={s.list}>{listItems}</div>;
   return (
     <div ref={setNodeRef} className={s.column} data-over={isOver || undefined}>
       <div className={s.columnHeader}>
         <StageBadge stage={stage} className={s.columnHeaderBadge} />
       </div>
-      <div className={s.list}>{children}</div>
+      {isAdminOrdering ? (
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          {list}
+        </SortableContext>
+      ) : (
+        list
+      )}
     </div>
   );
 }
@@ -87,9 +126,19 @@ export function RoadmapView() {
     setSearchText(text);
     if (text) analytics.onSearched(text);
   };
+  const [sortOption, setSortOption] = useState<RoadmapSortOption>('default');
+  const handleSortChange = (value: string) => {
+    setSortOption(value as RoadmapSortOption);
+    analytics.onSortChanged(value);
+  };
+  const isAdminOrdering = canCurate && sortOption === 'default';
+  // Local uid-order overrides per stage, set immediately on admin drag so the display
+  // doesn't depend on whether the backend has persisted the `order` field yet.
+  const [adminOrderMap, setAdminOrderMap] = useState<Partial<Record<RoadmapColumnStage, string[]>>>({});
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
+  const [dropPreview, setDropPreview] = useState<{ columnId: RoadmapColumnStage; insertIndex: number } | null>(null);
 
   // Mobile layout state (< 1024px)
   const isNarrow = useIsNarrow();
@@ -114,6 +163,7 @@ export function RoadmapView() {
   const { data, isLoading, isError } = useGantryItems(params, !!currentUser && orderedVisibleColumns.length > 0);
   const transition = useGantryTransition();
   const upvote = useGantryUpvote();
+  const reorder = useReorderGantryItem();
 
   useEffect(() => {
     analytics.onRoadmapViewed();
@@ -214,8 +264,24 @@ export function RoadmapView() {
       map[item.stage].push(item);
     });
 
+    const sortFn =
+      sortOption === 'upvotes' ? sortGantryItems : sortOption === 'date' ? sortGantryItemsByDate : sortGantryItemsByDefault;
+    orderedVisibleColumns.forEach((stage) => {
+      map[stage] = sortFn(map[stage]);
+
+      // Apply local admin ordering override: preserves the user's drag position even
+      // when the server hasn't persisted the `order` field yet.
+      const adminOrder = adminOrderMap[stage];
+      if (adminOrder) {
+        const itemMap = new Map(map[stage].map((item) => [item.uid, item]));
+        const known = adminOrder.filter((uid) => itemMap.has(uid)).map((uid) => itemMap.get(uid)!);
+        const extra = map[stage].filter((item) => !new Set(adminOrder).has(item.uid));
+        map[stage] = [...known, ...extra];
+      }
+    });
+
     return map;
-  }, [data?.items, orderedVisibleColumns, searchText]);
+  }, [data?.items, orderedVisibleColumns, searchText, sortOption, adminOrderMap]);
 
   const applyStageChange = async (itemUid: string, item: GantryItem, nextStage: GantryStage) => {
     if (nextStage === 'DECLINED') {
@@ -231,6 +297,32 @@ export function RoadmapView() {
     await transition.mutateAsync({ uid: itemUid, payload: { type: 'transition', stage: nextStage } });
   };
 
+  const applyReorder = async (activeId: string, overId: string) => {
+    const activeItem = data?.items.find((i) => i.uid === activeId);
+    if (!activeItem || !isRoadmapColumnStage(activeItem.stage)) return;
+    const columnItems = itemsByStage[activeItem.stage];
+    const activeIdx = columnItems.findIndex((i) => i.uid === activeId);
+    const overIdx = columnItems.findIndex((i) => i.uid === overId);
+    if (activeIdx === -1 || overIdx === -1 || activeIdx === overIdx) return;
+
+    const reordered = arrayMove(columnItems, activeIdx, overIdx);
+
+    // Update local display order immediately — the visual position is driven by this,
+    // not by the server `order` field, so it works even when all items have order=null.
+    setAdminOrderMap((prev) => ({ ...prev, [activeItem.stage]: reordered.map((i) => i.uid) }));
+
+    // Compute fractional order for the backend PATCH.
+    const BASE = 1000;
+    const prev = reordered[overIdx - 1];
+    const next = reordered[overIdx + 1];
+    const prevOrder = prev?.order ?? (overIdx - 1) * BASE;
+    const nextOrder = next?.order ?? (overIdx + 1) * BASE;
+    const newOrder = (prevOrder + nextOrder) / 2;
+
+    analytics.onItemReordered(activeId, activeItem.stage);
+    await reorder.mutateAsync({ uid: activeId, order: newOrder });
+  };
+
   const activeDragItem = useMemo(
     () => (activeDragId ? data?.items.find((i) => i.uid === activeDragId) : undefined),
     [activeDragId, data?.items],
@@ -239,6 +331,7 @@ export function RoadmapView() {
   const clearActiveDrag = () => {
     setActiveDragId(null);
     setActiveDragWidth(null);
+    setDropPreview(null);
   };
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -246,17 +339,82 @@ export function RoadmapView() {
     setActiveDragWidth(event.active.rect.current.initial?.width ?? null);
   };
 
+  const handleDragOver = (event: DragOverEvent) => {
+    const activeId = String(event.active.id);
+    const overId = event.over?.id ? String(event.over.id) : null;
+    if (!overId) { setDropPreview(null); return; }
+
+    const draggedItem = data?.items.find((i) => i.uid === activeId);
+    let targetStage: RoadmapColumnStage | null = null;
+    let insertIndex: number;
+
+    if (isRoadmapColumnStage(overId)) {
+      targetStage = overId;
+      insertIndex = itemsByStage[overId]?.length ?? 0;
+    } else {
+      const overItem = data?.items.find((i) => i.uid === overId);
+      if (!overItem || !isRoadmapColumnStage(overItem.stage)) { setDropPreview(null); return; }
+      targetStage = overItem.stage;
+      const columnItems = itemsByStage[targetStage] ?? [];
+      const overIdx = columnItems.findIndex((i) => i.uid === overId);
+      if (overIdx === -1) { setDropPreview(null); return; }
+      const activeTranslated = event.active.rect.current.translated;
+      const overRect = event.over?.rect;
+      let insertBefore = true;
+      if (activeTranslated && overRect) {
+        const activeCenterY = activeTranslated.top + activeTranslated.height / 2;
+        const overCenterY = overRect.top + overRect.height / 2;
+        insertBefore = activeCenterY < overCenterY;
+      }
+      insertIndex = insertBefore ? overIdx : overIdx + 1;
+    }
+
+    if (!targetStage || !draggedItem || draggedItem.stage === targetStage) { setDropPreview(null); return; }
+    setDropPreview({ columnId: targetStage, insertIndex });
+  };
+
+  // Pre-seeds adminOrderMap for the destination column so the card lands at the drop
+  // position after the React Query refetch, not wherever the sort function would put it.
+  const lockDropPosition = (activeId: string, destStage: RoadmapColumnStage, preview: typeof dropPreview) => {
+    const columnUids = itemsByStage[destStage].map((i) => i.uid);
+    const insertIndex = preview?.columnId === destStage ? preview.insertIndex : columnUids.length;
+    const newOrder = [...columnUids.slice(0, insertIndex), activeId, ...columnUids.slice(insertIndex)];
+    setAdminOrderMap((prev) => ({ ...prev, [destStage]: newOrder }));
+  };
+
   const handleDragEnd = async (event: DragEndEvent) => {
+    const savedDropPreview = dropPreview; // capture before clearActiveDrag clears it
     clearActiveDrag();
-    if (!canTransition) return;
-    const itemUid = String(event.active.id);
-    const nextStage = event.over?.id ? String(event.over.id) : null;
-    if (!nextStage || !isRoadmapColumnStage(nextStage) || !orderedVisibleColumns.includes(nextStage)) return;
+    const activeId = String(event.active.id);
+    const overId = event.over?.id ? String(event.over.id) : null;
+    if (!overId) return;
 
-    const item = data?.items.find((i) => i.uid === itemUid);
-    if (!item || item.stage === nextStage) return;
+    // over a card uid (same or different column)
+    if (!isRoadmapColumnStage(overId)) {
+      const activeItem = data?.items.find((i) => i.uid === activeId);
+      const overItem = data?.items.find((i) => i.uid === overId);
+      if (!activeItem || !overItem) return;
 
-    await applyStageChange(itemUid, item, nextStage);
+      // Different stages → treat as cross-column move
+      if (activeItem.stage !== overItem.stage) {
+        if (!canTransition || !isRoadmapColumnStage(overItem.stage) || !orderedVisibleColumns.includes(overItem.stage)) return;
+        lockDropPosition(activeId, overItem.stage, savedDropPreview);
+        await applyStageChange(activeId, activeItem, overItem.stage);
+        return;
+      }
+
+      // Same stage → within-column reorder (admin only, default sort only)
+      if (!isAdminOrdering) return;
+      await applyReorder(activeId, overId);
+      return;
+    }
+
+    // over a stage droppable → cross-column move
+    if (!canTransition || !orderedVisibleColumns.includes(overId)) return;
+    const item = data?.items.find((i) => i.uid === activeId);
+    if (!item || item.stage === overId) return;
+    lockDropPosition(activeId, overId, savedDropPreview);
+    await applyStageChange(activeId, item, overId);
   };
 
   const handleDragCancel = () => {
@@ -288,6 +446,11 @@ export function RoadmapView() {
                 <div className={s.titleInline}>
                   <h1 className={s.title}>Gantry</h1>
                   <div className={s.mobileActionsRow}>
+                    <SortDropdown
+                      options={ROADMAP_SORT_OPTIONS}
+                      currentSort={sortOption}
+                      onSortChange={handleSortChange}
+                    />
                     <button className={s.filtersButton} onClick={() => setFiltersOpen(true)} type="button">
                       <svg className={s.filtersButtonIcon} viewBox="0 0 16 16" fill="none" aria-hidden>
                         <path
@@ -438,14 +601,19 @@ export function RoadmapView() {
                       Submit what you need, see what we are building. The shortest path to the LabOS roadmap.
                     </p>
                   </div>
-                  {canCreate && (
-                    <div className={s.actions}>
+                  <div className={s.actions}>
+                    <SortDropdown
+                      options={ROADMAP_SORT_OPTIONS}
+                      currentSort={sortOption}
+                      onSortChange={handleSortChange}
+                    />
+                    {canCreate && (
                       <IdeasSubmitButton
                         label={createLabel}
                         onClick={() => submitIdeaModalActions.openModal(createVariant)}
                       />
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -469,6 +637,7 @@ export function RoadmapView() {
                   <DndContext
                     sensors={sensors}
                     onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
                     onDragEnd={handleDragEnd}
                     onDragCancel={handleDragCancel}
                   >
@@ -477,7 +646,13 @@ export function RoadmapView() {
                       style={{ gridTemplateColumns: `repeat(${orderedVisibleColumns.length}, minmax(240px, 1fr))` }}
                     >
                       {orderedVisibleColumns.map((stage) => (
-                        <RoadmapDropColumn key={stage} stage={stage}>
+                        <RoadmapDropColumn
+                          key={stage}
+                          stage={stage}
+                          isAdminOrdering={isAdminOrdering}
+                          itemIds={itemsByStage[stage].map((i) => i.uid)}
+                          dropPreviewIndex={dropPreview?.columnId === stage ? dropPreview.insertIndex : undefined}
+                        >
                           {itemsByStage[stage].map((item) => (
                             <RoadmapCard
                               key={item.uid}

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -298,8 +298,8 @@ export function RoadmapView() {
                         />
                       </svg>
                       Filters
-                      {visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0) > 0 && (
-                        <span className={s.filtersButtonBadge}>{visibleColumns.length + selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}</span>
+                      {selectedTags.length + selectedTypes.length + (searchText ? 1 : 0) > 0 && (
+                        <span className={s.filtersButtonBadge}>{selectedTags.length + selectedTypes.length + (searchText ? 1 : 0)}</span>
                       )}
                     </button>
                     {canCreate && (

--- a/components/page/gantry/shared/Shared.module.scss
+++ b/components/page/gantry/shared/Shared.module.scss
@@ -50,17 +50,17 @@
 .upvote {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   padding: 0;
   border: none;
   background: transparent;
   color: #8897ae;
   font-size: 12px;
   font-weight: 400;
-  line-height: 18px;
   letter-spacing: -0.2px;
   cursor: pointer;
   transition: color 0.15s ease;
+  min-width: 24px;
 
   &:hover:not(:disabled) {
     color: #6b7b93;

--- a/services/gantry/constants.ts
+++ b/services/gantry/constants.ts
@@ -59,6 +59,29 @@ export function sortGantryItems(items: GantryItem[]): GantryItem[] {
   });
 }
 
+/** Admin-curated order ASC; items with null order sort to the end. */
+export function sortGantryItemsByDefault(items: GantryItem[]): GantryItem[] {
+  return [...items].sort((a, b) => {
+    if (a.order == null && b.order == null) return 0;
+    if (a.order == null) return 1;
+    if (b.order == null) return -1;
+    return a.order - b.order;
+  });
+}
+
+/** Newest created first. */
+export function sortGantryItemsByDate(items: GantryItem[]): GantryItem[] {
+  return [...items].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+export const ROADMAP_SORT_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'upvotes', label: 'By upvotes' },
+  { value: 'date', label: 'By date' },
+] as const;
+
+export type RoadmapSortOption = (typeof ROADMAP_SORT_OPTIONS)[number]['value'];
+
 /**
  * Stage transitions are unrestricted for members with the transition permission —
  * an item can move from any stage to any other stage. The selector simply offers

--- a/services/gantry/hooks/useGantryTransition.ts
+++ b/services/gantry/hooks/useGantryTransition.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { declineGantryItem, promoteGantryItem, transitionGantryItem } from '../gantry.service';
 import { GantryQueryKeys } from '../constants';
-import type { GantryStage } from '../types';
+import type { GantryItemListResponse, GantryStage } from '../types';
 
 type TransitionPayload =
   | { type: 'promote' }
@@ -15,6 +15,12 @@ type TransitionMutationPayload = {
   payload: TransitionPayload;
 };
 
+function resolveTargetStage(payload: TransitionPayload): GantryStage {
+  if (payload.type === 'promote') return 'PLANNED';
+  if (payload.type === 'decline') return 'DECLINED';
+  return payload.stage;
+}
+
 export function useGantryTransition() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -23,11 +29,22 @@ export function useGantryTransition() {
       if (payload.type === 'decline') return declineGantryItem(uid, payload.reason);
       return transitionGantryItem(uid, payload.stage);
     },
-    onSuccess: async (_result, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] }),
-        queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEM, variables.uid] }),
-      ]);
+    onMutate: async ({ uid, payload }) => {
+      await queryClient.cancelQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      const targetStage = resolveTargetStage(payload);
+      const snapshot = queryClient.getQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.setQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] }, (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.map((item) => (item.uid === uid ? { ...item, stage: targetStage } : item)) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _variables, context) => {
+      context?.snapshot.forEach(([queryKey, data]) => queryClient.setQueryData(queryKey, data));
+    },
+    onSettled: (_result, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEM, variables.uid] });
     },
   });
 }

--- a/services/gantry/hooks/useReorderGantryItem.ts
+++ b/services/gantry/hooks/useReorderGantryItem.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateGantryItem } from '../gantry.service';
+import { GantryQueryKeys } from '../constants';
+import type { GantryItemListResponse } from '../types';
+
+export function useReorderGantryItem() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ uid, order }: { uid: string; order: number }) => updateGantryItem(uid, { order }),
+    onMutate: async ({ uid, order }) => {
+      await queryClient.cancelQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.setQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] }, (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.map((item) => (item.uid === uid ? { ...item, order } : item)) };
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+    },
+  });
+}

--- a/services/gantry/types.ts
+++ b/services/gantry/types.ts
@@ -17,6 +17,7 @@ export interface GantryItem {
   focusArea: string | null;
   tags: string[] | null;
   type: GantryItemType | null;
+  order: number | null;
   createdByUid: string;
   createdBy: GantryMemberSummary;
   promotedAt: string | null;
@@ -64,4 +65,5 @@ export interface UpdateGantryItemPayload {
   externalTrackerUrl?: string | null;
   tags?: string[];
   type?: GantryItemType | null;
+  order?: number | null;
 }


### PR DESCRIPTION
## Summary

- Adds a `SearchInput` field at the **top of the Gantry filter sidebar** (above the Stages section) on both desktop and mobile
- Filters Kanban cards by **title** and **description** (HTML stripped via `stripHtml` from `@/utils/forum`) — case-insensitive `String.includes` match
- **Client-side only** — no API changes, no new query params; filters the already-fetched `data.items` list inside the `itemsByStage` memo
- **700ms debounce** built into the existing `SearchInput`/`DebouncedInput` component — no extra hook needed in `RoadmapView`
- Non-empty search text counts as **+1** toward the filter badge on both desktop (`appliedFiltersCount`) and mobile (inline badge expression)
- **"Clear All"** in the desktop sidebar resets search text along with columns/tags/type
- Mobile empty-state message differentiates: _"No items match your search."_ when a search is active vs _"No items in this stage."_ otherwise
- PostHog **`gantry_searched`** event fires on each debounced query

## Files changed

| File | Change |
|---|---|
| `components/page/gantry/roadmap/RoadmapView.tsx` | Add `searchText` state, filter predicate in `itemsByStage`, prop threading, badge + empty state |
| `components/page/gantry/roadmap/RoadmapFiltersContent.tsx` | Add props, render `SearchInput` at top |
| `components/page/gantry/roadmap/RoadmapFilters.tsx` | Add props, update `clearParams` + `appliedFiltersCount` |
| `analytics/gantry.analytics.ts` | Add `SEARCHED` event + `onSearched` |

## Test plan

- [ ] Type in the search field — cards filter after ~700ms to those matching the query in title or description
- [ ] Clear via the X button inside the field — board resets immediately
- [ ] "Clear All" resets the search field along with all other filters
- [ ] Desktop filter badge includes +1 when search is active
- [ ] Mobile Filters button badge includes +1 when search is active
- [ ] Mobile: open drawer, type search, close — board remains filtered
- [ ] Columns with no matching items show "No items match your search." (not the generic empty state)
- [ ] `npm run build` passes with no TypeScript errors

## Known deferred

- Mobile drawer has no "Clear All" button (pre-existing) — the X in `SearchInput` is sufficient for mobile
- Escape key on mobile competes between `MobileDrawer` close and `DebouncedInput` clear — left as-is (low priority)

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)