### PR TITLE
feat(gantry): add saved draft with IndexedDB persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ approve-pr.sh
 /docs
 .graphifyignore
 graphify-out
+openspec

--- a/__tests__/hooks/useGantryDraft.test.tsx
+++ b/__tests__/hooks/useGantryDraft.test.tsx
@@ -1,0 +1,101 @@
+import { type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+
+jest.unmock('@tanstack/react-query');
+
+// In-memory IDB simulation
+function makeMemoryDB() {
+  const store = new Map<string, unknown>();
+  return {
+    get: jest.fn((_s: string, key: string) => Promise.resolve(store.get(key))),
+    put: jest.fn((_s: string, value: unknown, key: string) => { store.set(key, value); return Promise.resolve(); }),
+    delete: jest.fn((_s: string, key: string) => { store.delete(key); return Promise.resolve(); }),
+    objectStoreNames: { contains: () => true },
+    _store: store,
+  };
+}
+
+let memDB = makeMemoryDB();
+
+jest.mock('idb', () => ({
+  openDB: jest.fn(() => Promise.resolve(memDB)),
+}));
+
+import {
+  useGantryDraftQuery,
+  useGantrySaveDraftMutation,
+  useGantryDiscardDraftMutation,
+} from '@/services/gantry/hooks/useGantryDraft';
+
+const sampleDraft: SubmitIdeaDraft = {
+  form: { title: 'Test title', description: '', tags: [], type: null, objective: null },
+  showCreateObjective: false,
+  newObjectiveTitle: '',
+};
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return { client, wrapper: ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )};
+}
+
+beforeEach(() => {
+  memDB = makeMemoryDB();
+  const { openDB } = require('idb');
+  (openDB as jest.Mock).mockResolvedValue(memDB);
+});
+
+describe('useGantryDraftQuery', () => {
+  it('returns null when no draft is stored', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useGantrySaveDraftMutation', () => {
+  it('writes draft and resolves successfully', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGantrySaveDraftMutation('idea'), { wrapper });
+    await act(async () => { result.current.mutate(sampleDraft); });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(memDB.put).toHaveBeenCalled();
+  });
+});
+
+describe('useGantryDiscardDraftMutation', () => {
+  it('deletes the draft and resolves successfully', async () => {
+    const envelope = { v: 1, savedAt: Date.now(), data: sampleDraft };
+    memDB._store.set('idea', envelope);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGantryDiscardDraftMutation('idea'), { wrapper });
+    await act(async () => { result.current.mutate(); });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(memDB._store.has('idea')).toBe(false);
+  });
+});
+
+describe('save then discard flow', () => {
+  it('draft is null after save + discard', async () => {
+    const { wrapper, client } = makeWrapper();
+
+    const { result: saveResult } = renderHook(() => useGantrySaveDraftMutation('idea'), { wrapper });
+    await act(async () => { saveResult.current.mutate(sampleDraft); });
+    await waitFor(() => expect(saveResult.current.isSuccess).toBe(true));
+
+    const { result: discardResult } = renderHook(() => useGantryDiscardDraftMutation('idea'), { wrapper });
+    await act(async () => { discardResult.current.mutate(); });
+    await waitFor(() => expect(discardResult.current.isSuccess).toBe(true));
+
+    await act(async () => { await client.invalidateQueries(); });
+
+    const { result: queryResult } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
+    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
+    expect(queryResult.current.data).toBeNull();
+  });
+});

--- a/__tests__/page/gantry/roadmap-view.test.tsx
+++ b/__tests__/page/gantry/roadmap-view.test.tsx
@@ -77,6 +77,11 @@ jest.mock('@/analytics/gantry.analytics', () => ({
   }),
 }));
 
+jest.mock('@/services/gantry/hooks/useGantryDraft', () => ({
+  useGantryDraftQuery: () => ({ data: null, isLoading: false }),
+  useGantryDiscardDraftMutation: () => ({ mutate: jest.fn(), isPending: false }),
+}));
+
 jest.mock('@/hooks/useIsNarrow', () => ({
   useIsNarrow: () => false,
 }));

