### PR TITLE
feat(roadmap): add IndexedDB-backed UI flags for boost tip dismissal

### DIFF
--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { clsx } from 'clsx';
+import { getUiFlag, setUiFlag } from '@/utils/uiFlags';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import DashboardPagesLayout from '@/components/core/dashboard-pages-layout/DashboardPagesLayout';
 import { useLocalStorageParam } from '@/hooks/useLocalStorageParam';
@@ -172,13 +173,17 @@ export function RoadmapView() {
   }, [analytics]);
 
   useEffect(() => {
-    if (!localStorage.getItem(BOOST_TIP_KEY)) {
-      setShowBoostTip(true);
+    if (!currentUser?.uid) {
+      setShowBoostTip(false);
+      return;
     }
-  }, []);
+    getUiFlag(`${BOOST_TIP_KEY}_${currentUser.uid}`).then((dismissed) => {
+      setShowBoostTip(!dismissed);
+    });
+  }, [currentUser?.uid]);
 
   const dismissBoostTip = () => {
-    localStorage.setItem(BOOST_TIP_KEY, '1');
+    if (currentUser?.uid) setUiFlag(`${BOOST_TIP_KEY}_${currentUser.uid}`);
     setShowBoostTip(false);
   };
 

--- a/utils/uiFlags.ts
+++ b/utils/uiFlags.ts
@@ -1,0 +1,38 @@
+const DB_NAME = 'pl_ui_flags';
+const STORE_NAME = 'flags';
+const DB_VERSION = 1;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getUiFlag(key: string): Promise<boolean> {
+  try {
+    const db = await openDb();
+    return new Promise((resolve) => {
+      const req = db.transaction(STORE_NAME).objectStore(STORE_NAME).get(key);
+      req.onsuccess = () => resolve(!!req.result);
+      req.onerror = () => resolve(false);
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function setUiFlag(key: string): Promise<void> {
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const req = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).put(true, key);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    // non-critical, ignore
+  }
+}


### PR DESCRIPTION
- Replace localStorage with per-user IndexedDB flags for boost tip state.
- Introduce `getUiFlag` and `setUiFlag` utilities.
- Update boost tip logic to ensure unique user-based persistence.