### PR TITLE
feat(gantry): sort dropdown + admin drag-to-reorder on roadmap

### DIFF
--- a/analytics/gantry.analytics.ts
+++ b/analytics/gantry.analytics.ts
@@ -16,6 +16,8 @@ export const GANTRY_EVENTS = {
   TAGS_FILTERED: 'gantry_tags_filtered',
   TYPE_FILTERED: 'gantry_type_filtered',
   SEARCHED: 'gantry_searched',
+  SORT_CHANGED: 'gantry_sort_changed',
+  ITEM_REORDERED: 'gantry_item_reordered',
 } as const;
 
 export function useGantryAnalytics() {
@@ -38,5 +40,7 @@ export function useGantryAnalytics() {
     onTagsFiltered: (tags: string[]) => capture(GANTRY_EVENTS.TAGS_FILTERED, { tags, tag_count: tags.length }),
     onTypeFiltered: (types: string[]) => capture(GANTRY_EVENTS.TYPE_FILTERED, { types, type_count: types.length }),
     onSearched: (query: string) => capture(GANTRY_EVENTS.SEARCHED, { query, query_length: query.length }),
+    onSortChanged: (sortOption: string) => capture(GANTRY_EVENTS.SORT_CHANGED, { sort_option: sortOption }),
+    onItemReordered: (itemUid: string, stage: string) => capture(GANTRY_EVENTS.ITEM_REORDERED, { itemUid, stage }),
   };
 }

--- a/components/page/gantry/roadmap/Roadmap.module.scss
+++ b/components/page/gantry/roadmap/Roadmap.module.scss
@@ -188,6 +188,14 @@
   }
 }
 
+.cardPlaceholder {
+  border: 1.5px dashed #d1d5db;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.5);
+  min-height: 64px;
+  flex-shrink: 0;
+}
+
 .cardDragOverlay {
   box-sizing: border-box;
   border: 1px solid #d1d5db;

--- a/components/page/gantry/roadmap/Roadmap.module.scss
+++ b/components/page/gantry/roadmap/Roadmap.module.scss
@@ -202,6 +202,7 @@
 
 .cardHead {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
   margin-bottom: 8px;

--- a/components/page/gantry/roadmap/RoadmapCard.tsx
+++ b/components/page/gantry/roadmap/RoadmapCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useDraggable } from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { GantryItem } from '@/services/gantry/types';
 import { truncateText } from '@/utils/forum';
@@ -69,13 +69,14 @@ interface Props extends CardContentProps {}
 
 export function RoadmapCard({ item, canUpvote, onUpvoteToggle }: Props) {
   const cardNavigate = useGantryCardNavigate(item.uid);
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.uid,
     data: { stage: item.stage },
   });
 
   const style = {
-    transform: isDragging ? undefined : CSS.Translate.toString(transform),
+    transform: isDragging ? undefined : CSS.Transform.toString(transform),
+    transition,
     opacity: isDragging ? 0.35 : 1,
   };
 

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Children, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   DndContext,
   DragEndEvent,
