### PR TITLE
feat: align GantryDetailPage with boost interactions

### DIFF
--- a/components/page/gantry/GantryDetailPage.module.scss
+++ b/components/page/gantry/GantryDetailPage.module.scss
@@ -172,6 +172,15 @@
   white-space: nowrap;
 }
 
+.boostArea {
+  padding: 0 20px;
+  margin-top: 12px;
+
+  @include mobile-only {
+    padding: 0;
+  }
+}
+
 .mobileDivider {
   display: none;
 

--- a/components/page/gantry/GantryDetailPage.tsx
+++ b/components/page/gantry/GantryDetailPage.tsx
@@ -14,14 +14,20 @@ import { useGantryAccess } from '@/services/rbac/hooks/useGantryAccess';
 import { useGantryItem } from '@/services/gantry/hooks/useGantryItem';
 import { useArchiveGantryItem } from '@/services/gantry/hooks/useArchiveGantryItem';
 import { useGantryTransition } from '@/services/gantry/hooks/useGantryTransition';
-import { useGantryUpvote } from '@/services/gantry/hooks/useGantryUpvote';
+import { useGantryPin } from '@/services/gantry/hooks/useGantryPin';
+import { useGantryPinNote } from '@/services/gantry/hooks/useGantryPinNote';
+import { useGantryPinStatus } from '@/services/gantry/hooks/useGantryPinStatus';
 import { isPreRoadmapStage } from '@/services/gantry/constants';
 import type { GantryStage } from '@/services/gantry/types';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
+import { useRoadmapPinActions } from './roadmap/hooks/useRoadmapPinActions';
 import { EditIdeaForm } from './shared/EditIdeaForm';
+import { BoostersSection } from './shared/BoostersSection';
+import { BoostButton } from './shared/BoostButton';
 import { GantryItemAuthor } from './shared/GantryItemAuthor';
+import { PinNotePopover } from './shared/PinNotePopover';
+import { PinSwapPicker } from './shared/PinSwapPicker';
 import { StageSelector } from './shared/StageSelector';
-import { UpvoteButton } from './shared/UpvoteButton';
 import { BuildWithAgentsButton } from './shared/BuildWithAgentsButton';
 import { DeclineIdeaModal } from './shared/DeclineIdeaModal';
 import s from './GantryDetailPage.module.scss';
@@ -40,7 +46,18 @@ export function GantryDetailPage({ uid }: Props) {
   const { data: item, isLoading, isError } = useGantryItem(uid);
   const archiveMutation = useArchiveGantryItem(uid);
   const transitionMutation = useGantryTransition();
-  const upvoteMutation = useGantryUpvote();
+  const pin = useGantryPin();
+  const pinNote = useGantryPinNote();
+  const { data: pinStatus } = useGantryPinStatus(!!currentUser);
+  const {
+    pinNotePopover,
+    setPinNotePopover,
+    handlePinToggle,
+    handlePinNoteSave,
+    swapPickerState,
+    handleSwapSelect,
+    handleSwapDismiss,
+  } = useRoadmapPinActions(pin, pinNote, analytics, pinStatus);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
   const [isDeclineModalOpen, setIsDeclineModalOpen] = useState(false);
@@ -169,16 +186,19 @@ export function GantryDetailPage({ uid }: Props) {
                 <span className={s.metaDot} aria-hidden />
                 <GantryItemAuthor author={item.createdBy} backTo={`/gantry/${item.uid}`} />
                 <span className={s.metaDot} aria-hidden />
-                <UpvoteButton
-                  count={item.upvoteCount}
-                  hasUpvoted={item.viewerHasUpvoted}
-                  disabled={!access.canUpvote}
-                  onToggle={(next) => {
-                    upvoteMutation.mutateAsync({ uid: item.uid, nextHasUpvoted: next });
-                    if (next) analytics.onItemUpvoted(item.uid);
-                  }}
+                <BoostButton
+                  count={item.pinCount}
+                  hasPinned={item.viewerHasPinned}
+                  readonly={item.stage === 'IN_PROGRESS' || item.stage === 'SHIPPED' || item.stage === 'DECLINED'}
+                  disabled={!currentUser || pin.isPending}
+                  onToggle={(next, el) => handlePinToggle(item.uid, next, el)}
                 />
               </div>
+              {access.canCurate && item.pinCount > 0 && (
+                <div className={s.boostArea}>
+                  <BoostersSection item={item} />
+                </div>
+              )}
             </div>
 
             {item.tags && item.tags.length > 0 && !isEditMode && (
@@ -229,6 +249,23 @@ export function GantryDetailPage({ uid }: Props) {
           </div>
         </div>
       </div>
+
+      {pinNotePopover && (
+        <PinNotePopover
+          uid={pinNotePopover.uid}
+          pos={{ top: pinNotePopover.top, left: pinNotePopover.left }}
+          onSave={handlePinNoteSave}
+        />
+      )}
+      {swapPickerState && (
+        <PinSwapPicker
+          targetItemTitle={item.title}
+          pins={pinStatus?.pins ?? []}
+          pos={{ top: swapPickerState.top, left: swapPickerState.left }}
+          onSelect={handleSwapSelect}
+          onDismiss={handleSwapDismiss}
+        />
+      )}
 
       <ConfirmDialog
         isOpen={isArchiveModalOpen}

--- a/components/page/gantry/roadmap/RoadmapCard.tsx
+++ b/components/page/gantry/roadmap/RoadmapCard.tsx
@@ -5,74 +5,12 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { clsx } from 'clsx';
 import type { GantryItem } from '@/services/gantry/types';
-import { useGantryItemPins } from '@/services/gantry/hooks/useGantryItemPins';
 import { truncateText } from '@/utils/forum';
+import { BoostersSection } from '../shared/BoostersSection';
 import { GantryItemAuthor } from '../shared/GantryItemAuthor';
 import { BoostButton } from '../shared/BoostButton';
 import { useGantryCardNavigate } from '../shared/useGantryCardNavigate';
 import s from './Roadmap.module.scss';
-
-const AVATAR_COLORS = [
-  { bg: '#dbeafe', text: '#1d4ed8' },
-  { bg: '#dcfce7', text: '#15803d' },
-  { bg: '#ede9fe', text: '#6d28d9' },
-  { bg: '#fce7f3', text: '#9d174d' },
-  { bg: '#fef3c7', text: '#92400e' },
-  { bg: '#e0f2fe', text: '#0369a1' },
-];
-function avatarColor(name: string) {
-  const h = name.split('').reduce((a, c) => a + c.charCodeAt(0), 0);
-  return AVATAR_COLORS[h % AVATAR_COLORS.length];
-}
-function initials(name: string) {
-  return name
-    .split(' ')
-    .slice(0, 2)
-    .map((w) => w[0])
-    .join('')
-    .toUpperCase();
-}
-
-const MAX_PINNERS_VISIBLE = 3;
-
-function CardBoostersSection({ item }: { item: GantryItem }) {
-  const { data: pinners = [], isLoading } = useGantryItemPins(item.uid, item.pinCount > 0);
-  if (isLoading) return <div className={s.boostersLoading}>Loading boosters…</div>;
-  if (pinners.length === 0) return null;
-  const visible = pinners.slice(0, MAX_PINNERS_VISIBLE);
-  const hasMore = item.pinCount > MAX_PINNERS_VISIBLE;
-  return (
-    <div className={s.boostersSection}>
-      <div className={s.boostersHeader}>
-        <LockIcon />
-        <span>{item.pinCount} BOOSTED · TEAM-ONLY</span>
-      </div>
-      {visible.map((p) => {
-        const c = avatarColor(p.member.name);
-        return (
-          <div key={p.uid} className={s.boosterRow}>
-            <span className={s.boosterAvatar} style={{ background: c.bg, color: c.text }}>
-              {initials(p.member.name)}
-            </span>
-            <div className={s.boosterInfo}>
-              <span className={s.boosterName}>{p.member.name}</span>
-              {p.note ? (
-                <span className={s.boosterNote}>{p.note}</span>
-              ) : (
-                <span className={s.boosterNoNote}>No note</span>
-              )}
-            </div>
-          </div>
-        );
-      })}
-      {hasMore && (
-        <button type="button" className={s.showAllBoosters} onClick={(e) => e.stopPropagation()}>
-          Show all {item.pinCount} boosters &amp; notes
-        </button>
-      )}
-    </div>
-  );
-}
 
 const CARD_DESCRIPTION_MAX_LENGTH = 160;
 
@@ -135,8 +73,7 @@ function RoadmapCardContent({
         <h3 className={s.cardTitle}>{item.title}</h3>
         {item.objective && (
           <span className={s.objectiveBadge}>
-            <span className={s.objectiveDot} aria-hidden />
-            O{item.objective.order}
+            <span className={s.objectiveDot} aria-hidden />O{item.objective.order}
           </span>
         )}
       </div>
@@ -172,7 +109,7 @@ function RoadmapCardContent({
         </div>
       </div>
 
-      {warnPinOrder && position !== undefined && (
+      {warnPinOrder && position !== undefined && canCurate && (
         <div className={s.boostOrderWarning}>
           <WarningIcon />
           <span>
@@ -194,7 +131,7 @@ function RoadmapCardContent({
         </p>
       )}
 
-      {canCurate && item.pinCount > 0 && <CardBoostersSection item={item} />}
+      {canCurate && item.pinCount > 0 && <BoostersSection item={item} />}
     </>
   );
 }
@@ -289,16 +226,6 @@ function DragGripIcon() {
       <circle cx="8" cy="7" r="1.5" fill="currentColor" />
       <circle cx="2" cy="12" r="1.5" fill="currentColor" />
       <circle cx="8" cy="12" r="1.5" fill="currentColor" />
-    </svg>
-  );
-}
-
-function LockIcon() {
-  return (
-    <svg width="11" height="13" viewBox="0 0 11 13" fill="none" aria-hidden>
-      <rect x="1.5" y="5.5" width="8" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.25" />
-      <path d="M3.5 5.5V3.5a2 2 0 0 1 4 0v2" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
-      <circle cx="5.5" cy="9" r="1" fill="currentColor" />
     </svg>
   );
 }

--- a/components/page/gantry/shared/BoostersSection.module.scss
+++ b/components/page/gantry/shared/BoostersSection.module.scss
@@ -1,0 +1,96 @@
+.boostersLoading {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.boostersSection {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #f1f5f9;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.boostersHeader {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #64748b;
+  text-transform: uppercase;
+
+  svg {
+    color: #94a3b8;
+    flex-shrink: 0;
+  }
+}
+
+.boosterRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.boosterAvatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 9px;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+
+.boosterInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.boosterName {
+  font-size: 12px;
+  font-weight: 600;
+  color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.boosterNote {
+  font-size: 11px;
+  color: #475569;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.boosterNoNote {
+  font-size: 11px;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.showAllBoosters {
+  margin-top: 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #156ff7;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/components/page/gantry/shared/BoostersSection.tsx
+++ b/components/page/gantry/shared/BoostersSection.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useGantryItemPins } from '@/services/gantry/hooks/useGantryItemPins';
+import type { GantryItem } from '@/services/gantry/types';
+import s from './BoostersSection.module.scss';
+
+const AVATAR_COLORS = [
+  { bg: '#dbeafe', text: '#1d4ed8' },
+  { bg: '#dcfce7', text: '#15803d' },
+  { bg: '#ede9fe', text: '#6d28d9' },
+  { bg: '#fce7f3', text: '#9d174d' },
+  { bg: '#fef3c7', text: '#92400e' },
+  { bg: '#e0f2fe', text: '#0369a1' },
+];
+
+function avatarColor(name: string) {
+  const h = name.split('').reduce((a, c) => a + c.charCodeAt(0), 0);
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+
+function initials(name: string) {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase();
+}
+
+const MAX_PINNERS_VISIBLE = 3;
+
+function LockIcon() {
+  return (
+    <svg width="11" height="13" viewBox="0 0 11 13" fill="none" aria-hidden>
+      <rect x="1.5" y="5.5" width="8" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.25" />
+      <path d="M3.5 5.5V3.5a2 2 0 0 1 4 0v2" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+      <circle cx="5.5" cy="9" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function BoostersSection({ item }: { item: GantryItem }) {
+  const { data: pinners = [], isLoading } = useGantryItemPins(item.uid, item.pinCount > 0);
+  if (isLoading) return <div className={s.boostersLoading}>Loading boosters…</div>;
+  if (pinners.length === 0) return null;
+  const visible = pinners.slice(0, MAX_PINNERS_VISIBLE);
+  const hasMore = item.pinCount > MAX_PINNERS_VISIBLE;
+  return (
+    <div className={s.boostersSection}>
+      <div className={s.boostersHeader}>
+        <LockIcon />
+        <span>{item.pinCount} BOOSTED · TEAM-ONLY</span>
+      </div>
+      {visible.map((p) => {
+        const c = avatarColor(p.member.name);
+        return (
+          <div key={p.uid} className={s.boosterRow}>
+            <span className={s.boosterAvatar} style={{ background: c.bg, color: c.text }}>
+              {initials(p.member.name)}
+            </span>
+            <div className={s.boosterInfo}>
+              <span className={s.boosterName}>{p.member.name}</span>
+              {p.note ? (
+                <span className={s.boosterNote}>{p.note}</span>
+              ) : (
+                <span className={s.boosterNoNote}>No note</span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+      {hasMore && (
+        <button type="button" className={s.showAllBoosters} onClick={(e) => e.stopPropagation()}>
+          Show all {item.pinCount} boosters &amp; notes
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Replace upvotes with boost/pin on the detail page. Extract CardBoostersSection into a shared BoostersSection component reused by both RoadmapCard and GantryDetailPage. Admins see an inline pinners list (avatars, names, notes) when pinCount > 0.