### PR TITLE
feat(gantry): migrate draft storage from IndexedDB to API (LAB-2022)

### DIFF
--- a/__tests__/hooks/useGantryDraft.test.tsx
+++ b/__tests__/hooks/useGantryDraft.test.tsx
@@ -2,25 +2,18 @@ import { type ReactNode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+import type { ApiGantryDraft } from '@/services/gantry/types';
 
 jest.unmock('@tanstack/react-query');
 
-// In-memory IDB simulation
-function makeMemoryDB() {
-  const store = new Map<string, unknown>();
-  return {
-    get: jest.fn((_s: string, key: string) => Promise.resolve(store.get(key))),
-    put: jest.fn((_s: string, value: unknown, key: string) => { store.set(key, value); return Promise.resolve(); }),
-    delete: jest.fn((_s: string, key: string) => { store.delete(key); return Promise.resolve(); }),
-    objectStoreNames: { contains: () => true },
-    _store: store,
-  };
-}
+const mockFetchGantryDraftFromApi = jest.fn<Promise<ApiGantryDraft | null>, []>();
+const mockSaveGantryDraftToApi = jest.fn<Promise<void>, [unknown]>();
+const mockDiscardGantryDraftFromApi = jest.fn<Promise<void>, []>();
 
-let memDB = makeMemoryDB();
-
-jest.mock('idb', () => ({
-  openDB: jest.fn(() => Promise.resolve(memDB)),
+jest.mock('@/services/gantry/gantry.service', () => ({
+  fetchGantryDraftFromApi: (...args: unknown[]) => mockFetchGantryDraftFromApi(...(args as [])),
+  saveGantryDraftToApi: (...args: unknown[]) => mockSaveGantryDraftToApi(...(args as [unknown])),
+  discardGantryDraftFromApi: (...args: unknown[]) => mockDiscardGantryDraftFromApi(...(args as [])),
 }));
 
 import {
@@ -28,6 +21,22 @@ import {
   useGantrySaveDraftMutation,
   useGantryDiscardDraftMutation,
 } from '@/services/gantry/hooks/useGantryDraft';
+
+const UPDATED_AT = '2026-06-17T12:00:00.000Z';
+
+const apiDraft: ApiGantryDraft = {
+  uid: 'draft-1',
+  variant: 'idea',
+  title: 'Test title',
+  description: '',
+  tags: [],
+  type: null,
+  stage: null,
+  objectiveUid: null,
+  newObjectiveTitle: null,
+  showCreateObjective: false,
+  updatedAt: UPDATED_AT,
+};
 
 const sampleDraft: SubmitIdeaDraft = {
   form: { title: 'Test title', description: '', tags: [], type: null, objective: null },
@@ -37,65 +46,81 @@ const sampleDraft: SubmitIdeaDraft = {
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
-  return { client, wrapper: ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
-  )};
+  return {
+    client,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  };
 }
 
 beforeEach(() => {
-  memDB = makeMemoryDB();
-  const { openDB } = require('idb');
-  (openDB as jest.Mock).mockResolvedValue(memDB);
+  jest.clearAllMocks();
+  mockFetchGantryDraftFromApi.mockResolvedValue(null);
+  mockSaveGantryDraftToApi.mockResolvedValue(undefined);
+  mockDiscardGantryDraftFromApi.mockResolvedValue(undefined);
 });
 
 describe('useGantryDraftQuery', () => {
-  it('returns null when no draft is stored', async () => {
+  it('returns null when no draft exists', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeNull();
   });
+
+  it('returns draft data when API returns a matching draft', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(apiDraft);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data!.data.form.title).toBe('Test title');
+    expect(result.current.data!.savedAt).toBe(new Date(UPDATED_AT).getTime());
+  });
 });
 
 describe('useGantrySaveDraftMutation', () => {
-  it('writes draft and resolves successfully', async () => {
+  it('calls saveGantryDraftToApi and resolves successfully', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useGantrySaveDraftMutation('idea'), { wrapper });
     await act(async () => { result.current.mutate(sampleDraft); });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(memDB.put).toHaveBeenCalled();
+    expect(mockSaveGantryDraftToApi).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'idea', title: 'Test title' }),
+    );
   });
 });
 
 describe('useGantryDiscardDraftMutation', () => {
-  it('deletes the draft and resolves successfully', async () => {
-    const envelope = { v: 1, savedAt: Date.now(), data: sampleDraft };
-    memDB._store.set('idea', envelope);
-
+  it('calls discardGantryDraftFromApi and resolves successfully', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useGantryDiscardDraftMutation('idea'), { wrapper });
     await act(async () => { result.current.mutate(); });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(memDB._store.has('idea')).toBe(false);
+    expect(mockDiscardGantryDraftFromApi).toHaveBeenCalled();
   });
 });
 
 describe('save then discard flow', () => {
-  it('draft is null after save + discard', async () => {
-    const { wrapper, client } = makeWrapper();
+  it('draft is null after discard invalidates the query', async () => {
+    // Start with a draft visible, then discard it
+    mockFetchGantryDraftFromApi
+      .mockResolvedValueOnce(apiDraft)  // initial query fetch → has draft
+      .mockResolvedValueOnce(null);      // re-fetch after discard → no draft
 
-    const { result: saveResult } = renderHook(() => useGantrySaveDraftMutation('idea'), { wrapper });
-    await act(async () => { saveResult.current.mutate(sampleDraft); });
-    await waitFor(() => expect(saveResult.current.isSuccess).toBe(true));
+    const { wrapper } = makeWrapper();
+
+    // Render query first so it subscribes before mutations fire
+    const { result: queryResult } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
+    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
+    expect(queryResult.current.data).not.toBeNull();
 
     const { result: discardResult } = renderHook(() => useGantryDiscardDraftMutation('idea'), { wrapper });
     await act(async () => { discardResult.current.mutate(); });
     await waitFor(() => expect(discardResult.current.isSuccess).toBe(true));
 
-    await act(async () => { await client.invalidateQueries(); });
-
-    const { result: queryResult } = renderHook(() => useGantryDraftQuery('idea'), { wrapper });
-    await waitFor(() => expect(queryResult.current.isSuccess).toBe(true));
-    expect(queryResult.current.data).toBeNull();
+    // invalidateQueries triggers a re-fetch of the active query
+    await waitFor(() => expect(queryResult.current.data).toBeNull());
   });
 });

--- a/__tests__/utils/gantryDraftStorage.test.ts
+++ b/__tests__/utils/gantryDraftStorage.test.ts
@@ -1,116 +1,168 @@
 import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
+import type { ApiGantryDraft } from '@/services/gantry/types';
 
-// In-memory IDB simulation — keeps one store keyed by string.
-function makeMemoryDB() {
-  const store = new Map<string, unknown>();
-  return {
-    get: jest.fn((_s: string, key: string) => Promise.resolve(store.get(key))),
-    put: jest.fn((_s: string, value: unknown, key: string) => { store.set(key, value); return Promise.resolve(); }),
-    delete: jest.fn((_s: string, key: string) => { store.delete(key); return Promise.resolve(); }),
-    objectStoreNames: { contains: () => true },
-    _store: store,
-  };
-}
+const mockFetchGantryDraftFromApi = jest.fn<Promise<ApiGantryDraft | null>, []>();
+const mockSaveGantryDraftToApi = jest.fn<Promise<void>, [unknown]>();
+const mockDiscardGantryDraftFromApi = jest.fn<Promise<void>, []>();
 
-let memDB = makeMemoryDB();
-
-jest.mock('idb', () => ({
-  openDB: jest.fn(() => Promise.resolve(memDB)),
+jest.mock('@/services/gantry/gantry.service', () => ({
+  fetchGantryDraftFromApi: (...args: unknown[]) => mockFetchGantryDraftFromApi(...(args as [])),
+  saveGantryDraftToApi: (...args: unknown[]) => mockSaveGantryDraftToApi(...(args as [unknown])),
+  discardGantryDraftFromApi: (...args: unknown[]) => mockDiscardGantryDraftFromApi(...(args as [])),
 }));
 
 import {
   readGantryDraft,
+  readGantryDraftResult,
+  readGantryDraftSavedAt,
   writeGantryDraft,
   deleteGantryDraft,
-  readGantryDraftSavedAt,
 } from '@/utils/gantryDraftStorage';
 
-const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const UPDATED_AT = '2026-06-17T12:00:00.000Z';
+const UPDATED_AT_MS = new Date(UPDATED_AT).getTime();
 
 const sampleDraft: SubmitIdeaDraft = {
-  form: { title: 'Need better filters', description: '', tags: [], type: null, objective: null },
+  form: { title: 'Need better filters', description: '', tags: [], type: null, stage: null, objective: null },
   showCreateObjective: false,
   newObjectiveTitle: '',
 };
 
+const apiDraft: ApiGantryDraft = {
+  uid: 'draft-1',
+  variant: 'idea',
+  title: 'Need better filters',
+  description: '',
+  tags: [],
+  type: null,
+  stage: null,
+  objectiveUid: null,
+  newObjectiveTitle: null,
+  showCreateObjective: false,
+  updatedAt: UPDATED_AT,
+};
+
 beforeEach(() => {
-  memDB = makeMemoryDB();
-  const { openDB } = require('idb');
-  (openDB as jest.Mock).mockResolvedValue(memDB);
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+  jest.clearAllMocks();
 });
 
-afterEach(() => {
-  jest.useRealTimers();
+describe('readGantryDraftResult', () => {
+  it('returns mapped draft and savedAt when variant matches', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(apiDraft);
+    const result = await readGantryDraftResult('idea');
+    expect(result).not.toBeNull();
+    expect(result!.savedAt).toBe(UPDATED_AT_MS);
+    expect(result!.data.form.title).toBe('Need better filters');
+  });
+
+  it('returns null when no draft exists', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(null);
+    expect(await readGantryDraftResult('idea')).toBeNull();
+  });
+
+  it('returns null when stored draft variant does not match requested variant', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({ ...apiDraft, variant: 'roadmap' });
+    expect(await readGantryDraftResult('idea')).toBeNull();
+  });
+
+  it('returns null on API error', async () => {
+    mockFetchGantryDraftFromApi.mockRejectedValueOnce(new Error('network error'));
+    expect(await readGantryDraftResult('idea')).toBeNull();
+  });
 });
 
-describe('writeGantryDraft + readGantryDraft', () => {
-  it('writes and reads back a draft', async () => {
-    await writeGantryDraft('idea', sampleDraft);
-    const result = await readGantryDraft('idea');
-    expect(result).toEqual(sampleDraft);
-  });
-
-  it('returns null when no draft is stored', async () => {
-    expect(await readGantryDraft('idea')).toBeNull();
-  });
-
-  it('stores drafts per variant independently', async () => {
-    await writeGantryDraft('idea', sampleDraft);
-    expect(await readGantryDraft('roadmap')).toBeNull();
+describe('readGantryDraft', () => {
+  it('returns draft data', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(apiDraft);
     expect(await readGantryDraft('idea')).toEqual(sampleDraft);
   });
-});
 
-describe('expired draft', () => {
-  it('returns null and deletes a draft past TTL', async () => {
-    await writeGantryDraft('idea', sampleDraft);
-    jest.setSystemTime(new Date('2026-06-12T12:00:00Z').getTime() + DRAFT_TTL_MS + 1000);
-    expect(await readGantryDraft('idea')).toBeNull();
-    expect(memDB.delete).toHaveBeenCalledWith(STORE_NAME_SENTINEL, 'idea');
-  });
-});
-
-// Sentinel for store name used in assertions
-const STORE_NAME_SENTINEL = 'drafts';
-
-describe('deleteGantryDraft', () => {
-  it('removes the stored draft', async () => {
-    await writeGantryDraft('idea', sampleDraft);
-    await deleteGantryDraft('idea');
+  it('returns null when no draft', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(null);
     expect(await readGantryDraft('idea')).toBeNull();
   });
 });
 
 describe('readGantryDraftSavedAt', () => {
-  it('returns the savedAt timestamp', async () => {
-    await writeGantryDraft('idea', sampleDraft);
-    const savedAt = await readGantryDraftSavedAt('idea');
-    expect(savedAt).toBe(new Date('2026-06-12T12:00:00Z').getTime());
+  it('returns the updatedAt timestamp as ms', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(apiDraft);
+    expect(await readGantryDraftSavedAt('idea')).toBe(UPDATED_AT_MS);
   });
 
   it('returns null when no draft exists', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce(null);
     expect(await readGantryDraftSavedAt('idea')).toBeNull();
   });
 });
 
-describe('IDB unavailable fallback', () => {
-  it('writeGantryDraft silently swallows errors', async () => {
-    const { openDB } = require('idb');
-    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
+describe('writeGantryDraft', () => {
+  it('calls saveGantryDraftToApi with mapped payload', async () => {
+    mockSaveGantryDraftToApi.mockResolvedValueOnce(undefined);
+    await writeGantryDraft('idea', sampleDraft);
+    expect(mockSaveGantryDraftToApi).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'idea', title: 'Need better filters' }),
+    );
+  });
+
+  it('silently swallows API errors', async () => {
+    mockSaveGantryDraftToApi.mockRejectedValueOnce(new Error('network error'));
     await expect(writeGantryDraft('idea', sampleDraft)).resolves.toBeUndefined();
   });
+});
 
-  it('readGantryDraft returns null on error', async () => {
-    const { openDB } = require('idb');
-    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
-    expect(await readGantryDraft('idea')).toBeNull();
+describe('deleteGantryDraft', () => {
+  it('calls discardGantryDraftFromApi', async () => {
+    mockDiscardGantryDraftFromApi.mockResolvedValueOnce(undefined);
+    await deleteGantryDraft('idea');
+    expect(mockDiscardGantryDraftFromApi).toHaveBeenCalled();
   });
 
-  it('deleteGantryDraft silently swallows errors', async () => {
-    const { openDB } = require('idb');
-    (openDB as jest.Mock).mockRejectedValueOnce(new Error('IDB unavailable'));
+  it('silently swallows API errors', async () => {
+    mockDiscardGantryDraftFromApi.mockRejectedValueOnce(new Error('network error'));
     await expect(deleteGantryDraft('idea')).resolves.toBeUndefined();
+  });
+});
+
+describe('field mapping — API → SubmitIdeaDraft', () => {
+  it('maps tags from string[] to Option[]', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({
+      ...apiDraft,
+      tags: ['infra', 'perf'],
+    });
+    const result = await readGantryDraft('idea');
+    expect(result!.form.tags).toEqual([
+      { label: 'infra', value: 'infra' },
+      { label: 'perf', value: 'perf' },
+    ]);
+  });
+
+  it('maps type string to Option', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({ ...apiDraft, type: 'Bug Report' });
+    const result = await readGantryDraft('idea');
+    expect(result!.form.type).toEqual({ label: 'Bug Report', value: 'Bug Report' });
+  });
+
+  it('maps stage string to Option with label from GANTRY_STAGE_LABELS', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({ ...apiDraft, stage: 'PLANNED' });
+    const result = await readGantryDraft('idea');
+    expect(result!.form.stage?.value).toBe('PLANNED');
+    expect(result!.form.stage?.label).toBe('Planned');
+  });
+
+  it('maps objectiveUid to Option with empty label', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({ ...apiDraft, objectiveUid: 'obj-123' });
+    const result = await readGantryDraft('idea');
+    expect(result!.form.objective).toEqual({ label: '', value: 'obj-123' });
+  });
+
+  it('maps newObjectiveTitle and showCreateObjective', async () => {
+    mockFetchGantryDraftFromApi.mockResolvedValueOnce({
+      ...apiDraft,
+      newObjectiveTitle: 'Q3 Access',
+      showCreateObjective: true,
+    });
+    const result = await readGantryDraft('idea');
+    expect(result!.newObjectiveTitle).toBe('Q3 Access');
+    expect(result!.showCreateObjective).toBe(true);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "framer-motion": "^12.16.0",
         "he": "^1.2.0",
         "html-react-parser": "^5.2.6",
-        "idb": "^8.0.3",
         "isomorphic-dompurify": "^2.13.0",
         "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.2",
@@ -15075,11 +15074,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/idb": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
-      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "framer-motion": "^12.16.0",
     "he": "^1.2.0",
     "html-react-parser": "^5.2.6",
-    "idb": "^8.0.3",
     "isomorphic-dompurify": "^2.13.0",
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.2",

--- a/services/gantry/gantry.service.ts
+++ b/services/gantry/gantry.service.ts
@@ -1,5 +1,7 @@
 import { customFetch } from '@/utils/fetch-wrapper';
 import type {
+  ApiGantryDraft,
+  ApiGantryDraftPayload,
   CreateGantryItemPayload,
   GantryItem,
   GantryItemListResponse,
@@ -274,4 +276,25 @@ export async function trackBuildButtonClick(uid: string): Promise<void> {
   if (!res || !res.ok) {
     throw new Error('Failed to track build button click');
   }
+}
+
+const ROADMAP_DRAFT_URL = `${process.env.DIRECTORY_API_URL}/v1/roadmap/drafts/me`;
+
+export async function fetchGantryDraftFromApi(): Promise<ApiGantryDraft | null> {
+  const res = await customFetch(ROADMAP_DRAFT_URL, { method: 'GET' }, true);
+  if (!res || !res.ok) return null;
+  const json = await res.json();
+  return json.draft ?? null;
+}
+
+export async function saveGantryDraftToApi(payload: ApiGantryDraftPayload): Promise<void> {
+  await customFetch(
+    ROADMAP_DRAFT_URL,
+    { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) },
+    true,
+  );
+}
+
+export async function discardGantryDraftFromApi(): Promise<void> {
+  await customFetch(ROADMAP_DRAFT_URL, { method: 'DELETE' }, true);
 }

--- a/services/gantry/hooks/useGantryDraft.ts
+++ b/services/gantry/hooks/useGantryDraft.ts
@@ -3,8 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   deleteGantryDraft,
-  readGantryDraft,
-  readGantryDraftSavedAt,
+  readGantryDraftResult,
   writeGantryDraft,
 } from '@/utils/gantryDraftStorage';
 import { GantryQueryKeys } from '../constants';
@@ -19,14 +18,7 @@ export type GantryDraftQueryResult = {
 export function useGantryDraftQuery(variant: SubmitIdeaModalVariant) {
   return useQuery<GantryDraftQueryResult>({
     queryKey: [GantryQueryKeys.DRAFT, variant],
-    queryFn: async () => {
-      const [data, savedAt] = await Promise.all([
-        readGantryDraft(variant),
-        readGantryDraftSavedAt(variant),
-      ]);
-      if (!data || savedAt === null) return null;
-      return { data, savedAt };
-    },
+    queryFn: () => readGantryDraftResult(variant),
     staleTime: Infinity,
   });
 }

--- a/services/gantry/types.ts
+++ b/services/gantry/types.ts
@@ -100,6 +100,32 @@ export interface CreateGantryItemPayload {
   type?: GantryItemType;
 }
 
+export interface ApiGantryDraft {
+  uid: string;
+  variant: 'idea' | 'roadmap';
+  title: string;
+  description: string | null;
+  tags: string[];
+  type: string | null;
+  stage: string | null;
+  objectiveUid: string | null;
+  newObjectiveTitle: string | null;
+  showCreateObjective: boolean;
+  updatedAt: string;
+}
+
+export interface ApiGantryDraftPayload {
+  variant: 'idea' | 'roadmap';
+  title: string;
+  description?: string;
+  tags?: string[];
+  type?: string | null;
+  stage?: string | null;
+  objectiveUid?: string | null;
+  newObjectiveTitle?: string | null;
+  showCreateObjective?: boolean;
+}
+
 export interface UpdateGantryItemPayload {
   title?: string;
   description?: string;

--- a/utils/gantryDraftStorage.ts
+++ b/utils/gantryDraftStorage.ts
@@ -1,71 +1,77 @@
-import { openDB } from 'idb';
+import {
+  discardGantryDraftFromApi,
+  fetchGantryDraftFromApi,
+  saveGantryDraftToApi,
+} from '@/services/gantry/gantry.service';
+import type { ApiGantryDraft, ApiGantryDraftPayload } from '@/services/gantry/types';
+import { GANTRY_STAGE_LABELS } from '@/services/gantry/constants';
+import type { GantryStage } from '@/services/gantry/types';
 import type { SubmitIdeaModalVariant } from '@/services/gantry/submitIdeaModal';
 import type { SubmitIdeaDraft } from '@/components/page/gantry/ideas/SubmitIdeaModal/helpers';
 
-const DB_NAME = 'gantry-drafts';
-const DB_VERSION = 1;
-const STORE_NAME = 'drafts';
-const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-
-export type GantryDraftEnvelope = {
-  v: 1;
-  savedAt: number;
-  data: SubmitIdeaDraft;
-};
-
-async function getDB() {
-  return openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME);
-      }
-    },
-  });
+function draftToApiPayload(variant: SubmitIdeaModalVariant, draft: SubmitIdeaDraft): ApiGantryDraftPayload {
+  return {
+    variant,
+    title: draft.form.title,
+    description: draft.form.description ?? '',
+    tags: draft.form.tags?.map((o) => o.value) ?? [],
+    type: draft.form.type?.value ?? null,
+    stage: draft.form.stage?.value ?? null,
+    objectiveUid: draft.form.objective?.value ?? null,
+    newObjectiveTitle: draft.newObjectiveTitle || null,
+    showCreateObjective: draft.showCreateObjective,
+  };
 }
 
-export async function readGantryDraft(variant: SubmitIdeaModalVariant): Promise<SubmitIdeaDraft | null> {
+function apiDraftToDraft(api: ApiGantryDraft): SubmitIdeaDraft {
+  return {
+    form: {
+      title: api.title,
+      description: api.description ?? '',
+      tags: (api.tags ?? []).map((v) => ({ label: v, value: v })),
+      type: api.type ? { label: api.type, value: api.type } : null,
+      stage: api.stage
+        ? { label: GANTRY_STAGE_LABELS[api.stage as GantryStage] ?? api.stage, value: api.stage }
+        : null,
+      objective: api.objectiveUid ? { label: '', value: api.objectiveUid } : null,
+    },
+    showCreateObjective: api.showCreateObjective ?? false,
+    newObjectiveTitle: api.newObjectiveTitle ?? '',
+  };
+}
+
+export async function readGantryDraftResult(
+  variant: SubmitIdeaModalVariant,
+): Promise<{ data: SubmitIdeaDraft; savedAt: number } | null> {
   try {
-    const db = await getDB();
-    const envelope = await db.get(STORE_NAME, variant) as GantryDraftEnvelope | undefined;
-    if (!envelope || envelope.v !== 1 || typeof envelope.savedAt !== 'number' || !envelope.data) {
-      return null;
-    }
-    if (Date.now() - envelope.savedAt > DRAFT_TTL_MS) {
-      await db.delete(STORE_NAME, variant);
-      return null;
-    }
-    return envelope.data;
+    const api = await fetchGantryDraftFromApi();
+    if (!api || api.variant !== variant) return null;
+    return { data: apiDraftToDraft(api), savedAt: new Date(api.updatedAt).getTime() };
   } catch {
     return null;
   }
 }
 
+export async function readGantryDraft(variant: SubmitIdeaModalVariant): Promise<SubmitIdeaDraft | null> {
+  return (await readGantryDraftResult(variant))?.data ?? null;
+}
+
 export async function writeGantryDraft(variant: SubmitIdeaModalVariant, data: SubmitIdeaDraft): Promise<void> {
   try {
-    const db = await getDB();
-    const envelope: GantryDraftEnvelope = { v: 1, savedAt: Date.now(), data };
-    await db.put(STORE_NAME, envelope, variant);
+    await saveGantryDraftToApi(draftToApiPayload(variant, data));
   } catch {
-    // IDB unavailable or quota exceeded — fail silently
+    // network or auth error — fail silently
   }
 }
 
-export async function deleteGantryDraft(variant: SubmitIdeaModalVariant): Promise<void> {
+export async function deleteGantryDraft(_variant: SubmitIdeaModalVariant): Promise<void> {
   try {
-    const db = await getDB();
-    await db.delete(STORE_NAME, variant);
+    await discardGantryDraftFromApi();
   } catch {
     // ignore
   }
 }
 
 export async function readGantryDraftSavedAt(variant: SubmitIdeaModalVariant): Promise<number | null> {
-  try {
-    const db = await getDB();
-    const envelope = await db.get(STORE_NAME, variant) as GantryDraftEnvelope | undefined;
-    if (!envelope || envelope.v !== 1) return null;
-    return envelope.savedAt;
-  } catch {
-    return null;
-  }
+  return (await readGantryDraftResult(variant))?.savedAt ?? null;
 }


### PR DESCRIPTION
Replaces the temporary idb-backed draft storage with calls to the new /v1/roadmap/drafts/me endpoints (GET / PUT / DELETE). The React Query hooks and all components are unchanged — only the storage layer swaps.

- Add ApiGantryDraft / ApiGantryDraftPayload types to gantry/types.ts
- Add fetchGantryDraftFromApi / saveGantryDraftToApi / discardGantryDraftFromApi to gantry.service.ts following the existing customFetch pattern
- Rewrite gantryDraftStorage.ts as a thin API adapter with two-way mapping between SubmitIdeaDraft (Option objects) and the flat API shape
- readGantryDraftResult() makes one round-trip instead of two parallel calls; useGantryDraftQuery uses it directly
- Variant filtering: if the stored draft has a different variant, return null so each variant sees only its own draft
- All API calls wrapped in try/catch with null/void fallback (same contract as the prior IDB layer)
- Remove idb package