--- a/__tests__/utils/gantryDraftStorage.test.ts
+++ b/__tests__/utils/gantryDraftStorage.test.ts
@@ -1,0 +1,116 @@
+import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+
+// In-memory IDB simulation — keeps one store keyed by string.
+function makeMemoryDB() {
+  const store = new Map<string, unknown>();
+  return {
+    get: jest.fn((_s: string, key: string) => Promise.resolve(store.get(key))),
+    put: jest.fn((_s: string, value: unknown, key: string) => { store.set(key, value); return Promise.resolve(); }),
+    delete: jest.fn((_s: string, key: string) => { store.delete(key); return Promise.resolve(); }),
+    objectStoreNames: { contains: () => true },
+    _store: store,
+  };
+}
+
+let memDB = makeMemoryDB();
+
+jest.mock('idb', () => ({
+  openDB: jest.fn(() => Promise.resolve(memDB)),
+}));
+
+import {
+  readGantryDraft,
+  writeGantryDraft,
+  deleteGantryDraft,
+  readGantryDraftSavedAt,
+} from '@/utils/gantryDraftStorage';
+
+const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+const sampleDraft: SubmitIdeaDraft = {
+  form: { title: 'Need better filters', description: '', tags: [], type: null, objective: null },
+  showCreateObjective: false,
+  newObjectiveTitle: '',
+};
+
+beforeEach(() => {
+  memDB = makeMemoryDB();
+  const { openDB } = require('idb');
+  (openDB as jest.Mock).mockResolvedValue(memDB);
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('writeGantryDraft + readGantryDraft', () => {
+  it('writes and reads back a draft', async () => {
+    await writeGantryDraft('idea', sampleDraft);
+    const result = await readGantryDraft('idea');
+    expect(result).toEqual(sampleDraft);
+  });
+
+  it('returns null when no draft is stored', async () => {
+    expect(await readGantryDraft('idea')).toBeNull();
+  });
+
+  it('stores drafts per variant independently', async () => {
+    await writeGantryDraft('idea', sampleDraft);
+    expect(await readGantryDraft('roadmap')).toBeNull();
+    expect(await readGantryDraft('idea')).toEqual(sampleDraft);
+  });
+});
+
+describe('expired draft', () => {
+  it('returns null and deletes a draft past TTL', async () => {
+    await writeGantryDraft('idea', sampleDraft);
+    jest.setSystemTime(new Date('2026-06-12T12:00:00Z').getTime() + DRAFT_TTL_MS + 1000);
+    expect(await readGantryDraft('idea')).toBeNull();
+    expect(memDB.delete).toHaveBeenCalledWith(STORE_NAME_SENTINEL, 'idea');
+  });
+});
+
+// Sentinel for store name used in assertions
+const STORE_NAME_SENTINEL = 'drafts';
+
+describe('deleteGantryDraft', () => {
+  it('removes the stored draft', async () => {
+    await writeGantryDraft('idea', sampleDraft);
+    await deleteGantryDraft('idea');
+    expect(await readGantryDraft('idea')).toBeNull();
+  });
+});
+
+describe('readGantryDraftSavedAt', () => {
+  it('returns the savedAt timestamp', async () => {
+    await writeGantryDraft('idea', sampleDraft);
+    const savedAt = await readGantryDraftSavedAt('idea');
+    expect(savedAt).toBe(new Date('2026-06-12T12:00:00Z').getTime());
+  });
+
+  it('returns null when no draft exists', async () => {
+    expect(await readGantryDraftSavedAt('idea')).toBeNull();
+  });
+});
+
+describe('IDB unavailable fallback', () => {
+  it('writeGantryDraft silently swallows errors', async () => {
+    const { openDB } = require('idb');
+    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
+    await expect(writeGantryDraft('idea', sampleDraft)).resolves.toBeUndefined();
+  });
+
+  it('readGantryDraft returns null on error', async () => {
+    const { openDB } = require('idb');
+    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
+    expect(await readGantryDraft('idea')).toBeNull();
+  });
+
+  it('deleteGantryDraft silently swallows errors', async () => {
+    const { openDB } = require('idb');
+    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
+    await expect(deleteGantryDraft('idea')).resolves.toBeUndefined();
+  });
+});

--- a/components/page/gantry/ideas/DiscardDraftDialog.module.scss
+++ b/components/page/gantry/ideas/DiscardDraftDialog.module.scss
@@ -1,0 +1,64 @@
+.content {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+}
+
+.body {
+  margin-top: 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: 400;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.keepBtn {
+  padding: 9px 20px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  color: #0f172a;
+  cursor: pointer;
+  box-shadow: 0 1px 1px 0 rgba(15, 23, 42, 0.08);
+
+  &:hover {
+    background: #f8fafc;
+  }
+}
+
+.discardBtn {
+  padding: 9px 20px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: #dd2c5a;
+  font-size: 14px;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 1px 1px 0 rgba(15, 23, 42, 0.08);
+
+  &:hover {
+    background: #c4264f;
+  }
+}

--- a/components/page/gantry/ideas/DiscardDraftDialog.tsx
+++ b/components/page/gantry/ideas/DiscardDraftDialog.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Modal } from '@/components/common/Modal';
+import s from './DiscardDraftDialog.module.scss';
+
+interface Props {
+  readonly isOpen: boolean;
+  readonly draftTitle: string;
+  readonly onKeep: () => void;
+  readonly onDiscard: () => void;
+}
+
+export function DiscardDraftDialog({ isOpen, draftTitle, onKeep, onDiscard }: Props) {
+  return (
+    <Modal isOpen={isOpen} onClose={onKeep} closeOnBackdropClick closeOnEscape>
+      <div className={s.content} role="dialog" aria-modal aria-labelledby="discard-draft-title">
+        <h2 id="discard-draft-title" className={s.title}>Discard draft?</h2>
+        <p className={s.body}>
+          You&apos;ll lose &ldquo;{draftTitle}&rdquo;. This can&apos;t be undone.
+        </p>
+        <div className={s.actions}>
+          <button type="button" className={s.keepBtn} onClick={onKeep}>
+            Keep draft
+          </button>
+          <button type="button" className={s.discardBtn} onClick={onDiscard}>
+            Discard draft
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/page/gantry/ideas/GantryDraftBanner.module.scss
+++ b/components/page/gantry/ideas/GantryDraftBanner.module.scss
@@ -1,0 +1,100 @@
+@import 'styles/media.scss';
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(14, 15, 17, 0.1);
+  background: #fff;
+  flex-shrink: 0;
+
+  @include mobile-only {
+    display: none;
+  }
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.draftPill {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  border: 1px solid rgba(14, 15, 17, 0.12);
+  background: #f8fafc;
+  font-size: 12px;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #0a0c11;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  font-size: 12px;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.resumeBtn {
+  padding: 6px 14px;
+  border: 1px solid rgba(14, 15, 17, 0.12);
+  border-radius: 8px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  color: #0a0c11;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background: #f8fafc;
+  }
+}
+
+.discardBtn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: #dd2c5a;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background: #fff1f2;
+  }
+}

--- a/components/page/gantry/ideas/GantryDraftBanner.tsx
+++ b/components/page/gantry/ideas/GantryDraftBanner.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import s from './GantryDraftBanner.module.scss';
+
+interface Props {
+  readonly title: string;
+  readonly savedAt: number;
+  readonly onResume: () => void;
+  readonly onDiscard: () => void;
+}
+
+export function GantryDraftBanner({ title, savedAt, onResume, onDiscard }: Props) {
+  return (
+    <div className={s.banner} role="status">
+      <div className={s.left}>
+        <span className={s.draftPill}>Draft</span>
+        <div className={s.info}>
+          <span className={s.title}>{title}</span>
+          <span className={s.meta}>Edited {formatTimeAgo(savedAt)} · not published yet</span>
+        </div>
+      </div>
+      <div className={s.actions}>
+        <button type="button" className={s.resumeBtn} onClick={onResume}>
+          Resume
+        </button>
+        <button type="button" className={s.discardBtn} onClick={onDiscard}>
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/page/gantry/ideas/GantryDraftChip.module.scss
+++ b/components/page/gantry/ideas/GantryDraftChip.module.scss
@@ -1,0 +1,77 @@
+@import 'styles/media.scss';
+
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border-radius: 8px;
+  border: 1px solid rgba(14, 15, 17, 0.1);
+  background: #fff;
+  overflow: hidden;
+  flex-shrink: 0;
+  width: 100%;
+
+  @include tablet-landscape {
+    display: none;
+  }
+}
+
+.body {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: #f8fafc;
+  }
+}
+
+.draftPill {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 9999px;
+  border: 1px solid rgba(14, 15, 17, 0.12);
+  background: #f1f5f9;
+  font-size: 11px;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.title {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0a0c11;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.closeBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-left: 1px solid rgba(14, 15, 17, 0.08);
+  background: none;
+  color: #64748b;
+  cursor: pointer;
+
+  &:hover {
+    background: #fff1f2;
+    color: #dd2c5a;
+  }
+}

--- a/components/page/gantry/ideas/GantryDraftChip.tsx
+++ b/components/page/gantry/ideas/GantryDraftChip.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import s from './GantryDraftChip.module.scss';
+
+interface Props {
+  readonly title: string;
+  readonly onResume: () => void;
+  readonly onDiscard: () => void;
+}
+
+export function GantryDraftChip({ title, onResume, onDiscard }: Props) {
+  return (
+    <div className={s.chip}>
+      <button type="button" className={s.body} onClick={onResume} aria-label={`Resume draft: ${title}`}>
+        <span className={s.draftPill}>Draft</span>
+        <span className={s.title}>{title}</span>
+      </button>
+      <button
+        type="button"
+        className={s.closeBtn}
+        onClick={onDiscard}
+        aria-label="Discard draft"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+          <path d="M11 3L3 11M3 3l8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/components/page/gantry/ideas/IdeasSubmitButton.tsx
+++ b/components/page/gantry/ideas/IdeasSubmitButton.tsx
@@ -4,6 +4,7 @@ interface Props {
   readonly onClick: () => void;
   readonly className?: string;
   readonly label?: string;
+  readonly hasDraft?: boolean;
 }
 
 function PlusIcon() {
@@ -27,11 +28,25 @@ function PlusIcon() {
   );
 }
 
-export function IdeasSubmitButton({ onClick, className, label = 'Share a need' }: Props) {
+function PencilIcon() {
+  return (
+    <svg className={s.submitIcon} viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+      <path
+        d="M12.75 2.25a1.5 1.5 0 0 1 2.121 0l.879.879a1.5 1.5 0 0 1 0 2.121l-9 9L3 15l.75-3.75 9-9Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function IdeasSubmitButton({ onClick, className, label = 'Share a need', hasDraft = false }: Props) {
   return (
     <button type="button" className={className ?? s.submitButton} onClick={onClick}>
-      <PlusIcon />
-      {label}
+      {hasDraft ? <PencilIcon /> : <PlusIcon />}
+      {hasDraft ? 'Resume draft' : label}
     </button>
   );
 }

--- a/components/page/gantry/ideas/SubmitIdeaModal/DraftSaveStatus.module.scss
+++ b/components/page/gantry/ideas/SubmitIdeaModal/DraftSaveStatus.module.scss
@@ -1,0 +1,22 @@
+.saving,
+.saved {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+.saving {
+  background: rgba(14, 15, 17, 0.06);
+  color: #64748b;
+}
+
+.saved {
+  background: #dcfce7;
+  color: #166534;
+}

--- a/components/page/gantry/ideas/SubmitIdeaModal/DraftSaveStatus.tsx
+++ b/components/page/gantry/ideas/SubmitIdeaModal/DraftSaveStatus.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import s from './DraftSaveStatus.module.scss';
+
+interface Props {
+  readonly status: 'idle' | 'saving' | 'saved';
+}
+
+export function DraftSaveStatus({ status }: Props) {
+  if (status === 'idle') return null;
+
+  return (
+    <span className={status === 'saving' ? s.saving : s.saved}>
+      {status === 'saved' && (
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
+          <path d="M2 5l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      )}
+      {status === 'saving' ? 'Saving…' : 'Saved'}
+    </span>
+  );
+}

--- a/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.module.scss
+++ b/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.module.scss
@@ -1,3 +1,26 @@
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.discardDraftLink {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 14px;
+  font-weight: 500;
+  color: #dd2c5a;
+  cursor: pointer;
+  margin-right: auto;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .root {
   display: flex;
   flex-direction: column;

--- a/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.tsx
+++ b/components/page/gantry/ideas/SubmitIdeaModal/SubmitIdeaModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useRouter } from 'next/navigation';
 
@@ -15,13 +15,12 @@ import { useCreateGantryItem } from '@/services/gantry/hooks/useCreateGantryItem
 import { useGantryAccess } from '@/services/rbac/hooks/useGantryAccess';
 import { assignGantryItemObjective } from '@/services/gantry/gantry.service';
 import type { GantryItemType, GantryObjective, GantryStage } from '@/services/gantry/types';
-
+import { getSubmitIdeaFormDefaults, SUBMIT_IDEA_MODAL_COPY } from '@/services/gantry/submitIdeaModal';
 import {
-  getSubmitIdeaDraftKey,
-  getSubmitIdeaFormDefaults,
-  SUBMIT_IDEA_MODAL_COPY,
-} from '@/services/gantry/submitIdeaModal';
-import { useFormDraft } from '@/hooks/useFormDraft';
+  useGantryDiscardDraftMutation,
+  useGantryDraftQuery,
+  useGantrySaveDraftMutation,
+} from '@/services/gantry/hooks/useGantryDraft';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
 import {
   submitIdeaSchema,
@@ -30,8 +29,12 @@ import {
   type SubmitIdeaDraft,
   type SubmitIdeaFormData,
 } from './helpers';
+import { DraftSaveStatus } from './DraftSaveStatus';
+import { DiscardDraftDialog } from '../DiscardDraftDialog';
 import dealModalStyles from '@/components/page/deals/SubmitDealModal/SubmitDealModal.module.scss';
 import s from './SubmitIdeaModal.module.scss';
+
+const SAVE_DEBOUNCE_MS = 500;
 
 interface Props {
   readonly objectives?: GantryObjective[];
@@ -49,45 +52,98 @@ export function SubmitIdeaModal({ objectives = [] }: Props) {
 
   const [showCreateObjective, setShowCreateObjective] = useState(false);
   const [newObjectiveTitle, setNewObjectiveTitle] = useState('');
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+
+  const { data: draftResult } = useGantryDraftQuery(variant);
+  const saveDraftMutation = useGantrySaveDraftMutation(variant);
+  const discardDraftMutation = useGantryDiscardDraftMutation(variant);
+
+  const hasDraft = !!draftResult && !isSubmitIdeaDraftEmpty(draftResult.data);
+
+  const saveStatus = saveDraftMutation.isPending
+    ? 'saving'
+    : saveDraftMutation.isSuccess
+    ? 'saved'
+    : 'idle';
 
   const methods = useForm<SubmitIdeaFormData>({
     resolver: yupResolver(submitIdeaSchema) as any,
-    defaultValues: getSubmitIdeaFormDefaults('idea'),
+    defaultValues: getSubmitIdeaFormDefaults(variant),
     mode: 'onChange',
   });
 
   const {
     handleSubmit,
     reset,
+    getValues,
+    control,
     formState: { isValid },
   } = methods;
 
-  const { clearDraft } = useFormDraft<SubmitIdeaFormData, SubmitIdeaDraft>({
-    storageKey: getSubmitIdeaDraftKey(variant),
-    enabled: open,
-    methods,
-    getDefaults: () => getSubmitIdeaFormDefaults(variant),
-    toDraft: (form) => ({
-      form,
-      showCreateObjective,
-      newObjectiveTitle,
-    }),
-    fromDraft: (draft) => draft.form,
-    isEmpty: isSubmitIdeaDraftEmpty,
-    onRestore: (draft) => {
-      setShowCreateObjective(draft?.showCreateObjective ?? false);
-      setNewObjectiveTitle(draft?.newObjectiveTitle ?? '');
-    },
-    saveDeps: [showCreateObjective, newObjectiveTitle],
-  });
+  const values = useWatch({ control });
+  const skipSaveRef = useRef(true);
+
+  // Restore draft when modal opens
+  useEffect(() => {
+    if (!open) {
+      skipSaveRef.current = true;
+      return;
+    }
+    skipSaveRef.current = true;
+    if (draftResult && !isSubmitIdeaDraftEmpty(draftResult.data)) {
+      reset(draftResult.data.form);
+      setShowCreateObjective(draftResult.data.showCreateObjective ?? false);
+      setNewObjectiveTitle(draftResult.data.newObjectiveTitle ?? '');
+    } else {
+      reset(getSubmitIdeaFormDefaults(variant));
+      setShowCreateObjective(false);
+      setNewObjectiveTitle('');
+    }
+    const id = window.setTimeout(() => { skipSaveRef.current = false; }, 0);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, variant]);
+
+  // Autosave draft while modal is open
+  const toDraft = useCallback((): SubmitIdeaDraft => ({
+    form: getValues(),
+    showCreateObjective,
+    newObjectiveTitle,
+  }), [getValues, showCreateObjective, newObjectiveTitle]);
+
+  useEffect(() => {
+    if (!open || skipSaveRef.current) return;
+    const id = window.setTimeout(() => {
+      const draft = toDraft();
+      if (isSubmitIdeaDraftEmpty(draft)) {
+        discardDraftMutation.mutate();
+      } else {
+        saveDraftMutation.mutate(draft);
+      }
+    }, SAVE_DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, values, showCreateObjective, newObjectiveTitle]);
 
   const onClose = () => {
     actions.closeModal();
   };
 
+  const handleDiscardFromModal = () => {
+    setDiscardDialogOpen(true);
+  };
+
+  const handleConfirmDiscard = () => {
+    discardDraftMutation.mutate();
+    setDiscardDialogOpen(false);
+    reset(getSubmitIdeaFormDefaults(variant));
+    setShowCreateObjective(false);
+    setNewObjectiveTitle('');
+    actions.closeModal();
+  };
+
   const onSubmit = (data: SubmitIdeaFormData) => {
     const stageValue = data.stage?.value as GantryStage | undefined;
-
     const tags = data.tags?.map((o) => o.value) ?? [];
     const itemType = data.type?.value as GantryItemType | undefined;
 
@@ -117,7 +173,7 @@ export function SubmitIdeaModal({ objectives = [] }: Props) {
             }
           }
           analytics.onIdeaCreated(created.uid, tags, itemType);
-          clearDraft();
+          discardDraftMutation.mutate();
           reset(getSubmitIdeaFormDefaults('idea'));
           setShowCreateObjective(false);
           setNewObjectiveTitle('');
@@ -129,106 +185,121 @@ export function SubmitIdeaModal({ objectives = [] }: Props) {
   };
 
   return (
-    <Modal isOpen={open} onClose={onClose} closeOnBackdropClick={false}>
-      <div className={s.root}>
-        <div className={dealModalStyles.header}>
-          <div className={dealModalStyles.headerText}>
-            <h2 className={dealModalStyles.title}>{copy.title}</h2>
-            <p className={dealModalStyles.subtitle}>{copy.subtitle}</p>
-          </div>
-          <button type="button" className={dealModalStyles.closeButton} onClick={onClose} aria-label="Close">
-            <CloseIcon width={20} height={20} color="#0a0c11" />
-          </button>
-        </div>
-
-        <div className={dealModalStyles.content}>
-          <FormProvider {...methods}>
-            <IdeaFormFields canSetStageOnCreate={canSetStageOnCreate} />
-            {canCurate && (
-              <div className={s.objectiveField}>
-                <FormSelect
-                  name="objective"
-                  label="Objective"
-                  placeholder="Select an objective..."
-                  options={objectiveOptions}
-                  isClearable
-                  menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
-                  onChange={() => {
-                    setShowCreateObjective(false);
-                    setNewObjectiveTitle('');
-                  }}
-                />
-                {!showCreateObjective ? (
-                  <button
-                    type="button"
-                    className={s.objectiveCreateBtn}
-                    onClick={() => {
-                      setShowCreateObjective(true);
-                    }}
-                  >
-                    + New objective
-                  </button>
-                ) : (
-                  <div className={s.objectiveCreateForm}>
-                    <input
-                      className={s.objectiveCreateInput}
-                      value={newObjectiveTitle}
-                      onChange={(e) => setNewObjectiveTitle(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Escape') {
-                          setShowCreateObjective(false);
-                          setNewObjectiveTitle('');
-                        }
-                      }}
-                      placeholder="Objective title..."
-                      maxLength={150}
-                      autoFocus
-                    />
-                    <div className={s.objectiveCreateMeta}>
-                      <span className={s.objectiveCharCount}>{newObjectiveTitle.length}/150</span>
-                      <button
-                        type="button"
-                        className={s.objectiveCancelBtn}
-                        onClick={() => {
-                          setShowCreateObjective(false);
-                          setNewObjectiveTitle('');
-                        }}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                )}
+    <>
+      <Modal isOpen={open} onClose={onClose} closeOnBackdropClick={false}>
+        <div className={s.root}>
+          <div className={dealModalStyles.header}>
+            <div className={dealModalStyles.headerText}>
+              <div className={s.titleRow}>
+                <h2 className={dealModalStyles.title}>{copy.title}</h2>
+                <DraftSaveStatus status={saveStatus} />
               </div>
-            )}
-          </FormProvider>
-        </div>
+              <p className={dealModalStyles.subtitle}>{copy.subtitle}</p>
+            </div>
+            <button type="button" className={dealModalStyles.closeButton} onClick={onClose} aria-label="Close">
+              <CloseIcon width={20} height={20} color="#0a0c11" />
+            </button>
+          </div>
 
-        <div className={dealModalStyles.footer}>
-          {copy.footerNote ? (
-            <>
-              <p className={dealModalStyles.footerNote}>{copy.footerNote}</p>
-              <div className={dealModalStyles.footerActions}>
-                <Button style="link" variant="secondary" onClick={onClose}>
+          <div className={dealModalStyles.content}>
+            <FormProvider {...methods}>
+              <IdeaFormFields canSetStageOnCreate={canSetStageOnCreate} />
+              {canCurate && (
+                <div className={s.objectiveField}>
+                  <FormSelect
+                    name="objective"
+                    label="Objective"
+                    placeholder="Select an objective..."
+                    options={objectiveOptions}
+                    isClearable
+                    menuPortalTarget={typeof document !== 'undefined' ? document.body : null}
+                    onChange={() => {
+                      setShowCreateObjective(false);
+                      setNewObjectiveTitle('');
+                    }}
+                  />
+                  {!showCreateObjective ? (
+                    <button
+                      type="button"
+                      className={s.objectiveCreateBtn}
+                      onClick={() => { setShowCreateObjective(true); }}
+                    >
+                      + New objective
+                    </button>
+                  ) : (
+                    <div className={s.objectiveCreateForm}>
+                      <input
+                        className={s.objectiveCreateInput}
+                        value={newObjectiveTitle}
+                        onChange={(e) => setNewObjectiveTitle(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Escape') {
+                            setShowCreateObjective(false);
+                            setNewObjectiveTitle('');
+                          }
+                        }}
+                        placeholder="Objective title..."
+                        maxLength={150}
+                        autoFocus
+                      />
+                      <div className={s.objectiveCreateMeta}>
+                        <span className={s.objectiveCharCount}>{newObjectiveTitle.length}/150</span>
+                        <button
+                          type="button"
+                          className={s.objectiveCancelBtn}
+                          onClick={() => {
+                            setShowCreateObjective(false);
+                            setNewObjectiveTitle('');
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </FormProvider>
+          </div>
+
+          <div className={dealModalStyles.footer}>
+            {hasDraft && (
+              <button type="button" className={s.discardDraftLink} onClick={handleDiscardFromModal}>
+                Discard draft
+              </button>
+            )}
+            {copy.footerNote ? (
+              <>
+                <p className={dealModalStyles.footerNote}>{copy.footerNote}</p>
+                <div className={dealModalStyles.footerActions}>
+                  <Button style="link" variant="secondary" onClick={onClose}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleSubmit(onSubmit)} disabled={!isValid || isPending}>
+                    {isPending ? copy.submittingLabel : copy.submitLabel}
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <Button style="border" variant="neutral" onClick={onClose}>
                   Cancel
                 </Button>
                 <Button onClick={handleSubmit(onSubmit)} disabled={!isValid || isPending}>
                   {isPending ? copy.submittingLabel : copy.submitLabel}
                 </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <Button style="border" variant="neutral" onClick={onClose}>
-                Cancel
-              </Button>
-              <Button onClick={handleSubmit(onSubmit)} disabled={!isValid || isPending}>
-                {isPending ? copy.submittingLabel : copy.submitLabel}
-              </Button>
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+
+      <DiscardDraftDialog
+        isOpen={discardDialogOpen}
+        draftTitle={draftResult?.data.form.title ?? ''}
+        onKeep={() => setDiscardDialogOpen(false)}
+        onDiscard={handleConfirmDiscard}
+      />
+    </>
   );
 }

--- a/components/page/gantry/roadmap/Roadmap.module.scss
+++ b/components/page/gantry/roadmap/Roadmap.module.scss
@@ -594,6 +594,7 @@
   gap: 8px;
   width: 100%;
   justify-content: space-between;
+  margin-top: 12px;
 }
 
 .drawerClearAllBtn {

--- a/components/page/gantry/roadmap/RoadmapView.tsx
+++ b/components/page/gantry/roadmap/RoadmapView.tsx
@@ -38,6 +38,14 @@ import FilterCount from '@/components/ui/filter-count';
 import { useGantryPinNote } from '@/services/gantry/hooks/useGantryPinNote';
 import { PinNotePopover } from '@/components/page/gantry/shared/PinNotePopover';
 import { PinSwapPicker } from '@/components/page/gantry/shared/PinSwapPicker';
+import {
+  useGantryDraftQuery,
+  useGantryDiscardDraftMutation,
+} from '@/services/gantry/hooks/useGantryDraft';
+import { isSubmitIdeaDraftEmpty } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+import { GantryDraftBanner } from '@/components/page/gantry/ideas/GantryDraftBanner';
+import { GantryDraftChip } from '@/components/page/gantry/ideas/GantryDraftChip';
+import { DiscardDraftDialog } from '@/components/page/gantry/ideas/DiscardDraftDialog';
 import { RoadmapCard, RoadmapCardDragOverlay } from './RoadmapCard';
 import { RoadmapDropColumn, isRoadmapColumnStage } from './RoadmapDropColumn';
 import { RoadmapFilters, type RoadmapColumnStage } from './RoadmapFilters';
@@ -50,6 +58,9 @@ import gantryPageStyles from '@/components/page/gantry/GantryPage.module.scss';
 import s from './Roadmap.module.scss';
 
 const BOOST_TIP_KEY = 'gantry_boost_tip_dismissed';
+
+const DEFAULT_SUBTITLE = 'Submit what you need, see what we are building. The shortest path to the LabOS roadmap.';
+const DRAFT_SUBTITLE = 'Share what the network needs and track it across the roadmap. You can keep one draft at a time.';
 
 function ArrowUpSmallIcon() {
   return (
@@ -76,6 +87,28 @@ export function RoadmapView() {
   const canCreate = canSetStageOnCreate || canCreateIdea;
   const createLabel = canSetStageOnCreate ? 'Create Item' : 'Share a need';
   const createVariant = canSetStageOnCreate ? 'roadmap' : 'idea';
+
+  // Draft state
+  const { data: draftResult } = useGantryDraftQuery(createVariant);
+  const discardDraftMutation = useGantryDiscardDraftMutation(createVariant);
+  const hasDraft = !!draftResult && !isSubmitIdeaDraftEmpty(draftResult.data);
+  const draftSavedAt = draftResult?.savedAt ?? 0;
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+
+  const handleResumeDraft = () => {
+    submitIdeaModalActions.openModal(createVariant);
+  };
+
+  const handleOpenDiscardDialog = () => {
+    setDiscardDialogOpen(true);
+  };
+
+  const handleConfirmDiscard = () => {
+    discardDraftMutation.mutate();
+    setDiscardDialogOpen(false);
+  };
+
+  const subtitle = hasDraft ? DRAFT_SUBTITLE : DEFAULT_SUBTITLE;
 
   const [visibleColumns, setVisibleColumns] = useLocalStorageParam<RoadmapColumnStage[]>(
     GANTRY_VISIBLE_COLUMNS_STORAGE_KEY,
@@ -316,6 +349,12 @@ export function RoadmapView() {
           onDismiss={handleSwapDismiss}
         />
       )}
+      <DiscardDraftDialog
+        isOpen={discardDialogOpen}
+        draftTitle={draftResult?.data.form.title ?? ''}
+        onKeep={() => setDiscardDialogOpen(false)}
+        onDiscard={handleConfirmDiscard}
+      />
     </>
   );
 
@@ -355,13 +394,19 @@ export function RoadmapView() {
                     {canCreate && (
                       <IdeasSubmitButton
                         label={createLabel}
-                        onClick={() => submitIdeaModalActions.openModal(createVariant)}
+                        hasDraft={hasDraft}
+                        onClick={hasDraft ? handleResumeDraft : () => submitIdeaModalActions.openModal(createVariant)}
                       />
                     )}
                   </div>
-                  <p className={s.subtitle}>
-                    Submit what you need, see what we are building. The shortest path to the LabOS roadmap.
-                  </p>
+                  {hasDraft && (
+                    <GantryDraftChip
+                      title={draftResult?.data.form.title ?? ''}
+                      onResume={handleResumeDraft}
+                      onDiscard={handleOpenDiscardDialog}
+                    />
+                  )}
+                  <p className={s.subtitle}>{subtitle}</p>
                 </div>
               </div>
             </div>
@@ -529,26 +574,35 @@ export function RoadmapView() {
                         <div className={s.actionsMobile}>
                           <IdeasSubmitButton
                             label={createLabel}
-                            onClick={() => submitIdeaModalActions.openModal(createVariant)}
+                            hasDraft={hasDraft}
+                            onClick={hasDraft ? handleResumeDraft : () => submitIdeaModalActions.openModal(createVariant)}
                           />
                         </div>
                       )}
                     </div>
-                    <p className={s.subtitle}>
-                      Submit what you need, see what we are building. The shortest path to the LabOS roadmap.
-                    </p>
+                    <p className={s.subtitle}>{subtitle}</p>
                   </div>
                   <div className={s.actions}>
                     {boostStatusIndicator}
                     {canCreate && (
                       <IdeasSubmitButton
                         label={createLabel}
-                        onClick={() => submitIdeaModalActions.openModal(createVariant)}
+                        hasDraft={hasDraft}
+                        onClick={hasDraft ? handleResumeDraft : () => submitIdeaModalActions.openModal(createVariant)}
                       />
                     )}
                   </div>
                 </div>
               </div>
+
+              {hasDraft && (
+                <GantryDraftBanner
+                  title={draftResult?.data.form.title ?? ''}
+                  savedAt={draftSavedAt}
+                  onResume={handleResumeDraft}
+                  onDiscard={handleOpenDiscardDialog}
+                />
+              )}
 
               {orderedVisibleColumns.length === 0 ? (
                 <p className={s.empty}>Select at least one column to view the roadmap.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "framer-motion": "^12.16.0",
         "he": "^1.2.0",
         "html-react-parser": "^5.2.6",
+        "idb": "^8.0.3",
         "isomorphic-dompurify": "^2.13.0",
         "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.2",
@@ -13795,6 +13796,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "framer-motion": "^12.16.0",
     "he": "^1.2.0",
     "html-react-parser": "^5.2.6",
+    "idb": "^8.0.3",
     "isomorphic-dompurify": "^2.13.0",
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.2",

--- a/services/gantry/constants.ts
+++ b/services/gantry/constants.ts
@@ -8,6 +8,7 @@ export enum GantryQueryKeys {
   OBJECTIVES = 'gantry-objectives',
   PIN_STATUS = 'gantry-pin-status',
   ITEM_PINS = 'gantry-item-pins',
+  DRAFT = 'gantry-draft',
 }
 
 export const GANTRY_STAGE_VALUES = ['IDEA', 'BACKLOG', 'PLANNED', 'IN_PROGRESS', 'SHIPPED', 'DECLINED'] as const;

--- a/services/gantry/hooks/useGantryDraft.ts
+++ b/services/gantry/hooks/useGantryDraft.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  deleteGantryDraft,
+  readGantryDraft,
+  readGantryDraftSavedAt,
+  writeGantryDraft,
+} from '@/utils/gantryDraftStorage';
+import { GantryQueryKeys } from '../constants';
+import type { SubmitIdeaModalVariant } from '../submitIdeaModal';
+import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+
+export type GantryDraftQueryResult = {
+  data: SubmitIdeaDraft;
+  savedAt: number;
+} | null;
+
+export function useGantryDraftQuery(variant: SubmitIdeaModalVariant) {
+  return useQuery<GantryDraftQueryResult>({
+    queryKey: [GantryQueryKeys.DRAFT, variant],
+    queryFn: async () => {
+      const [data, savedAt] = await Promise.all([
+        readGantryDraft(variant),
+        readGantryDraftSavedAt(variant),
+      ]);
+      if (!data || savedAt === null) return null;
+      return { data, savedAt };
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function useGantrySaveDraftMutation(variant: SubmitIdeaModalVariant) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (draft: SubmitIdeaDraft) => writeGantryDraft(variant, draft),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.DRAFT, variant] });
+    },
+  });
+}
+
+export function useGantryDiscardDraftMutation(variant: SubmitIdeaModalVariant) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteGantryDraft(variant),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [GantryQueryKeys.DRAFT, variant] });
+    },
+  });
+}

--- a/utils/gantryDraftStorage.ts
+++ b/utils/gantryDraftStorage.ts
@@ -1,0 +1,71 @@
+import { openDB } from 'idb';
+import type { SubmitIdeaModalVariant } from '@/services/gantry/submitIdeaModal';
+import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+
+const DB_NAME = 'gantry-drafts';
+const DB_VERSION = 1;
+const STORE_NAME = 'drafts';
+const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type GantryDraftEnvelope = {
+  v: 1;
+  savedAt: number;
+  data: SubmitIdeaDraft;
+};
+
+async function getDB() {
+  return openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+}
+
+export async function readGantryDraft(variant: SubmitIdeaModalVariant): Promise<SubmitIdeaDraft | null> {
+  try {
+    const db = await getDB();
+    const envelope = await db.get(STORE_NAME, variant) as GantryDraftEnvelope | undefined;
+    if (!envelope || envelope.v !== 1 || typeof envelope.savedAt !== 'number' || !envelope.data) {
+      return null;
+    }
+    if (Date.now() - envelope.savedAt > DRAFT_TTL_MS) {
+      await db.delete(STORE_NAME, variant);
+      return null;
+    }
+    return envelope.data;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeGantryDraft(variant: SubmitIdeaModalVariant, data: SubmitIdeaDraft): Promise<void> {
+  try {
+    const db = await getDB();
+    const envelope: GantryDraftEnvelope = { v: 1, savedAt: Date.now(), data };
+    await db.put(STORE_NAME, envelope, variant);
+  } catch {
+    // IDB unavailable or quota exceeded — fail silently
+  }
+}
+
+export async function deleteGantryDraft(variant: SubmitIdeaModalVariant): Promise<void> {
+  try {
+    const db = await getDB();
+    await db.delete(STORE_NAME, variant);
+  } catch {
+    // ignore
+  }
+}
+
+export async function readGantryDraftSavedAt(variant: SubmitIdeaModalVariant): Promise<number | null> {
+  try {
+    const db = await getDB();
+    const envelope = await db.get(STORE_NAME, variant) as GantryDraftEnvelope | undefined;
+    if (!envelope || envelope.v !== 1) return null;
+    return envelope.savedAt;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Autosaves the Create Item / Share a Need form to IndexedDB (via idb) as the user types, with a debounced React Query mutation so switching to a real API endpoint requires only changing the mutation fn.

- DraftSaveStatus badge inline with modal title (Saving… / ✓ Saved)
- DiscardDraftDialog uses the animated Modal component
- GantryDraftBanner (desktop) and GantryDraftChip (mobile) surface the draft above the board with Resume / Discard actions
- IdeasSubmitButton switches to pencil icon + "Resume draft" when a draft exists
- Page subtitle updates to note one-draft-at-a-time limit
- Fixes infinite-save loop: replaced watch() with useWatch({ control }) so mutation state changes don't re-trigger the autosave effect