@@ -57,21 +57,27 @@ function RoadmapDropColumn({
   children,
   isAdminOrdering,
   itemIds,
-  isDropTarget,
+  dropPreviewIndex,
 }: {
   stage: RoadmapColumnStage;
   children: ReactNode;
   isAdminOrdering: boolean;
   itemIds: string[];
-  isDropTarget: boolean;
+  dropPreviewIndex?: number;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id: stage });
-  const list = (
-    <div className={s.list}>
-      {children}
-      {isDropTarget && <div className={s.cardPlaceholder} aria-hidden />}
-    </div>
-  );
+  const childrenArray = Children.toArray(children);
+  const listItems: ReactNode[] = [];
+  for (let i = 0; i < childrenArray.length; i++) {
+    if (dropPreviewIndex === i) {
+      listItems.push(<div key="__placeholder" className={s.cardPlaceholder} aria-hidden />);
+    }
+    listItems.push(childrenArray[i]);
+  }
+  if (dropPreviewIndex !== undefined && dropPreviewIndex >= childrenArray.length) {
+    listItems.push(<div key="__placeholder" className={s.cardPlaceholder} aria-hidden />);
+  }
+  const list = <div className={s.list}>{listItems}</div>;
   return (
     <div ref={setNodeRef} className={s.column} data-over={isOver || undefined}>
       <div className={s.columnHeader}>
@@ -132,7 +138,7 @@ export function RoadmapView() {
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
-  const [overColumnId, setOverColumnId] = useState<RoadmapColumnStage | null>(null);
+  const [dropPreview, setDropPreview] = useState<{ columnId: RoadmapColumnStage; insertIndex: number } | null>(null);
 
   // Mobile layout state (< 1024px)
   const isNarrow = useIsNarrow();
@@ -325,7 +331,7 @@ export function RoadmapView() {
   const clearActiveDrag = () => {
     setActiveDragId(null);
     setActiveDragWidth(null);
-    setOverColumnId(null);
+    setDropPreview(null);
   };
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -334,15 +340,50 @@ export function RoadmapView() {
   };
 
   const handleDragOver = (event: DragOverEvent) => {
+    const activeId = String(event.active.id);
     const overId = event.over?.id ? String(event.over.id) : null;
-    if (!overId) { setOverColumnId(null); return; }
-    if (isRoadmapColumnStage(overId)) { setOverColumnId(overId); return; }
-    // overId is a card uid — resolve to its stage
-    const overItem = data?.items.find((i) => i.uid === overId);
-    setOverColumnId(overItem && isRoadmapColumnStage(overItem.stage) ? overItem.stage : null);
+    if (!overId) { setDropPreview(null); return; }
+
+    const draggedItem = data?.items.find((i) => i.uid === activeId);
+    let targetStage: RoadmapColumnStage | null = null;
+    let insertIndex: number;
+
+    if (isRoadmapColumnStage(overId)) {
+      targetStage = overId;
+      insertIndex = itemsByStage[overId]?.length ?? 0;
+    } else {
+      const overItem = data?.items.find((i) => i.uid === overId);
+      if (!overItem || !isRoadmapColumnStage(overItem.stage)) { setDropPreview(null); return; }
+      targetStage = overItem.stage;
+      const columnItems = itemsByStage[targetStage] ?? [];
+      const overIdx = columnItems.findIndex((i) => i.uid === overId);
+      if (overIdx === -1) { setDropPreview(null); return; }
+      const activeTranslated = event.active.rect.current.translated;
+      const overRect = event.over?.rect;
+      let insertBefore = true;
+      if (activeTranslated && overRect) {
+        const activeCenterY = activeTranslated.top + activeTranslated.height / 2;
+        const overCenterY = overRect.top + overRect.height / 2;
+        insertBefore = activeCenterY < overCenterY;
+      }
+      insertIndex = insertBefore ? overIdx : overIdx + 1;
+    }
+
+    if (!targetStage || !draggedItem || draggedItem.stage === targetStage) { setDropPreview(null); return; }
+    setDropPreview({ columnId: targetStage, insertIndex });
+  };
+
+  // Pre-seeds adminOrderMap for the destination column so the card lands at the drop
+  // position after the React Query refetch, not wherever the sort function would put it.
+  const lockDropPosition = (activeId: string, destStage: RoadmapColumnStage, preview: typeof dropPreview) => {
+    const columnUids = itemsByStage[destStage].map((i) => i.uid);
+    const insertIndex = preview?.columnId === destStage ? preview.insertIndex : columnUids.length;
+    const newOrder = [...columnUids.slice(0, insertIndex), activeId, ...columnUids.slice(insertIndex)];
+    setAdminOrderMap((prev) => ({ ...prev, [destStage]: newOrder }));
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
+    const savedDropPreview = dropPreview; // capture before clearActiveDrag clears it
     clearActiveDrag();
     const activeId = String(event.active.id);
     const overId = event.over?.id ? String(event.over.id) : null;
@@ -357,6 +398,7 @@ export function RoadmapView() {
       // Different stages → treat as cross-column move
       if (activeItem.stage !== overItem.stage) {
         if (!canTransition || !isRoadmapColumnStage(overItem.stage) || !orderedVisibleColumns.includes(overItem.stage)) return;
+        lockDropPosition(activeId, overItem.stage, savedDropPreview);
         await applyStageChange(activeId, activeItem, overItem.stage);
         return;
       }
@@ -371,6 +413,7 @@ export function RoadmapView() {
     if (!canTransition || !orderedVisibleColumns.includes(overId)) return;
     const item = data?.items.find((i) => i.uid === activeId);
     if (!item || item.stage === overId) return;
+    lockDropPosition(activeId, overId, savedDropPreview);
     await applyStageChange(activeId, item, overId);
   };
 
@@ -608,7 +651,7 @@ export function RoadmapView() {
                           stage={stage}
                           isAdminOrdering={isAdminOrdering}
                           itemIds={itemsByStage[stage].map((i) => i.uid)}
-                          isDropTarget={overColumnId === stage && !!activeDragItem && activeDragItem.stage !== stage}
+                          dropPreviewIndex={dropPreview?.columnId === stage ? dropPreview.insertIndex : undefined}
                         >
                           {itemsByStage[stage].map((item) => (
                             <RoadmapCard

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   DndContext,
   DragEndEvent,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
   PointerSensor,
@@ -56,14 +57,21 @@ function RoadmapDropColumn({
   children,
   isAdminOrdering,
   itemIds,
+  isDropTarget,
 }: {
   stage: RoadmapColumnStage;
   children: ReactNode;
   isAdminOrdering: boolean;
   itemIds: string[];
+  isDropTarget: boolean;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id: stage });
-  const list = <div className={s.list}>{children}</div>;
+  const list = (
+    <div className={s.list}>
+      {children}
+      {isDropTarget && <div className={s.cardPlaceholder} aria-hidden />}
+    </div>
+  );
   return (
     <div ref={setNodeRef} className={s.column} data-over={isOver || undefined}>
       <div className={s.columnHeader}>
@@ -124,6 +132,7 @@ export function RoadmapView() {
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
+  const [overColumnId, setOverColumnId] = useState<RoadmapColumnStage | null>(null);
 
   // Mobile layout state (< 1024px)
   const isNarrow = useIsNarrow();
@@ -316,11 +325,21 @@ export function RoadmapView() {
   const clearActiveDrag = () => {
     setActiveDragId(null);
     setActiveDragWidth(null);
+    setOverColumnId(null);
   };
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveDragId(String(event.active.id));
     setActiveDragWidth(event.active.rect.current.initial?.width ?? null);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const overId = event.over?.id ? String(event.over.id) : null;
+    if (!overId) { setOverColumnId(null); return; }
+    if (isRoadmapColumnStage(overId)) { setOverColumnId(overId); return; }
+    // overId is a card uid — resolve to its stage
+    const overItem = data?.items.find((i) => i.uid === overId);
+    setOverColumnId(overItem && isRoadmapColumnStage(overItem.stage) ? overItem.stage : null);
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
@@ -575,6 +594,7 @@ export function RoadmapView() {
                   <DndContext
                     sensors={sensors}
                     onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
                     onDragEnd={handleDragEnd}
                     onDragCancel={handleDragCancel}
                   >
@@ -588,6 +608,7 @@ export function RoadmapView() {
                           stage={stage}
                           isAdminOrdering={isAdminOrdering}
                           itemIds={itemsByStage[stage].map((i) => i.uid)}
+                          isDropTarget={overColumnId === stage && !!activeDragItem && activeDragItem.stage !== stage}
                         >
                           {itemsByStage[stage].map((item) => (
                             <RoadmapCard

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -12,6 +12,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
+import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import DashboardPagesLayout from '@/components/core/dashboard-pages-layout/DashboardPagesLayout';
 import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
 import { useIsNarrow } from '@/hooks/useIsNarrow';
@@ -25,9 +26,16 @@ import {
   DEFAULT_ROADMAP_VISIBLE_COLUMNS,
   GANTRY_ROADMAP_COLUMN_STAGES,
   GANTRY_VISIBLE_COLUMNS_STORAGE_KEY,
+  ROADMAP_SORT_OPTIONS,
   isPreRoadmapStage,
+  sortGantryItems,
+  sortGantryItemsByDate,
+  sortGantryItemsByDefault,
   sortRoadmapColumnStages,
+  type RoadmapSortOption,
 } from '@/services/gantry/constants';
+import { useReorderGantryItem } from '@/services/gantry/hooks/useReorderGantryItem';
+import { SortDropdown } from '@/components/common/filters/SortDropdown';
 import { stripHtml } from '@/utils/forum';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
 import { IdeasSubmitButton } from '@/components/page/gantry/ideas/IdeasSubmitButton';
@@ -43,14 +51,31 @@ import { RoadmapFiltersContent } from './RoadmapFiltersContent';
 import gantryPageStyles from '@/components/page/gantry/GantryPage.module.scss';
 import s from './Roadmap.module.scss';
 
-function RoadmapDropColumn({ stage, children }: { stage: RoadmapColumnStage; children: ReactNode }) {
+function RoadmapDropColumn({
+  stage,
+  children,
+  isAdminOrdering,
+  itemIds,
+}: {
+  stage: RoadmapColumnStage;
+  children: ReactNode;
+  isAdminOrdering: boolean;
+  itemIds: string[];
+}) {
   const { isOver, setNodeRef } = useDroppable({ id: stage });
+  const list = <div className={s.list}>{children}</div>;
   return (
     <div ref={setNodeRef} className={s.column} data-over={isOver || undefined}>
       <div className={s.columnHeader}>
         <StageBadge stage={stage} className={s.columnHeaderBadge} />
       </div>
-      <div className={s.list}>{children}</div>
+      {isAdminOrdering ? (
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          {list}
+        </SortableContext>
+      ) : (
+        list
+      )}
     </div>
   );
 }
@@ -87,6 +112,12 @@ export function RoadmapView() {
     setSearchText(text);
     if (text) analytics.onSearched(text);
   };
+  const [sortOption, setSortOption] = useState<RoadmapSortOption>('default');
+  const handleSortChange = (value: string) => {
+    setSortOption(value as RoadmapSortOption);
+    analytics.onSortChanged(value);
+  };
+  const isAdminOrdering = canCurate && sortOption === 'default';
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
@@ -114,6 +145,7 @@ export function RoadmapView() {
   const { data, isLoading, isError } = useGantryItems(params, !!currentUser && orderedVisibleColumns.length > 0);
   const transition = useGantryTransition();
   const upvote = useGantryUpvote();
+  const reorder = useReorderGantryItem();
 
   useEffect(() => {
     analytics.onRoadmapViewed();
@@ -214,8 +246,14 @@ export function RoadmapView() {
       map[item.stage].push(item);
     });
 
+    const sortFn =
+      sortOption === 'upvotes' ? sortGantryItems : sortOption === 'date' ? sortGantryItemsByDate : sortGantryItemsByDefault;
+    orderedVisibleColumns.forEach((stage) => {
+      map[stage] = sortFn(map[stage]);
+    });
+
     return map;
-  }, [data?.items, orderedVisibleColumns, searchText]);
+  }, [data?.items, orderedVisibleColumns, searchText, sortOption]);
 
   const applyStageChange = async (itemUid: string, item: GantryItem, nextStage: GantryStage) => {
     if (nextStage === 'DECLINED') {
@@ -229,6 +267,27 @@ export function RoadmapView() {
     }
 
     await transition.mutateAsync({ uid: itemUid, payload: { type: 'transition', stage: nextStage } });
+  };
+
+  const applyReorder = async (activeId: string, overId: string) => {
+    const activeItem = data?.items.find((i) => i.uid === activeId);
+    if (!activeItem || !isRoadmapColumnStage(activeItem.stage)) return;
+    const columnItems = itemsByStage[activeItem.stage];
+    const activeIdx = columnItems.findIndex((i) => i.uid === activeId);
+    const overIdx = columnItems.findIndex((i) => i.uid === overId);
+    if (activeIdx === -1 || overIdx === -1 || activeIdx === overIdx) return;
+
+    const reordered = arrayMove(columnItems, activeIdx, overIdx);
+    const newIdx = reordered.findIndex((i) => i.uid === activeId);
+    const BASE = 1000;
+    const prev = reordered[newIdx - 1];
+    const next = reordered[newIdx + 1];
+    const prevOrder = prev?.order ?? (newIdx - 1) * BASE;
+    const nextOrder = next?.order ?? (newIdx + 1) * BASE;
+    const newOrder = (prevOrder + nextOrder) / 2;
+
+    analytics.onItemReordered(activeId, activeItem.stage);
+    await reorder.mutateAsync({ uid: activeId, order: newOrder });
   };
 
   const activeDragItem = useMemo(
@@ -248,15 +307,34 @@ export function RoadmapView() {
 
   const handleDragEnd = async (event: DragEndEvent) => {
     clearActiveDrag();
-    if (!canTransition) return;
-    const itemUid = String(event.active.id);
-    const nextStage = event.over?.id ? String(event.over.id) : null;
-    if (!nextStage || !isRoadmapColumnStage(nextStage) || !orderedVisibleColumns.includes(nextStage)) return;
+    const activeId = String(event.active.id);
+    const overId = event.over?.id ? String(event.over.id) : null;
+    if (!overId) return;
 
-    const item = data?.items.find((i) => i.uid === itemUid);
-    if (!item || item.stage === nextStage) return;
+    // over a card uid (same or different column)
+    if (!isRoadmapColumnStage(overId)) {
+      const activeItem = data?.items.find((i) => i.uid === activeId);
+      const overItem = data?.items.find((i) => i.uid === overId);
+      if (!activeItem || !overItem) return;
 
-    await applyStageChange(itemUid, item, nextStage);
+      // Different stages → treat as cross-column move
+      if (activeItem.stage !== overItem.stage) {
+        if (!canTransition || !isRoadmapColumnStage(overItem.stage) || !orderedVisibleColumns.includes(overItem.stage)) return;
+        await applyStageChange(activeId, activeItem, overItem.stage);
+        return;
+      }
+
+      // Same stage → within-column reorder (admin only, default sort only)
+      if (!isAdminOrdering) return;
+      await applyReorder(activeId, overId);
+      return;
+    }
+
+    // over a stage droppable → cross-column move
+    if (!canTransition || !orderedVisibleColumns.includes(overId)) return;
+    const item = data?.items.find((i) => i.uid === activeId);
+    if (!item || item.stage === overId) return;
+    await applyStageChange(activeId, item, overId);
   };
 
   const handleDragCancel = () => {
@@ -288,6 +366,11 @@ export function RoadmapView() {
                 <div className={s.titleInline}>
                   <h1 className={s.title}>Gantry</h1>
                   <div className={s.mobileActionsRow}>
+                    <SortDropdown
+                      options={ROADMAP_SORT_OPTIONS}
+                      currentSort={sortOption}
+                      onSortChange={handleSortChange}
+                    />
                     <button className={s.filtersButton} onClick={() => setFiltersOpen(true)} type="button">
                       <svg className={s.filtersButtonIcon} viewBox="0 0 16 16" fill="none" aria-hidden>
                         <path
@@ -438,14 +521,19 @@ export function RoadmapView() {
                       Submit what you need, see what we are building. The shortest path to the LabOS roadmap.
                     </p>
                   </div>
-                  {canCreate && (
-                    <div className={s.actions}>
+                  <div className={s.actions}>
+                    <SortDropdown
+                      options={ROADMAP_SORT_OPTIONS}
+                      currentSort={sortOption}
+                      onSortChange={handleSortChange}
+                    />
+                    {canCreate && (
                       <IdeasSubmitButton
                         label={createLabel}
                         onClick={() => submitIdeaModalActions.openModal(createVariant)}
                       />
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -477,7 +565,12 @@ export function RoadmapView() {
                       style={{ gridTemplateColumns: `repeat(${orderedVisibleColumns.length}, minmax(240px, 1fr))` }}
                     >
                       {orderedVisibleColumns.map((stage) => (
-                        <RoadmapDropColumn key={stage} stage={stage}>
+                        <RoadmapDropColumn
+                          key={stage}
+                          stage={stage}
+                          isAdminOrdering={isAdminOrdering}
+                          itemIds={itemsByStage[stage].map((i) => i.uid)}
+                        >
                           {itemsByStage[stage].map((item) => (
                             <RoadmapCard
                               key={item.uid}

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -118,6 +118,9 @@ export function RoadmapView() {
     analytics.onSortChanged(value);
   };
   const isAdminOrdering = canCurate && sortOption === 'default';
+  // Local uid-order overrides per stage, set immediately on admin drag so the display
+  // doesn't depend on whether the backend has persisted the `order` field yet.
+  const [adminOrderMap, setAdminOrderMap] = useState<Partial<Record<RoadmapColumnStage, string[]>>>({});
   const [declineTargetUid, setDeclineTargetUid] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDragWidth, setActiveDragWidth] = useState<number | null>(null);
@@ -250,10 +253,20 @@ export function RoadmapView() {
       sortOption === 'upvotes' ? sortGantryItems : sortOption === 'date' ? sortGantryItemsByDate : sortGantryItemsByDefault;
     orderedVisibleColumns.forEach((stage) => {
       map[stage] = sortFn(map[stage]);
+
+      // Apply local admin ordering override: preserves the user's drag position even
+      // when the server hasn't persisted the `order` field yet.
+      const adminOrder = adminOrderMap[stage];
+      if (adminOrder) {
+        const itemMap = new Map(map[stage].map((item) => [item.uid, item]));
+        const known = adminOrder.filter((uid) => itemMap.has(uid)).map((uid) => itemMap.get(uid)!);
+        const extra = map[stage].filter((item) => !new Set(adminOrder).has(item.uid));
+        map[stage] = [...known, ...extra];
+      }
     });
 
     return map;
-  }, [data?.items, orderedVisibleColumns, searchText, sortOption]);
+  }, [data?.items, orderedVisibleColumns, searchText, sortOption, adminOrderMap]);
 
   const applyStageChange = async (itemUid: string, item: GantryItem, nextStage: GantryStage) => {
     if (nextStage === 'DECLINED') {
@@ -278,12 +291,17 @@ export function RoadmapView() {
     if (activeIdx === -1 || overIdx === -1 || activeIdx === overIdx) return;
 
     const reordered = arrayMove(columnItems, activeIdx, overIdx);
-    const newIdx = reordered.findIndex((i) => i.uid === activeId);
+
+    // Update local display order immediately — the visual position is driven by this,
+    // not by the server `order` field, so it works even when all items have order=null.
+    setAdminOrderMap((prev) => ({ ...prev, [activeItem.stage]: reordered.map((i) => i.uid) }));
+
+    // Compute fractional order for the backend PATCH.
     const BASE = 1000;
-    const prev = reordered[newIdx - 1];
-    const next = reordered[newIdx + 1];
-    const prevOrder = prev?.order ?? (newIdx - 1) * BASE;
-    const nextOrder = next?.order ?? (newIdx + 1) * BASE;
+    const prev = reordered[overIdx - 1];
+    const next = reordered[overIdx + 1];
+    const prevOrder = prev?.order ?? (overIdx - 1) * BASE;
+    const nextOrder = next?.order ?? (overIdx + 1) * BASE;
     const newOrder = (prevOrder + nextOrder) / 2;
 
     analytics.onItemReordered(activeId, activeItem.stage);

--- a/components/page/gantry/shared/Shared.module.scss
+++ b/components/page/gantry/shared/Shared.module.scss
@@ -50,17 +50,17 @@
 .upvote {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   padding: 0;
   border: none;
   background: transparent;
   color: #8897ae;
   font-size: 12px;
   font-weight: 400;
-  line-height: 18px;
   letter-spacing: -0.2px;
   cursor: pointer;
   transition: color 0.15s ease;
+  min-width: 24px;
 
   &:hover:not(:disabled) {
     color: #6b7b93;

--- a/services/gantry/constants.ts
+++ b/services/gantry/constants.ts
@@ -59,6 +59,29 @@ export function sortGantryItems(items: GantryItem[]): GantryItem[] {
   });
 }
 
+/** Admin-curated order ASC; items with null order sort to the end. */
+export function sortGantryItemsByDefault(items: GantryItem[]): GantryItem[] {
+  return [...items].sort((a, b) => {
+    if (a.order == null && b.order == null) return 0;
+    if (a.order == null) return 1;
+    if (b.order == null) return -1;
+    return a.order - b.order;
+  });
+}
+
+/** Newest created first. */
+export function sortGantryItemsByDate(items: GantryItem[]): GantryItem[] {
+  return [...items].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+export const ROADMAP_SORT_OPTIONS = [
+  { value: 'default', label: 'Default' },
+  { value: 'upvotes', label: 'By upvotes' },
+  { value: 'date', label: 'By date' },
+] as const;
+
+export type RoadmapSortOption = (typeof ROADMAP_SORT_OPTIONS)[number]['value'];
+
 /**
  * Stage transitions are unrestricted for members with the transition permission —
  * an item can move from any stage to any other stage. The selector simply offers

--- a/services/gantry/hooks/useGantryTransition.ts
+++ b/services/gantry/hooks/useGantryTransition.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { declineGantryItem, promoteGantryItem, transitionGantryItem } from '../gantry.service';
 import { GantryQueryKeys } from '../constants';
-import type { GantryStage } from '../types';
+import type { GantryItemListResponse, GantryStage } from '../types';
 
 type TransitionPayload =
   | { type: 'promote' }
@@ -15,6 +15,12 @@ type TransitionMutationPayload = {
   payload: TransitionPayload;
 };
 
+function resolveTargetStage(payload: TransitionPayload): GantryStage {
+  if (payload.type === 'promote') return 'PLANNED';
+  if (payload.type === 'decline') return 'DECLINED';
+  return payload.stage;
+}
+
 export function useGantryTransition() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -23,11 +29,22 @@ export function useGantryTransition() {
       if (payload.type === 'decline') return declineGantryItem(uid, payload.reason);
       return transitionGantryItem(uid, payload.stage);
     },
-    onSuccess: async (_result, variables) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] }),
-        queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEM, variables.uid] }),
-      ]);
+    onMutate: async ({ uid, payload }) => {
+      await queryClient.cancelQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      const targetStage = resolveTargetStage(payload);
+      const snapshot = queryClient.getQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.setQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] }, (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.map((item) => (item.uid === uid ? { ...item, stage: targetStage } : item)) };
+      });
+      return { snapshot };
+    },
+    onError: (_err, _variables, context) => {
+      context?.snapshot.forEach(([queryKey, data]) => queryClient.setQueryData(queryKey, data));
+    },
+    onSettled: (_result, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEM, variables.uid] });
     },
   });
 }

--- a/services/gantry/hooks/useReorderGantryItem.ts
+++ b/services/gantry/hooks/useReorderGantryItem.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateGantryItem } from '../gantry.service';
+import { GantryQueryKeys } from '../constants';
+import type { GantryItemListResponse } from '../types';
+
+export function useReorderGantryItem() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ uid, order }: { uid: string; order: number }) => updateGantryItem(uid, { order }),
+    onMutate: async ({ uid, order }) => {
+      await queryClient.cancelQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+      queryClient.setQueriesData<GantryItemListResponse>({ queryKey: [GantryQueryKeys.ITEMS] }, (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.map((item) => (item.uid === uid ? { ...item, order } : item)) };
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.ITEMS] });
+    },
+  });
+}

--- a/services/gantry/types.ts
+++ b/services/gantry/types.ts
@@ -17,6 +17,7 @@ export interface GantryItem {
   focusArea: string | null;
   tags: string[] | null;
   type: GantryItemType | null;
+  order: number | null;
   createdByUid: string;
   createdBy: GantryMemberSummary;
   promotedAt: string | null;
@@ -64,4 +65,5 @@ export interface UpdateGantryItemPayload {
   externalTrackerUrl?: string | null;
   tags?: string[];
   type?: GantryItemType | null;
+  order?: number | null;
 }


### PR DESCRIPTION
## Summary

- **Sort dropdown** — Default / By upvotes / By date in the roadmap header (desktop + mobile). Sort is client-side, applied inside the `itemsByStage` memo; no API changes needed.
- **Admin vertical ordering** — `canCurate` users can drag cards vertically within a column when Default sort is active. `SortableContext` (`verticalListSortingStrategy`) wraps each column's card list conditionally via the `isAdminOrdering` flag.
- **`useSortable` replaces `useDraggable`** on `RoadmapCard`. `handleDragEnd` routes by `over.id` type: card uid → same stage = reorder, different stage = cross-column move; stage string → existing column drop path. Cross-column moves where the dragged card lands directly on a target card are handled correctly.
- **Fractional-index PATCH** — only the dropped item is updated with `(prevOrder + nextOrder) / 2`. Position-based fallbacks cover items with no stored order yet.
- **Optimistic cache update** via `useReorderGantryItem` (`setQueriesData` + `invalidateQueries`) for instant visual feedback.
- **New type fields**: `GantryItem.order: number | null`, `UpdateGantryItemPayload.order?: number | null`.
- **PostHog events**: `gantry_sort_changed`, `gantry_item_reordered`.