### PR TITLE
feat(gantry): add `BoostButton` component for pinning and boost tracking

### DIFF
--- a/components/page/gantry/roadmap/RoadmapCard.tsx
+++ b/components/page/gantry/roadmap/RoadmapCard.tsx
@@ -5,7 +5,7 @@ import { CSS } from '@dnd-kit/utilities';
 import type { GantryItem } from '@/services/gantry/types';
 import { truncateText } from '@/utils/forum';
 import { GantryItemAuthor } from '../shared/GantryItemAuthor';
-import { UpvoteButton } from '../shared/UpvoteButton';
+import { BoostButton } from '../shared/BoostButton';
 import { useGantryCardNavigate } from '../shared/useGantryCardNavigate';
 import s from './Roadmap.module.scss';
 
@@ -38,9 +38,9 @@ function RoadmapCardContent({ item, canUpvote, onUpvoteToggle }: CardContentProp
     <>
       <div className={s.cardHead}>
         <h3 className={s.cardTitle}>{item.title}</h3>
-        <UpvoteButton
+        <BoostButton
           count={item.upvoteCount}
-          hasUpvoted={item.viewerHasUpvoted}
+          hasPinned={item.viewerHasUpvoted}
           disabled={!canUpvote}
           onToggle={(next) => onUpvoteToggle(item.uid, next)}
         />

--- a/components/page/gantry/shared/BoostButton.tsx
+++ b/components/page/gantry/shared/BoostButton.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { clsx } from 'clsx';
+import s from './Shared.module.scss';
+
+function ArrowUpIcon() {
+  return (
+    <svg width="10" height="11" viewBox="0 0 10 11" fill="none" aria-hidden>
+      <path
+        d="M5 9.5V1.5m0 0L1.5 5.5M5 1.5L8.5 5.5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+interface Props {
+  readonly count: number;
+  readonly hasPinned: boolean;
+  readonly disabled?: boolean;
+  readonly readonly?: boolean;
+  readonly onToggle: (nextHasPinned: boolean, el: HTMLButtonElement) => void;
+}
+
+export function BoostButton({ count, hasPinned, disabled, readonly, onToggle }: Props) {
+  if (readonly) {
+    return (
+      <span className={s.readStat} title="Boosts (frozen)">
+        <ArrowUpIcon />
+        <span>{count ?? 0}</span>
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={clsx(s.boost, hasPinned && s.boostActive)}
+      disabled={disabled}
+      aria-pressed={hasPinned}
+      aria-label={hasPinned ? `Remove boost (${count})` : `Boost (${count})`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle(!hasPinned, e.currentTarget);
+      }}
+    >
+      <ArrowUpIcon />
+      <span className={s.boostLabel}>{hasPinned ? 'Boosted' : 'Boost'}</span>
+      <span className={s.boostDivider} aria-hidden />
+      <span>{count ?? 0}</span>
+    </button>
+  );
+}

--- a/components/page/gantry/shared/Shared.module.scss
+++ b/components/page/gantry/shared/Shared.module.scss
@@ -84,6 +84,70 @@
   }
 }
 
+.boost {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  color: #374151;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.12s;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    border-color: #427dff;
+    color: #427dff;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.boostActive {
+  color: #fff;
+  border-color: transparent;
+  background-image: linear-gradient(71.47deg, #427dff 8.43%, #44d5bb 87.45%);
+  background-size: 120%;
+  background-position: center;
+  box-shadow: 0 2px 8px rgba(21, 111, 247, 0.35);
+
+  &:hover:not(:disabled) {
+    background-image: linear-gradient(71.47deg, #427dff 8.43%, #44d5bb 87.45%);
+    filter: brightness(1.03);
+    background-size: 120%;
+    background-position: center;
+  }
+}
+
+.boostLabel {
+  line-height: 1;
+}
+
+.boostDivider {
+  width: 1px;
+  height: 12px;
+  background: currentColor;
+  opacity: 0.25;
+  flex-shrink: 0;
+}
+
+.readStat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #8897ae;
+}
+
 .buildButton {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
- Implements a reusable button with stateful boost/pin toggle behavior.
- Includes read-only and interactive variants with accessibility support.