### PR TITLE
refactor(pitch-view): simplify pitch access logic and update `closedA…

### DIFF
--- a/components/page/pitch/PitchView.tsx
+++ b/components/page/pitch/PitchView.tsx
@@ -38,8 +38,7 @@ export const PitchView = () => {
   const canLoadPitch =
     isLoggedIn &&
     access &&
-    access.access !== 'restricted' &&
-    !(access.status === 'CLOSED' && access.participantType === 'INVESTOR' && !access.isPitchAdmin);
+    access.access !== 'restricted';
   const { data: pitch, isLoading: pitchLoading } = useGetTeamPitch(slug, canLoadPitch);
   const teamPitchAnalytics = useTeamPitchAnalytics();
   const reportAnalytics = useReportAnalyticsEvent();
@@ -196,7 +195,7 @@ export const PitchView = () => {
           teamUid={access.teamUid}
           pitchSlug={slug}
           prefillEmail={prefillEmail}
-          closedAt={access.closedAt ?? access.updatedAt}
+          closedAt={pitch?.closedAt}
         />
       </div>
     );

--- a/services/team-pitch/hooks/useGetTeamPitch.ts
+++ b/services/team-pitch/hooks/useGetTeamPitch.ts
@@ -10,6 +10,7 @@ export type TeamPitchFull = {
   uid: string;
   slug: string;
   status: string;
+  closedAt?: string | null;
   title: string;
   description: string;
   supportEmail: string;

--- a/services/team-pitch/hooks/useGetTeamPitchAccess.ts
+++ b/services/team-pitch/hooks/useGetTeamPitchAccess.ts
@@ -8,7 +8,6 @@ export type TeamPitchAccess = {
   uid: string;
   slug: string;
   createdAt: string;
-  updatedAt?: string | null;
   status: 'DRAFT' | 'OPEN' | 'CLOSED';
   title: string;
   description: string;
@@ -23,7 +22,6 @@ export type TeamPitchAccess = {
   confidentialityAccepted: boolean;
   teamUid: string;
   teamName: string;
-  closedAt?: string | null;
 };
 
 export async function getTeamPitchAccess(slug: string, authenticated: boolean) {


### PR DESCRIPTION
…t` handling

- Remove redundant `access` conditions in `PitchView`.
- Use `pitch.closedAt` instead of `access.closedAt` fallback.
- Update `useGetTeamPitch` and