### PR TITLE
[Investor DB] Review and improve Warm Intros design

### DIFF
--- a/prototypes/entries/warm-intros-filter-update/AddToListButton.tsx
+++ b/prototypes/entries/warm-intros-filter-update/AddToListButton.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { InvestorList } from '@/services/investors/types';
+import { PlusIcon } from '@/components/icons';
+// Trigger uses the workspace .btn so it's the exact same size as the Export button.
+import s from '@/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss';
+import x from './WarmIntrosImprovements.module.scss';
+
+interface Props {
+  lists: InvestorList[];
+  onAdd: (listId: string) => void;
+  /**
+   * Remove the subject from a list. When provided, in-list rows become a
+   * clickable toggle (remove); when omitted, they stay disabled with a check.
+   */
+  onRemove?: (listId: string) => void;
+  /** Lists the subject already belongs to — shown disabled with a check. */
+  memberOf?: string[];
+  disabled?: boolean;
+  label?: string;
+  /** Open the menu upward (for use in the drawer footer at the bottom). */
+  openUp?: boolean;
+}
+
+/**
+ * Small popover that adds the subject(s) to a chosen list. Used as a bulk action
+ * over the selected table rows and inside the drawer for a single investor.
+ */
+export function AddToListButton({ lists, onAdd, onRemove, memberOf = [], disabled, label = 'Add to list', openUp }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  return (
+    <div className={x.addListWrap} ref={ref}>
+      <button type="button" className={s.btn} disabled={disabled} onClick={() => setOpen((o) => !o)}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <PlusIcon />
+          {label}
+        </span>
+      </button>
+      {open && (
+        <div className={openUp ? `${x.addListMenu} ${x.addListMenuUp}` : x.addListMenu}>
+          <div className={x.addListHead}>Add to list</div>
+          {lists.map((l) => {
+            const already = memberOf.includes(l.id);
+            // Removable when the subject is already in the list and a remove
+            // handler is wired up — the row then toggles membership off.
+            const removable = already && !!onRemove;
+            return (
+              <button
+                key={l.id}
+                type="button"
+                className={removable ? `${x.addListItem} ${x.addListItemToggle}` : x.addListItem}
+                disabled={already && !removable}
+                onClick={() => {
+                  if (removable) onRemove!(l.id);
+                  else onAdd(l.id);
+                  // Keep the popover open so users can toggle several lists, then
+                  // dismiss it themselves (outside-click or the trigger).
+                }}
+              >
+                <span>{l.name}</span>
+                {removable ? (
+                  <span className={x.addListToggle}>
+                    <span className={x.addListToggleIn}>✓ In list</span>
+                    <span className={x.addListToggleRemove}>Remove</span>
+                  </span>
+                ) : already ? (
+                  <span className={x.addListIn}>✓ in list</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-filter-update/COMPONENTS.md
+++ b/prototypes/entries/warm-intros-filter-update/COMPONENTS.md
@@ -1,0 +1,86 @@
+# Dev handoff — warm-intros-filter-update
+
+People-first redesign of the Warm Intros workspace (table + investor drawer). Every path is
+described by **who you reach**, not a company hop-chain. Mocked data only; no API/store/auth.
+
+**Imported** = production component used as-is. **SCSS-only** = data layer not reusable
+(react-query/store/closed API) so we import the `.module.scss` and feed mock data. **Copied** =
+markup replicated because the source isn't exported. **New** = prototype-only, needs a real impl.
+
+---
+
+## Files (all under `prototypes/entries/warm-intros-filter-update/`)
+
+| File | Role |
+|---|---|
+| `WarmIntrosFilterUpdatePrototype.tsx` | Page: filter bar, results table, mobile cards, drawer wiring |
+| `WarmPathPanel.tsx` | Drawer "Warm paths" — per-path card: connector / org card + contacts |
+| `PeopleChain.tsx` | The route node-chip renderer (the 4 node states below) |
+| `InvestorDrawerMock.tsx` | Investor detail drawer (sticky header + sections) |
+| `AddToListButton.tsx` | Add/remove-to-list popover (bulk + drawer) |
+| `WorkspaceSearch.tsx` | Connector/investor typeahead (lens filter) |
+| `ArrowUpRightIcon.tsx` | ↗ glyph copied from prod `OutreachInvestorTable` |
+| `mocks.ts` | **The data model** — read this first (types + factory) |
+| `WarmIntrosImprovements.module.scss` | All net-new styles |
+
+---
+
+## Data model (`mocks.ts`) — the important part for dev
+
+- `ContactPerson` — a person to reach. Key fields:
+  - `memberUid?` → **present = in PL network** (avatar + `/members/:uid`); **absent = external** (grey user icon, no link).
+  - `teams?: TeamLink[]` — orgs/firms the person is affiliated with, rendered as inline links in the role line. `TeamLink = { name, teamUid?, logo? }` (`teamUid` → `/teams/:uid`).
+- `OrgConnector` — used when we know a company can route the intro but **not who**:
+  `{ name, teamUid?, logo?, description, tags[], email?, website? }`. `teamUid` present ⇒ PL-network org (logo + link); absent ⇒ external firm (dashed building glyph).
+- `MockPath` — one route. `contact?` (person) **or** `orgConnector` (org). `chain` is kept only for the connector-lens search.
+- `RouteNode` / `connectorNode(path)` / `investorNode(inv)` / `pathChainNodes(path, inv)` — build the chain shown in the table (`[connector, investor]`).
+- `fourCasePaths(firstName, firm)` + the `MOCK_MEMBERS` map — **demo scaffolding**: every path-having investor is given the standard case set so all states are visible. Real data will have organic per-investor paths; drop this factory when wiring real data.
+
+## The node states (how a connector renders)
+
+| State | Condition | Visual |
+|---|---|---|
+| **Member known** | `contact.memberUid` set | avatar + name, links to `/members/:uid` (inline ↗) |
+| **Member unknown** | `contact`, no `memberUid` | grey user icon + name, no link |
+| **Org unknown** | `orgConnector`, no `teamUid` | dashed building glyph + name + `?`, not linked |
+| **Org known** | `orgConnector` + `teamUid` | real logo + name + `?`, links to `/teams/:uid` *(rendering exists; not used in current demo data)* |
+
+---
+
+## Imported (production, used as-is)
+- `Drawer`, `Button`, `Tabs` — `@/components/common/*`
+- `CopyButton`, `Tag` — `@/components/ui/*` (Tag = relationship + sector filter chips, `variant="secondary"` + `selected`)
+- `ProfileSocialLink` — `@/components/page/member-details/profile-social-link` (email/linkedin/telegram channels)
+- `ProximityCodeBadge`, `EngagementTierBadge`, `EmailStatusPill`, `SectorTagsList`, `ListPicker`, `GlossaryModal` — `@/components/page/investors/*`
+
+## Imported helpers / tokens
+- `getContactLogoByProvider` — `@/utils/profile/getContactLogoByProvider`
+- `getProfileFromURL` — `@/utils/common.utils`
+- `getDefaultAvatar` — `@/hooks/useDefaultAvatar`
+- Constants/types — `@/services/investors/{constants,types}`
+
+## SCSS-only (style reused, component mocked)
+- `WarmIntrosWorkspace.module.scss` (`s`) — workspace shell, filters, table, `.btn`/`.btnPrimary`
+- `InvestorDrawer.module.scss` (`s`) — drawer layout/sections
+- `WarmPathDetail.module.scss` (`pd`) — path card, chain (`.chain`/`.node`/`.arrow`/`.nodeLabel`)
+- `WorkspaceTypeahead.module.scss` — search input + dropdown
+- `Button.module.scss` (`btn`) — applied to anchors that can't be `<Button>`
+
+---
+
+## Behaviors a dev must wire to real data/routes
+- Links are **placeholder routes**: `/members/:uid`, `/teams/:uid` (also used for external firms in the demo — real impl should point external firms at a company route, not `/teams`).
+- **Sticky investor header** in the drawer (`.stickyHeader`) — keep on real drawer.
+- **Teams inline + "+N more"** in the role line (expand/collapse), each a `/teams` link.
+- **Per-path "Show N more paths"** (drawer shows the warmest, collapses the rest).
+- Stubbed: **"Suggest a correction"** (opens correction form in prod), **"Open in Affinity"**, **Export CSV**, **Add to list** (local state only).
+
+## Removed vs the earlier variant
+- **Save View** dropped (filter clutter; the team agreed it wasn't needed here).
+- **Collapsible row** dropped — only the drawer remains.
+- The in-drawer company hop-chain dropped (it repeated names already on screen).
+
+## DS notes (overrides to lift back into the design system, then delete)
+- Search magnifier icon + on-scale `14px` type; `<select>` custom chevron + `14px` (prod uses native chevron + 13px). Implemented as `!important` overrides on imported prod classes so they're easy to remove once adopted.
+- Inherited prod gaps kept on purpose to track dev: `#e5e7eb` borders (not a PL token), `13px` tab type.
+- Prototype color rule: every color is `var(--token, #fallback)` — the fallback renders today, the token wires up when the app adopts the DS.

--- a/prototypes/entries/warm-intros-filter-update/InvestorDrawerMock.tsx
+++ b/prototypes/entries/warm-intros-filter-update/InvestorDrawerMock.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+import clsx from 'clsx';
+import { INVESTOR_TYPE_LABEL, STAGE_FOCUS_LABEL } from '@/services/investors/constants';
+import { Drawer } from '@/components/common/Drawer/Drawer';
+import { Button } from '@/components/common/Button/Button';
+import { CopyButton } from '@/components/ui/CopyButton/CopyButton';
+// Reuse the pl-design-system Button styling for the footer link actions (anchors
+// can't use the <Button> component directly, so we borrow its classes).
+import btn from '@/components/common/Button/Button.module.scss';
+import { EngagementTierBadge } from '@/components/page/investors/EngagementTierBadge/EngagementTierBadge';
+import { EmailStatusPill } from '@/components/page/investors/EmailStatusPill/EmailStatusPill';
+import { SectorTagsList } from '@/components/page/investors/SectorTagsList/SectorTagsList';
+// Reuse the Member-page contact components (icon + handle links) for the contact row.
+import { ProfileSocialLink } from '@/components/page/member-details/profile-social-link';
+import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
+import { getProfileFromURL } from '@/utils/common.utils';
+// Reuse the production drawer styling verbatim so the layout matches the original.
+import s from '@/components/page/investors/InvestorDrawer/InvestorDrawer.module.scss';
+import type { InvestorList } from '@/services/investors/types';
+import { ArrowUpRightIcon, CheckIcon } from '@/components/icons';
+import x from './WarmIntrosImprovements.module.scss';
+import type { MockInvestor } from './mocks';
+import { WarmPathPanel } from './WarmPathPanel';
+import { AddToListButton } from './AddToListButton';
+
+interface Props {
+  investor: MockInvestor | null;
+  onClose: () => void;
+  /** Full-screen sheet on mobile (otherwise a fixed-width side drawer). */
+  fullScreen?: boolean;
+  /** All lists (with live counts) for the add menu + membership display. */
+  lists: InvestorList[];
+  onAddToList: (listId: string) => void;
+  onRemoveFromList: (listId: string) => void;
+}
+
+/**
+ * Mocked clone of the production InvestorDrawer (same section layout + styles),
+ * opened by tapping a table row — wired to mock data and the improved warm-path
+ * panel + list-membership control.
+ */
+export function InvestorDrawerMock({
+  investor,
+  onClose,
+  fullScreen,
+  lists,
+  onAddToList,
+  onRemoveFromList,
+}: Props) {
+  const isOpen = !!investor;
+  const [copied, setCopied] = useState(false);
+
+  const copyEmail = () => {
+    if (!investor?.email) return;
+    navigator.clipboard.writeText(investor.email);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} {...(fullScreen ? { fullScreen: true } : { width: 720 })}>
+      {investor && (
+        <>
+          <div className={`${s.header} ${x.stickyHeader}`}>
+            <div className={s.headerTop}>
+              <div className={s.headerWho}>
+                <h2 className={s.name}>
+                  {investor.first_name} {investor.last_name}
+                </h2>
+                <div className={s.meta}>
+                  {investor.title || '—'}
+                  {investor.firm && ' · '}
+                  {investor.firm &&
+                    (investor.firm_domain ? (
+                      <a
+                        href={`https://${investor.firm_domain}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={clsx(s.link, x.extLink)}
+                      >
+                        {investor.firm}
+                        <ArrowUpRightIcon width={13} height={13} />
+                      </a>
+                    ) : (
+                      investor.firm
+                    ))}
+                </div>
+                <div className={s.metaSub}>{investor.investor_id}</div>
+              </div>
+              <button className={s.closeBtn} onClick={onClose} aria-label="Close drawer">
+                ✕
+              </button>
+            </div>
+            <div className={s.pillRow}>
+              <EngagementTierBadge tier={investor.engagement_tier} />
+              <EmailStatusPill status={investor.email_status} />
+              <span className={s.sourcePill}>Source: {investor.source}</span>
+            </div>
+          </div>
+
+          <div className={s.section}>
+            <h3 className={s.sectionTitle}>Contact</h3>
+            <div className={x.channelsBox}>
+              {[
+                investor.email && (
+                  <span key="email" className={x.emailGroup}>
+                    <ProfileSocialLink
+                      type="email"
+                      handle={investor.email}
+                      profile={getProfileFromURL(investor.email, 'email')}
+                      logo={getContactLogoByProvider('email')}
+                      height={20}
+                      width={20}
+                      callback={() => {}}
+                    />
+                    <CopyButton text={investor.email} className={x.copyEmail} />
+                  </span>
+                ),
+                investor.linkedin_url && (
+                  <ProfileSocialLink
+                    key="linkedin"
+                    type="linkedin"
+                    handle={investor.linkedin_url}
+                    profile={getProfileFromURL(investor.linkedin_url, 'linkedin')}
+                    logo={getContactLogoByProvider('linkedin')}
+                    height={20}
+                    width={20}
+                    callback={() => {}}
+                  />
+                ),
+                investor.firm_domain && (
+                  <ProfileSocialLink
+                    key="website"
+                    type="website"
+                    handle={investor.firm_domain}
+                    profile={getProfileFromURL(investor.firm_domain, 'website')}
+                    logo={getContactLogoByProvider('website')}
+                    height={20}
+                    width={20}
+                    callback={() => {}}
+                  />
+                ),
+              ]
+                .filter(Boolean)
+                .map((el, i) => (
+                  <Fragment key={i}>
+                    {i > 0 && <span className={x.channelDivider} aria-hidden />}
+                    {el}
+                  </Fragment>
+                ))}
+            </div>
+            {investor.lab_os_profile && (
+              <a
+                className={clsx(s.link, x.extLink)}
+                style={{ marginTop: 10, fontSize: 13 }}
+                href={
+                  investor.lab_os_profile.type === 'member'
+                    ? `/members/${investor.lab_os_profile.uid}`
+                    : `/teams/${investor.lab_os_profile.uid}`
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View LabOS profile
+                <ArrowUpRightIcon width={13} height={13} />
+              </a>
+            )}
+          </div>
+
+          <div className={s.section}>
+            <h3 className={s.sectionTitle}>Investor profile</h3>
+            <dl className={s.kv}>
+              <dt>Type</dt>
+              <dd>{INVESTOR_TYPE_LABEL[investor.investor_type]}</dd>
+              <dt>Stage focus</dt>
+              <dd>{STAGE_FOCUS_LABEL[investor.stage_focus]}</dd>
+              <dt>Industry / Sector</dt>
+              <dd>
+                <SectorTagsList tags={investor.sector_tags} max={20} />
+              </dd>
+              <dt>Check size</dt>
+              <dd>
+                {investor.check_size_range !== 'unknown' ? (
+                  investor.check_size_range
+                ) : (
+                  <span className={s.muted}>unknown</span>
+                )}
+              </dd>
+              <dt>AUM</dt>
+              <dd>
+                {investor.aum_range !== 'unknown' ? investor.aum_range : <span className={s.muted}>unknown</span>}
+              </dd>
+              <dt>Geo focus</dt>
+              <dd>{investor.geo_focus || <span className={s.muted}>—</span>}</dd>
+            </dl>
+            {investor.fund_thesis && (
+              <p className={s.thesis}>
+                <strong>Thesis:</strong> {investor.fund_thesis}
+              </p>
+            )}
+          </div>
+
+          {(investor.has_path || investor.best_proximity_code) && (
+            <div className={s.section}>
+              <h3 className={s.sectionTitle}>Warm paths</h3>
+              <WarmPathPanel paths={investor.paths} />
+            </div>
+          )}
+
+          <div className={s.section}>
+            <h3 className={s.sectionTitle}>Outreach history</h3>
+            <div className={s.statRow}>
+              <div className={s.stat}>
+                <div className={s.statN}>{investor.outreach.touches}</div>
+                <div className={s.statL}>Touches</div>
+              </div>
+              <div className={s.stat}>
+                <div className={s.statN}>{investor.outreach.opened}</div>
+                <div className={s.statL}>Opened</div>
+              </div>
+              <div className={s.stat}>
+                <div className={s.statN}>{investor.outreach.clicked}</div>
+                <div className={s.statL}>Clicked</div>
+              </div>
+              <div className={s.stat}>
+                <div className={s.statN}>{investor.outreach.registered}</div>
+                <div className={s.statL}>Registered</div>
+              </div>
+            </div>
+            <div className={s.dateRow}>
+              <span>
+                First sent: <strong>{investor.outreach.first_sent_date || '—'}</strong>
+              </span>
+              <span>
+                Last sent: <strong>{investor.outreach.last_sent_date || '—'}</strong>
+              </span>
+            </div>
+          </div>
+
+          <div className={s.footer}>
+            {investor.firm_domain && (
+              <a
+                className={clsx(btn.root, btn.medium, btn.fill, btn.primary)}
+                href={`https://app.affinity.co/companies/?search=${encodeURIComponent(investor.firm_domain)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                  Open in Affinity
+                  <ArrowUpRightIcon width={15} height={15} />
+                </span>
+              </a>
+            )}
+            <AddToListButton lists={lists} memberOf={investor.list_ids} onAdd={onAddToList} onRemove={onRemoveFromList} openUp />
+            <Button style="border" variant="neutral" onClick={copyEmail} disabled={!investor.email}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                {copied ? <CheckIcon width={16} height={16} /> : <CopyIcon />}
+                {copied ? 'Copied' : 'Copy email'}
+              </span>
+            </Button>
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+}
+
+// No "copy" icon in the app set yet — keep this small inline one for the footer.
+const CopyIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+);

--- a/prototypes/entries/warm-intros-filter-update/PeopleChain.tsx
+++ b/prototypes/entries/warm-intros-filter-update/PeopleChain.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+// People-first route renderer. Each node is a PERSON (or, when the individual is
+// unknown, the organization that can route the intro). Icons come from the app's
+// own set (@/components/icons):
+//   • member   → person in the PL network: avatar + link to /members + ↗.
+//   • external → known person NOT in the network: ContributorIcon, no link.
+//   • org      → company we can route through but not who: UsersThreeIcon + "?".
+//     (PL-network org also shows its logo + links to /teams.)
+import pd from '@/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import { ArrowUpRightIcon, QuestionCircleStrokeIcon } from '@/components/icons';
+import type { RouteNode } from './mocks';
+import x from './WarmIntrosImprovements.module.scss';
+
+export function PeopleChain({ nodes, className }: { nodes: RouteNode[]; className?: string }) {
+  if (nodes.length === 0) return null;
+  return (
+    <div className={className ? `${pd.chain} ${className}` : pd.chain}>
+      {nodes.map((node, i) => (
+        <span key={`${node.label}-${i}`} className={pd.node}>
+          {i > 0 && <span className={pd.arrow}>→</span>}
+          <RouteNodeView node={node} />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// "Person unknown" marker — the app's question-circle icon.
+function UnknownBadge() {
+  return (
+    <span className={x.chainUnknownBadge} aria-hidden>
+      <QuestionCircleStrokeIcon width={14} height={14} />
+    </span>
+  );
+}
+
+function RouteNodeView({ node }: { node: RouteNode }) {
+  // Network person → clickable chip with avatar + ↗ → /members.
+  if (node.variant === 'member' && node.memberUid) {
+    return (
+      <a
+        className={`${pd.nodeLabel} ${x.chainNode} ${x.nodeChip}`}
+        href={`/members/${node.memberUid}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <img className={x.chainIcon} src={getDefaultAvatar(node.label)} alt="" width={14} height={14} />
+        <span>{node.label}</span>
+        <span className={x.chainArrowInline} aria-hidden>
+          <ArrowUpRightIcon width={12} height={12} />
+        </span>
+      </a>
+    );
+  }
+
+  // Org we can route through, person unknown.
+  if (node.variant === 'org') {
+    // PL-network org → real logo + link to its profile + "?".
+    if (node.teamUid) {
+      return (
+        <a
+          className={`${pd.nodeLabel} ${x.chainNode} ${x.nodeChip}`}
+          href={`/teams/${node.teamUid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          title="This team can connect — person unknown"
+        >
+          <img className={x.chainIcon} src={node.logo ?? getDefaultAvatar(node.label)} alt="" width={14} height={14} />
+          <span>{node.label}</span>
+          <UnknownBadge />
+          <span className={x.chainArrowInline} aria-hidden>
+            <ArrowUpRightIcon width={12} height={12} />
+          </span>
+        </a>
+      );
+    }
+    // External org → dashed chip + building glyph + "?".
+    return (
+      <span className={`${pd.nodeLabel} ${x.chainNode} ${x.chainNodeOrg}`} title="Someone here can connect — person unknown">
+        <span className={x.chainOrgIcon} aria-hidden>
+          <OrgGlyph />
+        </span>
+        <span>{node.label}</span>
+        <UnknownBadge />
+      </span>
+    );
+  }
+
+  // Known person, not in the PL network → plain user silhouette, no link.
+  return (
+    <span className={`${pd.nodeLabel} ${x.chainNode} ${x.chainNodeExternal}`} title="Not in the PL network">
+      <span className={x.chainPersonIcon} aria-hidden>
+        <PersonGlyph />
+      </span>
+      <span>{node.label}</span>
+    </span>
+  );
+}
+
+// Plain user silhouette (no frame/chevrons) for non-network connectors.
+export function PersonGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-4.42 0-8 2.69-8 6v2h16v-2c0-3.31-3.58-6-8-6Z" />
+    </svg>
+  );
+}
+
+// Building / org glyph for org-led (person-unknown) connectors.
+export function OrgGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M4 21V5a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v4h4a1 1 0 0 1 1 1v11H4Zm3-3h2v-2H7v2Zm0-4h2v-2H7v2Zm0-4h2V8H7v2Zm4 8h2v-2h-2v2Zm0-4h2v-2h-2v2Zm0-4h2V8h-2v2Zm4 8h3v-7h-3v2h1v5Z" />
+    </svg>
+  );
+}

--- a/prototypes/entries/warm-intros-filter-update/WarmIntrosFilterUpdatePrototype.tsx
+++ b/prototypes/entries/warm-intros-filter-update/WarmIntrosFilterUpdatePrototype.tsx
@@ -1,0 +1,597 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+import {
+  CHECK_SIZE_RANGES,
+  INDUSTRY_SECTOR_LABEL,
+  INVESTOR_TYPE_LABEL,
+  SECTOR_TAGS,
+  SECTOR_TAG_LABEL,
+  STAGE_FOCUSES,
+  STAGE_FOCUS_LABEL,
+} from '@/services/investors/constants';
+import type { CheckSizeRange, InvestorList, SectorTag, StageFocus, WarmIntroTier } from '@/services/investors/types';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import { EngagementTierBadge } from '@/components/page/investors/EngagementTierBadge/EngagementTierBadge';
+import { SectorTagsList } from '@/components/page/investors/SectorTagsList/SectorTagsList';
+import { Tag } from '@/components/ui/Tag/Tag';
+import { ListPicker } from '@/components/page/investors/WarmIntrosWorkspace/ListPicker';
+import { GlossaryModal } from '@/components/page/investors/WarmIntrosWorkspace/GlossaryModal';
+import { Drawer } from '@/components/common/Drawer/Drawer';
+import { Tabs } from '@/components/common/Tabs/Tabs';
+// Reuse the production workspace styling so the prototype tracks production 1:1.
+import s from '@/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss';
+import { DEFAULT_LIST_ID, MOCK_INVESTOR_LISTS, MOCK_LISTS, MOCK_MEMBERS, pathChainNodes, type MockInvestor } from './mocks';
+import { PeopleChain } from './PeopleChain';
+import { ArrowUpRightIcon } from '@/components/icons';
+import { WorkspaceSearch } from './WorkspaceSearch';
+import { InvestorDrawerMock } from './InvestorDrawerMock';
+import { AddToListButton } from './AddToListButton';
+import x from './WarmIntrosImprovements.module.scss';
+
+const REL_FILTERS: { tier: WarmIntroTier; label: string }[] = [
+  { tier: 'co_invested', label: 'Co-invested' },
+  { tier: 'engaged', label: 'Engaged' },
+  { tier: 'cold_match', label: 'Cold' },
+];
+
+const VISUAL_TABS = [
+  { value: 'all', label: 'All Investors' },
+  { value: 'warm-intros', label: 'Warm Intros' },
+];
+
+function relationshipMeta(rel: WarmIntroTier): { label: string; cls: string } {
+  if (rel === 'co_invested') return { label: 'Co-invested', cls: s.relCo };
+  if (rel === 'engaged') return { label: 'Engaged', cls: s.relEngaged };
+  return { label: 'Cold', cls: s.relCold };
+}
+
+// Warmer first: caliber A < B < none, then fewer hops; cold (no path) last.
+function proximityRank(inv: MockInvestor): number {
+  if (!inv.has_path || !inv.best_proximity_code) return 999;
+  const code = inv.best_proximity_code;
+  const cal = code.slice(-1);
+  const calRank = cal === 'A' ? 0 : cal === 'B' ? 1 : 2;
+  const hopMatch = code.match(/\+(\d)/);
+  const hops = hopMatch ? Number(hopMatch[1]) : 9;
+  return calRank * 10 + hops;
+}
+
+// Does any path for this investor route through the searched node?
+function matchesConnector(inv: MockInvestor, label: string): boolean {
+  const full = `${inv.first_name} ${inv.last_name}`;
+  if (full === label) return true;
+  return inv.paths.some(
+    (p) =>
+      p.contact?.name === label ||
+      p.orgConnector?.name === label ||
+      p.team?.name === label ||
+      p.chain.some((c) => c.label === label),
+  );
+}
+
+type Draft = { stage: string; sectors: SectorTag[]; check: string };
+
+export default function WarmIntrosFilterUpdatePrototype() {
+  // Reuse interactive, client-only widgets — gate render on mount so SSR === first
+  // client render (avoids hydration mismatches).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  // Track mobile so the detail drawer goes full-screen (our inline width on the
+  // Drawer would otherwise override its built-in mobile 100vw rule).
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)');
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const [members, setMembers] = useState<MockInvestor[]>(MOCK_MEMBERS);
+  const [currentListId, setCurrentListId] = useState(DEFAULT_LIST_ID);
+  const [drawerId, setDrawerId] = useState<string | null>(null);
+
+  const [draft, setDraft] = useState<Draft>({ stage: '', sectors: [], check: '' });
+  const [applied, setApplied] = useState<Draft>({ stage: '', sectors: [], check: '' });
+  const [relFilter, setRelFilter] = useState<Record<WarmIntroTier, boolean>>({
+    co_invested: true,
+    engaged: true,
+    cold_match: true,
+  });
+  const [connectorLabel, setConnectorLabel] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [glossaryOpen, setGlossaryOpen] = useState(false);
+  const [crosswalkOpen, setCrosswalkOpen] = useState(false);
+
+  // Sectors collapse into a count-badge popover to keep the filter bar to one row.
+  const [sectorOpen, setSectorOpen] = useState(false);
+  const sectorRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!sectorOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (sectorRef.current && !sectorRef.current.contains(e.target as Node)) setSectorOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [sectorOpen]);
+
+  const switchList = (list: InvestorList) => {
+    setCurrentListId(list.id);
+    setDrawerId(null);
+    setSelectedIds(new Set());
+    setConnectorLabel(null);
+  };
+
+  const applyFilters = () => setApplied(draft);
+  const clearFilters = () => {
+    setDraft({ stage: '', sectors: [], check: '' });
+    setApplied({ stage: '', sectors: [], check: '' });
+    setConnectorLabel(null);
+    setSelectedIds(new Set());
+  };
+
+  const toggleDraftSector = (sec: SectorTag) =>
+    setDraft((d) => ({
+      ...d,
+      sectors: d.sectors.includes(sec) ? d.sectors.filter((x) => x !== sec) : [...d.sectors, sec],
+    }));
+
+  const toggleSelected = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const onList = useMemo(
+    () => members.filter((m) => m.list_ids.includes(currentListId)),
+    [members, currentListId],
+  );
+
+  const visible = useMemo(() => {
+    let rows = onList;
+    if (applied.stage) rows = rows.filter((m) => m.stage_focus === (applied.stage as StageFocus));
+    if (applied.check) rows = rows.filter((m) => m.check_size_range === (applied.check as CheckSizeRange));
+    if (applied.sectors.length) rows = rows.filter((m) => m.sector_tags.some((t) => applied.sectors.includes(t)));
+    rows = rows.filter((m) => relFilter[m.relationship]);
+    if (connectorLabel) rows = rows.filter((m) => matchesConnector(m, connectorLabel));
+    return rows
+      .slice()
+      .sort((a, b) => proximityRank(a) - proximityRank(b) || a.last_name.localeCompare(b.last_name));
+  }, [onList, applied, relFilter, connectorLabel]);
+
+  // Clear only does something when a filter is actually set (draft, applied, or
+  // an active connector lens) — disable it otherwise so it's not dead UI.
+  const hasActiveFilters =
+    !!draft.stage ||
+    !!draft.check ||
+    draft.sectors.length > 0 ||
+    !!applied.stage ||
+    !!applied.check ||
+    applied.sectors.length > 0 ||
+    !!connectorLabel;
+
+  const totalOnList = members.filter((m) => m.list_ids.includes(currentListId)).length;
+  const currentListName = MOCK_LISTS.find((l) => l.id === currentListId)?.name ?? 'list';
+  const drawerInvestor = members.find((m) => m.investor_id === drawerId) ?? null;
+
+  // Live list membership: derive counts from members so the picker + add menu
+  // reflect add/remove. Lists are scopes; an investor can belong to several.
+  const liveLists = useMemo(
+    () =>
+      MOCK_INVESTOR_LISTS.map((l) => ({
+        ...l,
+        member_count: members.filter((m) => m.list_ids.includes(l.id)).length,
+      })),
+    [members],
+  );
+  const addToList = (investorIds: string[], listId: string) =>
+    setMembers((prev) =>
+      prev.map((m) =>
+        investorIds.includes(m.investor_id) && !m.list_ids.includes(listId)
+          ? { ...m, list_ids: [...m.list_ids, listId] }
+          : m,
+      ),
+    );
+  const removeFromList = (investorId: string, listId: string) =>
+    setMembers((prev) =>
+      prev.map((m) => (m.investor_id === investorId ? { ...m, list_ids: m.list_ids.filter((id) => id !== listId) } : m)),
+    );
+
+  const exportCsv = () => {
+    const rows = visible.filter((m) => selectedIds.has(m.investor_id));
+    if (rows.length === 0) return;
+    const head = ['name', 'firm', 'email', 'proximity', 'best_connector'];
+    const lines = rows.map((m) =>
+      [
+        `${m.first_name} ${m.last_name}`,
+        m.firm,
+        m.email,
+        m.best_proximity_code ?? 'Cold',
+        m.paths[0]?.contact?.name ?? m.paths[0]?.orgConnector?.name ?? '',
+      ]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(','),
+    );
+    const blob = new Blob([[head.join(','), ...lines].join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `warm-intros-${currentListId}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (!mounted) return <div className={s.root} />;
+
+  return (
+    <div className={x.page}>
+
+      {/* Page header (mirrors the real Investors DB page) */}
+      <div className={x.pageHeader}>
+        <div className={x.pageTitleRow}>
+          <h1 className={x.pageTitle}>Investors Database</h1>
+          <span className={x.internalBadge}>Access Restricted to - PL investment team</span>
+        </div>
+        <p className={x.pageSubtitle}>Internal Investors database — Network, co-investors, and outreach pipeline.</p>
+      </div>
+
+      <div className={x.tabBar}>
+        <Tabs
+          tabs={VISUAL_TABS}
+          value="warm-intros"
+          onValueChange={() => {}}
+          variant="underline"
+          classes={{ tab: x.tab, badge: x.tabBadge }}
+        />
+      </div>
+
+      {/* ── Workspace (faithful copy of WarmIntrosWorkspace) ─────────────────── */}
+      <div className={s.root}>
+        <section className={s.builder}>
+          <header className={s.builderH}>
+            <div className={s.builderTitleRow}>
+              <h2 className={s.title}>Find warm investor intros</h2>
+              <div className={s.titleActions}>
+                <button type="button" className={s.howScoredLink} onClick={() => setCrosswalkOpen(true)}>
+                  Crosswalk review
+                </button>
+                <button type="button" className={s.howScoredLink} onClick={() => setGlossaryOpen(true)}>
+                  What do these terms mean?
+                </button>
+              </div>
+            </div>
+            <p className={s.desc}>Pick a list, then search or filter it down to see the warmest paths PL can reach.</p>
+          </header>
+
+          {/* ── Compact filter bar: list · search · stage · check · sectors · actions ── */}
+          <div className={clsx(x.filterBar, x.builderRowResp)}>
+            <div className={x.listField}>
+              <span className={x.inlineLabel}>List</span>
+              <div className={x.listPickerWrap}>
+                <ListPicker lists={liveLists} selectedId={currentListId} onSelect={switchList} />
+              </div>
+            </div>
+
+            <div className={x.searchField}>
+              <WorkspaceSearch onSelect={setConnectorLabel} />
+            </div>
+
+            <select
+              className={clsx(s.select, x.select)}
+              value={draft.stage}
+              onChange={(e) => setDraft((d) => ({ ...d, stage: e.target.value }))}
+              aria-label="Stage focus"
+            >
+              <option value="">Any stage</option>
+              {STAGE_FOCUSES.filter((st) => st !== 'unknown').map((st) => (
+                <option key={st} value={st}>
+                  {STAGE_FOCUS_LABEL[st]}
+                </option>
+              ))}
+            </select>
+
+            <select
+              className={clsx(s.select, x.select)}
+              value={draft.check}
+              onChange={(e) => setDraft((d) => ({ ...d, check: e.target.value }))}
+              aria-label="Check size"
+            >
+              <option value="">Any check size</option>
+              {CHECK_SIZE_RANGES.filter((c) => c !== 'unknown').map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+
+            <div className={x.sectorPopWrap} ref={sectorRef}>
+              <button
+                type="button"
+                className={clsx(s.select, x.select, x.sectorTrigger)}
+                aria-expanded={sectorOpen}
+                onClick={() => setSectorOpen((o) => !o)}
+              >
+                {INDUSTRY_SECTOR_LABEL}
+                {draft.sectors.length > 0 && <span className={x.sectorCount}>{draft.sectors.length}</span>}
+              </button>
+              {sectorOpen && (
+                <div className={x.sectorPop}>
+                  <div className={x.sectorPopHead}>
+                    <span>{INDUSTRY_SECTOR_LABEL}</span>
+                    {draft.sectors.length > 0 && (
+                      <button
+                        type="button"
+                        className={x.sectorClear}
+                        onClick={() => setDraft((d) => ({ ...d, sectors: [] }))}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                  <div className={s.sectorChips}>
+                    {SECTOR_TAGS.map((sec) => (
+                      <Tag
+                        key={sec}
+                        value={SECTOR_TAG_LABEL[sec]}
+                        keyValue={sec}
+                        variant="secondary"
+                        selected={draft.sectors.includes(sec)}
+                        callback={() => toggleDraftSector(sec)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className={clsx(s.actions, x.filterActions, x.builderActions)}>
+              <button className={s.btnPrimary} onClick={applyFilters}>
+                Apply
+              </button>
+              <button className={s.btn} onClick={clearFilters} disabled={!hasActiveFilters}>
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {connectorLabel && (
+            <div className={clsx(s.lensBar, x.lensBarMt)}>
+              <span className={s.lensLabel}>Connector lens:</span>
+              <span className={x.savedView}>
+                <span className={x.lensChipText}>
+                  paths through <strong>{connectorLabel}</strong>
+                </span>
+                <button
+                  type="button"
+                  className={x.savedViewDelete}
+                  onClick={() => setConnectorLabel(null)}
+                  aria-label="Clear connector lens"
+                >
+                  &times;
+                </button>
+              </span>
+            </div>
+          )}
+
+        </section>
+
+        <section className={s.results}>
+          <div className={clsx(s.resultsHeader, x.resultsHeaderResp)}>
+            <div className={s.resultsCount}>
+              <strong>{visible.length}</strong> shown · {totalOnList.toLocaleString()} in {currentListName} · sorted by
+              proximity (warmest first)
+            </div>
+            <div className={clsx(s.resultsActions, x.resultsActionsResp)}>
+              <div className={s.relChips}>
+                {REL_FILTERS.map(({ tier, label }) => (
+                  <Tag
+                    key={tier}
+                    value={label}
+                    keyValue={tier}
+                    variant="secondary"
+                    selected={relFilter[tier]}
+                    className={x.relChip}
+                    callback={() => setRelFilter((r) => ({ ...r, [tier]: !r[tier] }))}
+                  />
+                ))}
+              </div>
+              <AddToListButton
+                lists={liveLists}
+                disabled={selectedIds.size === 0}
+                label={selectedIds.size ? `Add to list (${selectedIds.size})` : 'Add to list'}
+                onAdd={(listId) => addToList([...selectedIds], listId)}
+              />
+              <button className={s.btnPrimary} onClick={exportCsv} disabled={selectedIds.size === 0}>
+                ⤓ Export CSV ({selectedIds.size})
+              </button>
+            </div>
+          </div>
+
+          <div className={clsx(s.tableWrap, x.tableDesktop)}>
+            <table className={s.table}>
+              <thead>
+                <tr>
+                  <th className={s.checkboxCol}></th>
+                  <th>Investor</th>
+                  <th>Team</th>
+                  <th>{INDUSTRY_SECTOR_LABEL}</th>
+                  <th>Stage</th>
+                  <th>Type</th>
+                  <th>Relationship</th>
+                  <th>Proximity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((inv) => {
+                  const rel = relationshipMeta(inv.relationship);
+                  const bestPath = inv.paths[0];
+                  const hasProximity = !!inv.best_proximity_code || inv.has_path === false;
+                  return (
+                    <tr
+                      key={inv.investor_id}
+                      className={clsx(s.row, x.hoverRow)}
+                      onClick={() => setDrawerId(inv.investor_id)}
+                    >
+                        <td className={s.checkboxCol}>
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(inv.investor_id)}
+                            onClick={(e) => e.stopPropagation()}
+                            onChange={() => toggleSelected(inv.investor_id)}
+                          />
+                        </td>
+                        <td>
+                          <div className={x.nameCellRow}>
+                            <div>
+                              <div className={s.nameCell}>
+                                {inv.first_name} {inv.last_name}
+                              </div>
+                              <div className={s.subtle}>{inv.email}</div>
+                            </div>
+                            <span className={x.rowArrow} aria-hidden>
+                              <ArrowUpRightIcon />
+                            </span>
+                          </div>
+                        </td>
+                        <td>
+                          <div className={s.teamCell}>{inv.firm || <span className={s.muted}>—</span>}</div>
+                          {inv.title && <div className={s.subtle}>{inv.title}</div>}
+                        </td>
+                        <td>
+                          <SectorTagsList tags={inv.sector_tags} max={3} />
+                        </td>
+                        <td>
+                          {inv.stage_focus !== 'unknown' ? (
+                            STAGE_FOCUS_LABEL[inv.stage_focus]
+                          ) : (
+                            <span className={s.muted}>—</span>
+                          )}
+                        </td>
+                        <td>{INVESTOR_TYPE_LABEL[inv.investor_type] ?? <span className={s.muted}>—</span>}</td>
+                        <td>
+                          <div className={s.relCell}>
+                            <span className={clsx(s.relPill, rel.cls)}>{rel.label}</span>
+                            {inv.relationship === 'engaged' && inv.engagement_tier !== 'T4_cold' && (
+                              <EngagementTierBadge tier={inv.engagement_tier} compact />
+                            )}
+                          </div>
+                        </td>
+                        <td>
+                          <div className={x.bestPathCell}>
+                            {/* People-first: the warmest connector node (investor node
+                                dropped since the row is them) + the proximity badge. */}
+                            <div className={x.pathRow}>
+                              {hasProximity ? (
+                                <ProximityCodeBadge
+                                  code={inv.best_proximity_code}
+                                  cold={inv.has_path === false}
+                                  confidence={bestPath?.caliber_confidence}
+                                />
+                              ) : (
+                                <span className={s.muted}>—</span>
+                              )}
+                              {bestPath && pathChainNodes(bestPath, inv).length > 0 && (
+                                <PeopleChain nodes={pathChainNodes(bestPath, inv)} />
+                              )}
+                            </div>
+                            {inv.paths.length > 0 && (
+                              <button
+                                type="button"
+                                className={s.expandBtn}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setDrawerId(inv.investor_id);
+                                }}
+                              >
+                                {inv.paths.length > 1 ? `View all (${inv.paths.length})` : 'View path'}
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile: the table doesn't fit — render each investor as a tappable card. */}
+          <div className={x.mobileCards}>
+            {visible.map((inv) => {
+              const rel = relationshipMeta(inv.relationship);
+              const bestPath = inv.paths[0];
+              const hasProximity = !!inv.best_proximity_code || inv.has_path === false;
+              return (
+                <div
+                  key={inv.investor_id}
+                  className={x.mCard}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setDrawerId(inv.investor_id)}
+                >
+                  <div className={x.mCardHead}>
+                    <div>
+                      <div className={s.nameCell}>
+                        {inv.first_name} {inv.last_name}
+                      </div>
+                      <div className={s.subtle}>{inv.email}</div>
+                    </div>
+                    {hasProximity && (
+                      <ProximityCodeBadge
+                        code={inv.best_proximity_code}
+                        cold={inv.has_path === false}
+                        confidence={bestPath?.caliber_confidence}
+                      />
+                    )}
+                  </div>
+                  <div className={x.mCardMeta}>
+                    <span className={clsx(s.relPill, rel.cls)}>{rel.label}</span>
+                    <span className={x.mCardFirm}>{inv.firm || '—'}</span>
+                  </div>
+                  <SectorTagsList tags={inv.sector_tags} max={4} />
+                  {bestPath && pathChainNodes(bestPath, inv).length > 0 && <PeopleChain nodes={pathChainNodes(bestPath, inv)} />}
+                </div>
+              );
+            })}
+          </div>
+
+          {visible.length === 0 && (
+            <div className={s.empty}>
+              No members match the current filters — adjust the relationship chips
+              {connectorLabel ? ' or clear the connector lens' : ''}.
+            </div>
+          )}
+        </section>
+
+        <GlossaryModal open={glossaryOpen} onClose={() => setGlossaryOpen(false)} />
+        <Drawer
+          isOpen={crosswalkOpen}
+          onClose={() => setCrosswalkOpen(false)}
+          {...(isMobile ? { fullScreen: true } : { width: 560 })}
+        >
+          <div style={{ padding: 24, fontFamily: 'Inter, sans-serif' }}>
+            <h2 style={{ fontSize: 18, fontWeight: 600, margin: '0 0 8px' }}>Crosswalk review</h2>
+            <p style={{ fontSize: 13, color: '#455468', lineHeight: 1.55 }}>
+              (Prototype stub) In production this is the entity-resolution queue where a curator confirms or rejects
+              fuzzy name/firm matches the pathfinder couldn’t auto-link. Left as-is for this redesign.
+            </p>
+          </div>
+        </Drawer>
+      </div>
+
+      {/* Tapping a row opens the detail drawer — same layout as the original */}
+      <InvestorDrawerMock
+        investor={drawerInvestor}
+        onClose={() => setDrawerId(null)}
+        fullScreen={isMobile}
+        lists={liveLists}
+        onAddToList={(listId) => drawerId && addToList([drawerId], listId)}
+        onRemoveFromList={(listId) => drawerId && removeFromList(drawerId, listId)}
+      />
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-filter-update/WarmIntrosImprovements.module.scss
+++ b/prototypes/entries/warm-intros-filter-update/WarmIntrosImprovements.module.scss
@@ -1,0 +1,1420 @@
+// Net-new styles for the Warm Intros redesign prototype. Existing layout
+// (builder header, table, path cards, relationship pills) is reused by importing
+// the production .module.scss files in the .tsx, so those track production. Only
+// the styles for the *new* affordances live here. Colors use the prototype
+// token+fallback pattern (see prototypes/CLAUDE.md), with fallbacks copied from
+// the neighboring production investor SCSS.
+
+$brand: var(--foreground-brand-primary, #1b4dff);
+$text: var(--foreground-neutral-primary, #0a0c11);
+$text-2: var(--foreground-neutral-secondary, #455468);
+$muted: var(--foreground-neutral-tertiary, #8897ae);
+$border: var(--border-neutral-subtle, #e5e7eb);
+
+// ── Page shell — copied 1:1 from the production investors page.module.scss
+//    (app/investors/(investors-page)/@content). Kept identical so it tracks dev;
+//    the raw values + 13px tab are production's (slated for the design system). ──
+.pageHeader {
+  padding: 24px 0 8px;
+  font-family: 'Inter', sans-serif;
+}
+
+.pageTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.pageTitle {
+  margin: 0;
+  color: $text;
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 42px;
+  letter-spacing: -0.75px;
+}
+
+.internalBadge {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #4174ff;
+  background: rgba(27, 77, 255, 0.02);
+  border: 1px solid #aebfff;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.pageSubtitle {
+  margin: 0;
+  color: var(--Neutral-Slate-600, #475569);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+}
+
+.tabBar {
+  display: flex;
+  align-items: flex-end;
+  border-bottom: 1px solid #e2e8f0;
+  min-height: 48px;
+  margin-bottom: 16px;
+}
+
+.tab {
+  font-size: 13px;
+  padding: 10px 8px;
+}
+
+.tabBadge {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  background: #f1f5f9;
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+
+// ── Prototype DS improvements — OVERRIDE imported production styles ────────────
+//    These deliberately fork from the production search/select (which have no
+//    icon, a native chevron, and 13px type) to demo the design-system fix.
+//    !important is required because we're overriding imported module classes of
+//    equal specificity. Spec these back to production, then delete the overrides.
+.searchWrap {
+  position: relative;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  color: $muted;
+  pointer-events: none;
+}
+
+.searchInput {
+  padding: 8px 30px 8px 36px !important;
+  font-size: 14px !important;
+}
+
+.select,
+.listPickerWrap select {
+  font-size: 14px !important;
+  padding: 8px 30px 8px 10px !important;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238897ae' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 10px center !important;
+}
+
+// ── Compact filter bar (this prototype's focus) ───────────────────────────────
+//    Collapses the old stacked builder fields (list / search / stage / check /
+//    sector-wall, each with its own label) into ONE dense, wrapping toolbar.
+//    List + search stay primary; stage/check are inline placeholder selects;
+//    the sector chip-wall hides behind a count-badge popover. Every filter is
+//    still one click away (no hidden-filter anti-pattern) at ~half the height.
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.listField {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// Short inline label (replaces the stacked uppercase field labels).
+.inlineLabel {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: $text-2;
+  white-space: nowrap;
+}
+
+// Search is the primary control — it grows to absorb spare width.
+.searchField {
+  flex: 1 1 240px;
+  min-width: 200px;
+}
+
+// Apply / Clear / Save view sit at the far right of the bar.
+.filterActions {
+  margin-left: auto;
+}
+
+.lensBarMt {
+  margin-top: 12px;
+}
+
+// Sectors: a select-styled trigger (chevron comes from .select) with a count
+// badge, opening a popover that holds the full chip set.
+.sectorPopWrap {
+  position: relative;
+}
+
+.sectorTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sectorCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: $brand;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.sectorPop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 40;
+  width: 320px;
+  max-width: 90vw;
+  padding: 12px;
+  background: #fff;
+  border: 1px solid var(--border-neutral-subtle, #e5e7eb);
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(14, 15, 17, 0.12);
+}
+
+.sectorPopHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: $text-2;
+}
+
+.sectorClear {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  color: $brand;
+  cursor: pointer;
+}
+
+// ── Saved-view chips (apply + delete + selected state) ────────────────────────
+//    Mirrors the production saved-view affordance (InvestorsFilterRail: a body
+//    button to apply + an × to delete), restyled as an inline pill that matches
+//    this page's selectable Tag chips. Selected state uses the Tag .active
+//    palette (blue outline + light-blue fill) so it reads as "the active view".
+.savedView {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px 4px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 24px;
+  background: #fff;
+  transition: border-color 0.12s ease, background 0.12s ease, color 0.12s ease;
+
+  &:hover {
+    border-color: rgb(148 163 184);
+  }
+}
+
+.savedViewActive {
+  border-color: rgb(29 78 216);
+  background: rgb(219 234 254);
+
+  .savedViewBody {
+    color: rgb(29 78 216);
+  }
+
+  &:hover {
+    border-color: rgb(29 78 216);
+  }
+}
+
+.savedViewBody {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 14px;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+// Static text inside the connector-lens chip — mirrors .savedViewBody typography
+// (without the button/cursor) so the lens chip matches a saved-view chip.
+.lensChipText {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 14px;
+  color: #0f172a;
+
+  strong {
+    font-weight: 600;
+  }
+}
+
+.savedViewDelete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  background: none;
+  border: none;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  color: $muted;
+  cursor: pointer;
+
+  &:hover {
+    color: rgb(29 78 216);
+  }
+}
+
+// ── "What changed" prototype note (annotation, not product UI) ────────────────
+.bannerToggle {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: 8px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: $brand;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.banner {
+  background: linear-gradient(135deg, #fcfcff, #f5f3ff);
+  border: 1px solid #c7d2fe;
+  border-radius: 12px;
+  padding: 16px 20px;
+  font-family: 'Inter', sans-serif;
+}
+
+.bannerDesc {
+  margin: 0 0 12px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: $text-2;
+}
+
+.bannerList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.bannerItem {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  font-size: 12px;
+  line-height: 1.45;
+  color: $text-2;
+}
+
+.bannerTag {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: $brand;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+// ── Row hover arrow — signals the row opens the drawer (matches dev's
+//    All Investors table) ───────────────────────────────────────────────────────
+.nameCellRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rowArrow {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: $muted;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.hoverRow:hover .rowArrow {
+  opacity: 1;
+}
+
+// ── Inline "best path" preview in the table cell ──────────────────────────────
+.bestPathCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start; // left-align the row + the "View all" link
+  gap: 6px;
+  // Reserve slack so the badge's hover arrow grows into spare column width
+  // instead of resizing the column (which would shift the left columns).
+  min-width: 272px;
+}
+
+// Proximity badge + hop chain on one row, vertically centered together; the
+// "View all" link sits below, left-aligned.
+.pathRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+// ── "Who to contact" block in the expanded path ──────────────────────────────
+// Pin the investor header (name + meta + status pills) to the top of the
+// scrolling drawer so it stays visible while reading the lower sections.
+// Production .header already has padding + bottom border; we add the sticky
+// behaviour + an opaque background so content doesn't bleed through.
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--background-base-white, #fff);
+}
+
+// 12px between the explanation above and the profile below.
+.contactBlock {
+  margin-top: 12px;
+}
+
+// Override the production pd.correction's dashed top border → solid (prod uses
+// solid dividers). Applied alongside pd.correction on the correction row.
+.correctionRow {
+  border-top-style: solid !important;
+}
+
+.contactTitle {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: $muted;
+  margin-bottom: 6px;
+}
+
+.contactChannels {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  // Left-aligned to the card edge (under the avatar) — consistent across person
+  // and org cards.
+  padding-left: 0;
+}
+
+// Card surface — unified with the Warm Paths card (production pd.pathItem, also
+// used by the drawer stat boxes / co-teams): #f9fafb + subtle border + radius 8.
+.channelsBox {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--background-neutral-subtle, #f9fafb);
+  border: 1px solid var(--border-neutral-subtle, #eef0f3);
+}
+
+// Person connector sits flush-left (no inset card) so the avatar + email align
+// with the explanation above. (The org variant re-adds a card via .orgBox.)
+.contactBox {
+  display: flex;
+  flex-direction: column;
+}
+
+// Connector row, Teams-page style: avatar + name + role, divided like the
+// Members list on the Teams page.
+.memberRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-top: 1px solid $border;
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+// Email channel + its copy button kept as one tight unit.
+.emailGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+// When a card has 2+ contacts, every email is cropped to the SHORTEST one's
+// measured width (px set on --email-w by the component) so the copy button +
+// the channels after it line up across rows. The shortest shows in full; longer
+// ones get an ellipsis (full address still in ProfileSocialLink's tooltip).
+// Overrides ProfileSocialLink's styled-jsx max-width (runtime-injected → !important).
+.emailCropped :global(.profile-social-link__link) {
+  width: var(--email-w) !important;
+  max-width: var(--email-w) !important;
+}
+
+.memberLink {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  // Fixed-width identity column so every row's contact channels start at the
+  // same x (email of row 2 lines up under email of row 1).
+  width: 220px;
+  flex-shrink: 0;
+  text-decoration: none;
+  color: inherit;
+
+  &:hover .memberArrow {
+    opacity: 1;
+  }
+
+  // Slightly lighten the connector name on hover to reinforce it's clickable.
+  &:hover .memberName {
+    color: $text-2;
+  }
+}
+
+// Name + a hover arrow (shown when the connector links to a profile).
+.memberNameRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.memberArrow {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: $muted;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.memberAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: #fff;
+  object-fit: cover;
+}
+
+.memberText {
+  display: flex;
+  flex-direction: column;
+  flex: 1; // fill the fixed identity column so every row's name block is equal width
+  min-width: 0;
+}
+
+.memberName {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  color: $text;
+  transition: color 0.12s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.memberRole {
+  font-size: 12px;
+  line-height: 16px;
+  color: $muted;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// ── Hop chain ─────────────────────────────────────────────────────────────────
+// Clickable hop-chain node: keeps the production badge look (pd.nodeLabel) and
+// just layers interactivity — opens a portfolio team page.
+.nodeChip {
+  position: relative; // anchor for the absolutely-positioned hover arrow
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+  &:hover {
+    border-color: $brand;
+    // Light-blue brand tint (matches production InvestorDrawer's #eef2ff pills).
+    background: var(--background-brand-subtle, #eef2ff);
+    color: $brand;
+  }
+}
+
+// Hop-chain node with an avatar/logo + label (companies vs the investor).
+.chainNode {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding-left: 4px;
+  // System caption size (matches Tag chips / pd.explanation); production
+  // pd.nodeLabel is 11px, so !important to override the equal-specificity class.
+  font-size: 12px !important;
+  // Grow the pill vertically to breathe at 12px (production pd.nodeLabel is 1px
+  // top/bottom); keep production's 7px sides.
+  padding-top: 3px !important;
+  padding-bottom: 3px !important;
+}
+
+// Round icon badge for teams (square mark) + the investor (generated avatar).
+.chainIcon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #fff;
+  object-fit: contain;
+  padding: 1px;
+  border: 1px solid $border;
+}
+
+// Arrow icon for a clickable chain badge — shown on hover only. Positioned
+// ABSOLUTELY just past the badge's right edge so revealing it doesn't grow the
+// badge (which would widen the chain column and shift the whole table row). The
+// badge still hugs its content when not hovered (no reserved gap).
+.chainArrow {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 3px;
+  align-items: center;
+  color: $brand;
+}
+
+.nodeChip:hover .chainArrow {
+  display: inline-flex;
+}
+
+// Inline ↗ INSIDE a person chip — always visible, signals the node opens that
+// person in the PL system. Grey for every chip (incl. team chips), even on hover.
+.chainArrowInline {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 1px;
+  color: $muted !important;
+}
+
+// ── People-first node states ────────────────────────────────────────────────
+// Known person NOT in the PL network: grey person icon, no link/hover arrow.
+.chainNodeExternal {
+  color: $text-2;
+}
+
+// Grey person badge for non-network connectors (chain). ContributorIcon has no
+// size prop, so constrain its svg to fit the 16px badge.
+.chainPersonIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.06));
+  color: $muted;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+// Org we can route through but person unknown: dashed, muted, with a "?" badge.
+.chainNodeOrg {
+  color: $text-2;
+  border-style: dashed !important;
+}
+
+.chainOrgIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: $muted;
+}
+
+// "Person unknown" marker — the QuestionCircleIcon is itself a circle, so no
+// background needed; just sit it inline, muted.
+.chainUnknownBadge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: $muted;
+}
+
+// ── Drawer connector card (person + teams + contacts) ───────────────────────
+// Single connector only — padding lives on the .contactBox card, so no extra
+// vertical padding here (avoids a big gap below the divider).
+.connectorCard {
+  display: flex;
+  flex-direction: column;
+  // 4px between the profile and the contacts row.
+  gap: 4px;
+}
+
+.connectorTop {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.connectorIdentity {
+  display: flex;
+  align-items: flex-start; // top-align the avatar/icon against multi-line text
+  gap: 12px;
+  min-width: 0;
+}
+
+// Avatar links to the member page (separate from the name link → no nested <a>).
+.memberAvatarLink {
+  display: inline-flex;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+// Name link (avatar + name link separately to keep team links un-nested).
+.memberNameLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: inherit;
+
+  &:hover .memberName {
+    color: $text-2;
+  }
+  &:hover .memberArrow {
+    opacity: 1;
+  }
+}
+
+// Role line that carries the team(s) inline as links — wraps rather than clips.
+.memberRoleLine {
+  font-size: 12px;
+  line-height: 18px;
+  color: $muted;
+}
+
+// Inline team text-link (no logo) with a small grey ↗. On hover the WHOLE link
+// (name + arrow) turns brand blue.
+.teamInline {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  color: $text-2;
+  font-weight: 500;
+  text-decoration: none;
+
+  &:hover {
+    color: $brand;
+    text-decoration: underline;
+
+    .teamInlineArrow {
+      color: $brand;
+    }
+  }
+}
+
+.teamInlineArrow {
+  display: inline-flex;
+  align-items: center;
+  color: $muted;
+}
+
+// Middot divider between inline team links.
+.teamDivider {
+  margin: 0 4px;
+  color: $muted;
+}
+
+// 32px grey circle holding the person silhouette (non-network connector).
+.memberAvatarExternal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.06));
+  color: $muted;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+// Team chips: the team(s) a connector belongs to (can be several). Aligned to
+// start under the name (avatar 32 + 12 gap).
+.teamChips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  // Start at the avatar's left edge (no name-indent) so it reads as a tidy
+  // block under the connector rather than a detached, offset row.
+  padding-left: 0;
+}
+
+// Light inline label (sentence case) — demoted from the uppercase caption
+// treatment so "Who to contact" is the single high-attention caption.
+.teamChipsLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: $muted;
+}
+
+.teamChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid $border;
+  font-size: 12px;
+  line-height: 18px;
+  color: $text;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.teamChipLink {
+  transition: border-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    border-color: $brand;
+    color: $brand;
+  }
+}
+
+// Grey ↗ inside a linkable team chip — stays grey even when the chip hovers blue.
+.teamChipArrow {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 1px;
+  color: $muted;
+}
+
+.teamChipLogo {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #fff;
+  object-fit: contain;
+  padding: 1px;
+  border: 1px solid $border;
+}
+
+// "+N more" / "Show less" toggle for the collapsed team list.
+.teamMoreBtn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  color: $muted;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: $text-2;
+    text-decoration: underline;
+  }
+}
+
+// ── Drawer org-led line (person unknown) ────────────────────────────────────
+.orgBox {
+  border: 1px dashed var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+  border-radius: 8px;
+  background: var(--background-neutral-subtle, #f9fafb);
+  padding: 12px;
+  gap: 8px;
+}
+
+// Signal tags ("Org connection", "Person unknown") on their own line under the
+// org name (mirrors the person card's role line placement).
+.orgTagsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 3px;
+}
+
+// Org "why this works" description — wraps under the tags.
+.orgDescription {
+  margin-top: 3px;
+  font-size: 12px;
+  line-height: 18px;
+  color: $muted;
+}
+
+.orgAvatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.06));
+  color: $text-2;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+// Real logo for a PL-network org (clickable to its team profile).
+.orgLogo {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: #fff;
+  object-fit: contain;
+  padding: 2px;
+  border: 1px solid $border;
+}
+
+.orgNameRow {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+// Signal chip ("Org connection", "Person unknown") — dashed to read as a
+// status/uncertainty marker rather than a solid label.
+.orgTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px dashed var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: $muted;
+  white-space: nowrap;
+}
+
+.orgChannels {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding-left: 44px;
+}
+
+// External-link text link with a trailing arrow icon, vertically centered.
+.extLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+// Icon-only contact channel (linkedin / telegram): reuse ProfileSocialLink but
+// hide its handle text, keeping just the logo (the tooltip still shows the handle).
+.iconOnly {
+  display: inline-flex;
+  align-items: center;
+
+  // ProfileSocialLink styles its label via styled-jsx (injected at runtime, so
+  // same specificity but later in source) — !important is needed to hide it.
+  :global(.profile-social-link__link) {
+    display: none !important;
+  }
+}
+
+// Thin vertical separator between contact channels (email | linkedin | …).
+.channelDivider {
+  width: 1px;
+  align-self: stretch;
+  min-height: 16px;
+  margin: 0 4px;
+  background: $border;
+}
+
+// Stubbed "Suggest a correction" inline note.
+.correctionNote {
+  font-size: 12px;
+  line-height: 1.5;
+  color: $text-2;
+}
+
+// "Suggest a correction" link — pin to 13px (overrides the production Button
+// size="s" type). Equal-specificity override of an imported module class.
+.correctionLink {
+  font-size: 13px !important;
+}
+
+// Path-card labels (Best path / Alternative #N, warmth N%) bumped from
+// production's 11px to the system's 12px caption size (matches Tag / pd.explanation).
+.rankSm,
+.warmthSm {
+  font-size: 12px !important;
+}
+
+// A touch more vertical rhythm between the path-card rows (header → explanation
+// → chain); production pairs these at 6px, here 10px to breathe. Panel-only —
+// the inline table chain doesn't get these classes.
+.explanationSpaced,
+.chainSpaced {
+  margin-top: 10px !important;
+}
+
+// Path header carries the proximity badge + warmth + the node chain on one row;
+// let it wrap gracefully and sit the chain inline (no top margin).
+.pathHeadWrap {
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 6px;
+}
+
+.chainInline {
+  margin-top: 0 !important;
+}
+
+.copyEmail {
+  color: $muted;
+  padding: 2px;
+
+  // Smaller than the stock 16px icon, sits snug against the email.
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  &:hover {
+    color: $brand;
+  }
+}
+
+// ── Show-more paths ───────────────────────────────────────────────────────────
+.showMoreBtn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  padding: 7px 12px;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: $text-2;
+  cursor: pointer;
+
+  &:hover {
+    border-color: $brand;
+    color: $brand;
+  }
+}
+
+.coldNote {
+  font-size: 12px;
+  color: $muted;
+}
+
+// ── Add-to-list popover (bulk row action + drawer) + drawer membership chips ──
+.addListWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.addListMenu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 240px;
+  max-width: 90vw;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid var(--border-neutral-subtle, #e5e7eb);
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(14, 15, 17, 0.12);
+}
+
+// Opens upward — used by the drawer-footer trigger (sits at the bottom).
+.addListMenuUp {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+
+.addListHead {
+  padding: 6px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: $text-2;
+}
+
+.addListItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 8px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  color: $text;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+
+  &:disabled {
+    color: $muted;
+    cursor: default;
+  }
+}
+
+.addListIn {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--foreground-success-primary, #0a9952);
+}
+
+// In-list rows that toggle membership off when clicked (drawer single-investor).
+.addListItemToggle {
+  &:hover {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+}
+
+.addListToggle {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+// Default: show the "✓ In list" state.
+.addListToggleIn {
+  color: var(--foreground-success-primary, #0a9952);
+}
+
+// Hover: swap to a "Remove" hint so the row clearly reads as removable.
+.addListToggleRemove {
+  display: none;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.addListItemToggle:hover {
+  .addListToggleIn {
+    display: none;
+  }
+
+  .addListToggleRemove {
+    display: inline;
+  }
+}
+
+// Drawer: the investor's list memberships, each removable.
+.listChips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.listChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px 4px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 24px;
+  font-size: 12px;
+  font-weight: 500;
+  color: $text;
+}
+
+.listChipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  background: none;
+  border: none;
+  border-radius: 50%;
+  font-size: 14px;
+  line-height: 1;
+  color: $muted;
+  cursor: pointer;
+
+  &:hover {
+    color: rgb(29 78 216);
+  }
+}
+
+.listEmpty {
+  font-size: 13px;
+  color: $muted;
+}
+
+// ── Page padding (was an inline style; moved here so it can adapt on mobile) ───
+.page {
+  padding: 8px 20px 48px;
+}
+
+// ── Mobile card list — the table is replaced by tappable cards on small screens ─
+.mobileCards {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--border-neutral-subtle, #eef0f3);
+  border-radius: 12px;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mCardHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mCardMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mCardFirm {
+  font-size: 12px;
+  color: $text-2;
+}
+
+// Relationship chips + Export shouldn't wrap their own text into tall ovals.
+// Vertically center the chips against the Add-to-list / Export buttons.
+.resultsActionsResp {
+  align-items: center;
+}
+
+.resultsActionsResp button {
+  white-space: nowrap;
+}
+
+// ── Responsive: stack the filters/header + swap the table for cards (<640px) ───
+@media (max-width: 639px) {
+  // Chips + Export in one row; Export wraps under them only if it doesn't fit.
+  // Pin children to content width so a wrapped Export doesn't stretch full-width.
+  .resultsActionsResp {
+    flex-wrap: wrap;
+    align-items: center;
+
+    > * {
+      flex: 0 0 auto;
+    }
+  }
+
+  .page {
+    padding: 8px 12px 40px;
+  }
+
+  .pageTitleRow {
+    flex-wrap: wrap;
+  }
+
+  .pageTitle {
+    font-size: 24px;
+    line-height: 30px;
+    letter-spacing: -0.4px;
+  }
+
+  .tableDesktop {
+    display: none;
+  }
+
+  .mobileCards {
+    display: flex;
+  }
+
+  .builderRowResp {
+    flex-direction: column;
+    align-items: stretch;
+
+    // Production .field uses `flex: 1 1 200px`; in a column that makes each field
+    // grow vertically and leaves huge gaps. Size them to content instead.
+    > * {
+      flex: 0 0 auto;
+    }
+  }
+
+  .resultsHeaderResp {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  // Target-list selector: stack the "LIST" caption on top of the picker, and let
+  // the picker shrink to the available width (ListPicker's desktop min-width 320px
+  // would otherwise overflow).
+  .listField {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+  }
+
+  // Industry / Sector trigger spans the full width like the other fields.
+  .sectorPopWrap,
+  .sectorTrigger {
+    width: 100%;
+  }
+
+  .listPickerWrap {
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .listPickerWrap select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  // Connector card is already fluid (identity row + contacts row stack; channels
+  // wrap). On small screens give a wrapped contacts row a little row spacing and
+  // tighten the org card padding so it doesn't eat the narrow width.
+  .contactChannels {
+    row-gap: 6px;
+  }
+
+  .orgBox {
+    padding: 10px;
+  }
+
+  // Let the path header (badge · warmth) wrap rather than overflow.
+  .pathHeadWrap {
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+
+  // Filter actions: make the primary Apply button full-width (easy tap target);
+  // Clear + Save view wrap to a row below it. (Also clears the desktop
+  // margin-left:auto so the block spans the column.)
+  .builderActions {
+    width: 100%;
+    margin-left: 0;
+    flex-wrap: wrap;
+  }
+
+  // Both Apply and Clear span the full width (stacked), each an easy tap target.
+  .builderActions > button {
+    flex: 1 1 100%;
+  }
+}
+
+// ── Relationship filter chips (Co-invested / Engaged / Cold) ──────────────────
+//    The production Tag .secondary variant sets `white-space: wrap`, so the
+//    multi-word "Co-invested" label wraps to two lines and that chip renders
+//    ~2x the height of the single-word "Engaged"/"Cold" chips. Force a single
+//    line so all three sit at the same height in a tidy inline row. `!important`
+//    is needed because .secondary is an equal-specificity module class.
+//    Sizing (padding/font/line-height) is left to the Tag .root so these stay
+//    visually consistent with the sector chips (also Tag variant="secondary").
+.relChip {
+  white-space: nowrap !important;
+  align-items: center;
+  // Keep the normal Tag pill (24px radius, 12px text) — just reduce the height:
+  // tighter top/bottom padding so they're not so tall.
+  // Hug content — never grow/stretch to fill the row.
+  flex: 0 0 auto !important;
+  width: auto !important;
+  // Fixed 32px-tall pill; content centered.
+  height: 32px !important;
+  min-height: 32px !important;
+  box-sizing: border-box !important;
+  padding: 0 12px !important;
+  font-size: 12px !important;
+  line-height: 1 !important;
+}

--- a/prototypes/entries/warm-intros-filter-update/WarmPathPanel.tsx
+++ b/prototypes/entries/warm-intros-filter-update/WarmPathPanel.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import { Button } from '@/components/common/Button/Button';
+import { CopyButton } from '@/components/ui/CopyButton/CopyButton';
+// Reuse the Member-page contact components (icon + handle links) for the connectors.
+import { ProfileSocialLink } from '@/components/page/member-details/profile-social-link';
+import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
+import { getProfileFromURL } from '@/utils/common.utils';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+// Reuse the production path-card styling so the prototype tracks production.
+import pd from '@/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss';
+import { ArrowUpRightIcon } from '@/components/icons';
+import type { ContactPerson, MockPath, OrgConnector, TeamLink } from './mocks';
+import { PersonGlyph, OrgGlyph } from './PeopleChain';
+import x from './WarmIntrosImprovements.module.scss';
+
+interface Props {
+  paths: MockPath[];
+}
+
+// Issue #3: production renders ALL paths at once. Here we show only the best
+// path and collapse the rest behind a "Show N more" toggle.
+const TOP_N = 1;
+
+export function WarmPathPanel({ paths }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (paths.length === 0) {
+    return <div className={x.coldNote}>No warm path yet — this investor would be cold outreach.</div>;
+  }
+
+  const visible = expanded ? paths : paths.slice(0, TOP_N);
+  const hidden = paths.length - visible.length;
+
+  return (
+    <div className={pd.root}>
+      <ol className={pd.pathList}>
+        {visible.map((p) => (
+          <li key={p.id} className={pd.pathItem}>
+            <div className={`${pd.pathHead} ${x.pathHeadWrap}`}>
+              {/* One confidence signal: the proximity code stays as a quiet
+                  reference (no % on it); warmth is the single number. */}
+              <ProximityCodeBadge code={p.proximity_code} />
+              <span className={`${pd.rank} ${x.rankSm}`}>
+                {p.rank <= 1 ? 'Best path' : `Alternative #${p.rank}`} · {Math.round(p.score * 100)}% warm
+              </span>
+            </div>
+
+            {p.explanation && <div className={`${pd.explanation} ${x.explanationSpaced}`}>{p.explanation}</div>}
+
+            {/* Either a known person (with their team(s) + contacts) or an
+                org-led line where the specific person is unknown. */}
+            {p.orgConnector ? <OrgBlock org={p.orgConnector} /> : <ContactBlock path={p} />}
+
+            <div className={`${pd.correction} ${x.correctionRow}`}>
+              <CorrectionLink />
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      {hidden > 0 && (
+        <button type="button" className={x.showMoreBtn} onClick={() => setExpanded(true)}>
+          ＋ Show {hidden} more path{hidden === 1 ? '' : 's'}
+        </button>
+      )}
+      {expanded && paths.length > TOP_N && (
+        <button type="button" className={x.showMoreBtn} onClick={() => setExpanded(false)}>
+          – See less
+        </button>
+      )}
+    </div>
+  );
+}
+
+// "Suggest a correction" — same affordance as production WarmPathDetail. The
+// real form (wrong connector / caliber / invalid path) is wired in prod; here
+// it's a stubbed inline note.
+function CorrectionLink() {
+  const [open, setOpen] = useState(false);
+  if (!open) {
+    return (
+      <Button
+        style="link"
+        variant="secondary"
+        underline
+        size="s"
+        className={x.correctionLink}
+        onClick={() => setOpen(true)}
+      >
+        Suggest a correction
+      </Button>
+    );
+  }
+  return (
+    <div className={x.correctionNote}>
+      In production this opens the correction form — wrong connector, caliber too high/low, or invalid path.{' '}
+      <Button style="link" variant="secondary" underline size="s" onClick={() => setOpen(false)}>
+        Close
+      </Button>
+    </div>
+  );
+}
+
+function ContactBlock({ path }: { path: MockPath }) {
+  if (!path.contact) return null;
+
+  // Only the closest connector — warmth is scored on this single tie, so we
+  // don't stack the rest of the team underneath. No caption: the explanation
+  // above + the card itself already say "this is the person to reach".
+  return (
+    <div className={x.contactBlock}>
+      <div className={x.contactBox}>
+        <ConnectorCard person={path.contact} />
+      </div>
+    </div>
+  );
+}
+
+// One connector: avatar (network) or grey icon (external) + name, the role with
+// the team(s) inline as text links (+N more to expand the rest), and the contact
+// channels on their own row below so emails line up across cards.
+function ConnectorCard({ person }: { person: ContactPerson }) {
+  const teams = person.teams ?? [];
+  const [teamsExpanded, setTeamsExpanded] = useState(false);
+  const extraTeams = teams.length - 1;
+  const shownTeams = teamsExpanded ? teams : teams.slice(0, 1);
+  const memberHref = person.memberUid ? `/members/${person.memberUid}` : undefined;
+
+  const avatar = memberHref ? (
+    <img className={x.memberAvatar} src={getDefaultAvatar(person.name)} alt="" width={32} height={32} />
+  ) : (
+    <span className={x.memberAvatarExternal} aria-hidden title="Not in the PL network">
+      <PersonGlyph />
+    </span>
+  );
+
+  return (
+    <div className={x.connectorCard}>
+      <div className={x.connectorIdentity}>
+        {memberHref ? (
+          <a
+            className={x.memberAvatarLink}
+            href={memberHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {avatar}
+          </a>
+        ) : (
+          avatar
+        )}
+
+        <span className={x.memberText}>
+          <span className={x.memberNameRow}>
+            {memberHref ? (
+              <a
+                className={x.memberNameLink}
+                href={memberHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className={x.memberName}>{person.name}</span>
+                <span className={x.memberArrow} aria-hidden>
+                  <ArrowUpRightIcon width={12} height={12} />
+                </span>
+              </a>
+            ) : (
+              <span className={x.memberName}>{person.name}</span>
+            )}
+          </span>
+
+          {/* Role line carries the team(s) inline as links, side by side. */}
+          <span className={x.memberRoleLine}>
+            {person.role}
+            {teams.length > 0 && (
+              <>
+                {' · '}
+                {shownTeams.map((t, i) => (
+                  <Fragment key={t.teamUid ?? t.name}>
+                    {i > 0 && (
+                      <span className={x.teamDivider} aria-hidden>
+                        ·
+                      </span>
+                    )}
+                    <TeamInlineLink team={t} />
+                  </Fragment>
+                ))}
+                {extraTeams > 0 && (
+                  <button
+                    type="button"
+                    className={x.teamMoreBtn}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setTeamsExpanded((v) => !v);
+                    }}
+                  >
+                    {teamsExpanded ? 'Show less' : `+${extraTeams} more`}
+                  </button>
+                )}
+              </>
+            )}
+          </span>
+        </span>
+      </div>
+
+      <ContactChannels person={person} />
+    </div>
+  );
+}
+
+// A team rendered as an inline text link (no logo) with a small grey ↗.
+function TeamInlineLink({ team }: { team: TeamLink }) {
+  if (!team.teamUid) return <span className={x.teamInline}>{team.name}</span>;
+  return (
+    <a
+      className={x.teamInline}
+      href={`/teams/${team.teamUid}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {team.name}
+      <span className={x.teamInlineArrow} aria-hidden>
+        <ArrowUpRightIcon width={11} height={11} />
+      </span>
+    </a>
+  );
+}
+
+// Org-led connector: we know the company can route an intro but not who. Same
+// placement as a person card — name, then the signal tags under it, then the
+// description, then the org's contacts on their own row (aligned with people).
+function OrgBlock({ org }: { org: OrgConnector }) {
+  // PL-network org → clickable logo + name (link to its team profile); external
+  // firm → dashed building glyph + plain name.
+  const orgHref = org.teamUid ? `/teams/${org.teamUid}` : undefined;
+
+  return (
+    <div className={x.contactBlock}>
+      <div className={`${x.contactBox} ${x.orgBox}`}>
+        <div className={x.connectorIdentity}>
+          {orgHref ? (
+            <a
+              className={x.memberAvatarLink}
+              href={orgHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <img className={x.orgLogo} src={org.logo ?? getDefaultAvatar(org.name)} alt="" width={32} height={32} />
+            </a>
+          ) : (
+            <span className={x.orgAvatar} aria-hidden>
+              <OrgGlyph />
+            </span>
+          )}
+          <span className={x.memberText}>
+            <span className={x.orgNameRow}>
+              {orgHref ? (
+                <a
+                  className={x.memberNameLink}
+                  href={orgHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span className={x.memberName}>{org.name}</span>
+                  <span className={x.memberArrow} aria-hidden>
+                    <ArrowUpRightIcon width={12} height={12} />
+                  </span>
+                </a>
+              ) : (
+                <span className={x.memberName}>{org.name}</span>
+              )}
+              {org.tags.map((tag) => (
+                <span key={tag} className={x.orgTag}>
+                  {tag}
+                </span>
+              ))}
+            </span>
+            <span className={x.orgDescription}>{org.description}</span>
+          </span>
+        </div>
+
+        {(org.email || org.website) && (
+          <div className={x.contactChannels}>
+            {org.email && (
+              <span className={x.emailGroup}>
+                <ProfileSocialLink
+                  type="email"
+                  handle={org.email}
+                  profile={getProfileFromURL(org.email, 'email')}
+                  logo={getContactLogoByProvider('email')}
+                  height={20}
+                  width={20}
+                  callback={() => {}}
+                />
+                <CopyButton text={org.email} className={x.copyEmail} />
+              </span>
+            )}
+            {org.email && org.website && <span className={x.channelDivider} aria-hidden />}
+            {/* Website: icon only (the email is the one shown in full). */}
+            {org.website && (
+              <span className={x.iconOnly}>
+                <ProfileSocialLink
+                  type="website"
+                  handle={org.website}
+                  profile={getProfileFromURL(org.website, 'website')}
+                  logo={getContactLogoByProvider('website')}
+                  height={20}
+                  width={20}
+                  callback={() => {}}
+                />
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// A connector's individual contact channels (email + copy, linkedin, telegram).
+function ContactChannels({ person }: { person: ContactPerson }) {
+  const channels: { type: string; handle: string }[] = [];
+  if (person.email) channels.push({ type: 'email', handle: person.email });
+  if (person.linkedin) channels.push({ type: 'linkedin', handle: person.linkedin });
+  if (person.telegram) channels.push({ type: 'telegram', handle: person.telegram });
+  if (channels.length === 0) return null;
+
+  return (
+    <div className={x.contactChannels}>
+      {channels.map((ch, i) => (
+        <Fragment key={ch.type}>
+          {i > 0 && <span className={x.channelDivider} aria-hidden />}
+          {ch.type === 'email' ? (
+            <span className={x.emailGroup}>
+              <ProfileSocialLink
+                type="email"
+                handle={ch.handle}
+                profile={getProfileFromURL(ch.handle, 'email')}
+                logo={getContactLogoByProvider('email')}
+                height={20}
+                width={20}
+                callback={() => {}}
+              />
+              <CopyButton text={ch.handle} className={x.copyEmail} />
+            </span>
+          ) : (
+            <span className={x.iconOnly}>
+              <ProfileSocialLink
+                type={ch.type}
+                handle={ch.handle}
+                profile={getProfileFromURL(ch.handle, ch.type)}
+                logo={getContactLogoByProvider(ch.type)}
+                height={20}
+                width={20}
+                callback={() => {}}
+              />
+            </span>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-filter-update/WorkspaceSearch.tsx
+++ b/prototypes/entries/warm-intros-filter-update/WorkspaceSearch.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+// Reuse the production typeahead styling, with a prototype overlay that adds a
+// search icon + on-scale type (a DS improvement to spec back to production).
+import { SearchIcon } from '@/components/icons';
+import s from '@/components/page/investors/WarmIntrosWorkspace/WorkspaceTypeahead.module.scss';
+import x from './WarmIntrosImprovements.module.scss';
+import { MOCK_MEMBERS } from './mocks';
+
+type Row = { label: string; sub: string; kind: 'team' | 'founder' | 'investor' };
+
+interface Props {
+  onSelect: (label: string) => void;
+}
+
+// Mocked unified search: founders/teams (from portfolio paths) + investors/funds
+// (the list members). Mirrors production UnifiedSearchSelect's grouped dropdown.
+function buildIndex(): { local: Row[]; investors: Row[] } {
+  const teams = new Map<string, Row>();
+  const founders = new Map<string, Row>();
+  MOCK_MEMBERS.forEach((m) =>
+    m.paths.forEach((p) => {
+      if (p.team) teams.set(p.team.name, { label: p.team.name, sub: 'Portfolio team', kind: 'team' });
+      if (p.connector_type === 'F' && p.contact?.memberUid) {
+        founders.set(p.contact.name, { label: p.contact.name, sub: p.contact.role, kind: 'founder' });
+      }
+    }),
+  );
+  const local = [...teams.values(), ...founders.values()];
+  const investors: Row[] = MOCK_MEMBERS.map((m) => ({
+    label: `${m.first_name} ${m.last_name}`,
+    sub: m.firm,
+    kind: 'investor',
+  }));
+  return { local, investors };
+}
+
+export function WorkspaceSearch({ onSelect }: Props) {
+  const [term, setTerm] = useState('');
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { local, investors } = useMemo(buildIndex, []);
+
+  // Shorter placeholder on phones — the full prompt is clipped on narrow inputs.
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)');
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const q = term.trim().toLowerCase();
+  const searching = q.length >= 2;
+  const localHits = searching ? local.filter((r) => r.label.toLowerCase().includes(q)) : [];
+  const investorHits = searching ? investors.filter((r) => r.label.toLowerCase().includes(q)) : [];
+
+  const pick = (label: string) => {
+    onSelect(label);
+    setTerm('');
+    setOpen(false);
+  };
+
+  return (
+    <div className={clsx(s.wrap, x.searchWrap)} ref={ref}>
+      <span className={x.searchIcon} aria-hidden>
+        <SearchIcon />
+      </span>
+      <input
+        className={clsx(s.input, x.searchInput)}
+        type="search"
+        placeholder={isMobile ? 'Search…' : 'Search an investor, fund, founder or team…'}
+        value={term}
+        onChange={(e) => {
+          setTerm(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 120)}
+      />
+      {open && (
+        <div className={s.dropdown}>
+          {!searching && <div className={s.hint}>Type at least 2 characters to search</div>}
+          {localHits.length > 0 && <div className={s.groupLabel}>Founders / Teams</div>}
+          {localHits.map((r) => (
+            <div key={`l-${r.label}`} className={clsx(s.option)} onMouseDown={() => pick(r.label)}>
+              <span className={s.optName}>{r.label}</span>
+              <span className={s.optSub}>{r.sub}</span>
+            </div>
+          ))}
+          {searching && <div className={s.groupLabel}>Investors / Funds</div>}
+          {searching && investorHits.length === 0 && <div className={s.hint}>No investors found</div>}
+          {investorHits.map((r) => (
+            <div key={`i-${r.label}`} className={clsx(s.option)} onMouseDown={() => pick(r.label)}>
+              <span className={s.optName}>{r.label}</span>
+              <span className={s.optSub}>{r.sub}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-filter-update/mocks.ts
+++ b/prototypes/entries/warm-intros-filter-update/mocks.ts
@@ -1,0 +1,1122 @@
+// Mocked data for the Warm Intros redesign prototype. Shapes mirror the
+// production `OutreachInvestor` / `PathfinderPath` types just enough to render
+// the workspace table + the expanded path detail — no API, no react-query.
+//
+// Production source of truth:
+//   components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.tsx
+//   components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+import type {
+  AumRange,
+  CheckSizeRange,
+  EmailStatus,
+  EngagementTier,
+  InvestorList,
+  InvestorSource,
+  InvestorType,
+  LabOsProfileRef,
+  PathConnectorType,
+  SectorTag,
+  StageFocus,
+  WarmIntroTier,
+} from '@/services/investors/types';
+
+/** A target list (Lists IA). The workspace operates over one list at a time. */
+export type ListRef = { id: string; name: string };
+
+/** A link to a team a person belongs to. A connector can be in several teams. */
+export type TeamLink = { name: string; teamUid?: string; logo?: string };
+
+/** A person PL would actually reach out to on a given path. NEW vs production:
+ *  production only renders the hop-chain node *labels* — never an email or a
+ *  link to the person/team. This carries the contact info the issue asks for. */
+export type ContactPerson = {
+  name: string;
+  /** e.g. "Founder · Modular Globe" or "Partner · Pico Ventures". */
+  role: string;
+  email?: string;
+  /** LinkedIn / Telegram handles — rendered with the Member-page contact icons. */
+  linkedin?: string;
+  telegram?: string;
+  /** LabOS member uid → /members/:uid. Present ⇒ in the PL network (avatar +
+   *  link). Absent ⇒ a known person who is NOT in the network (grey icon). */
+  memberUid?: string;
+  /** Teams this person belongs to (can be several). Shown as chips in the drawer. */
+  teams?: TeamLink[];
+};
+
+/** An org-level connector for the case where we know a company can route an
+ *  intro but DON'T know which specific person yet. Renders with tags + the
+ *  organization's own contacts instead of an individual's. */
+export type OrgConnector = {
+  name: string;
+  /** When set, the org is in the PL network → its node/name link to /teams/:uid
+   *  and it shows its real logo (vs an external firm: dashed building glyph). */
+  teamUid?: string;
+  /** Real logo asset for a PL-network org. */
+  logo?: string;
+  /** Short why-this-works note. */
+  description: string;
+  /** Signal chips, e.g. ["Org connection", "Person unknown"]. */
+  tags: string[];
+  email?: string;
+  website?: string;
+};
+
+/** When a path routes through a PL portfolio team, the team + its contactable
+ *  leads. Issue #1: "no way to view team leads with emails / link to the team". */
+export type ConnectorTeam = {
+  name: string;
+  /** Team uid → /teams/:uid. */
+  teamUid: string;
+  leads: ContactPerson[];
+};
+
+/** One hop in the route to the investor. Production shows COMPANIES in the
+ *  middle (not individual people) ending at the investor — so each node is an
+ *  org/portfolio-team, or the investor themselves. */
+export type ChainNode = {
+  label: string;
+  kind: 'org' | 'team' | 'investor';
+  /** When kind==='team' (a PL portfolio team) → links to its page (new tab). */
+  teamUid?: string;
+  /** Real company logo asset; falls back to a generated avatar when absent. */
+  logo?: string;
+};
+
+export type MockPath = {
+  id: number;
+  rank: number;
+  proximity_code: string;
+  caliber_confidence: number | null;
+  /** 0–1 warmth (rendered as %). */
+  score: number;
+  connector_type: PathConnectorType;
+  explanation: string;
+  /** Hop-chain: PL → company(ies) → investor. Kept for connector-lens search;
+   *  the route is now rendered people-first (see `contact` / `orgConnector`). */
+  chain: ChainNode[];
+  /** The single best PERSON to contact on this path. Absent on org-led paths
+   *  where we know the company can connect but not the specific person. */
+  contact?: ContactPerson;
+  /** Present when we know an ORG can route the intro but not who specifically.
+   *  Mutually exclusive with a known `contact`. */
+  orgConnector?: OrgConnector;
+  /** Present when the path goes through a PL portfolio team. */
+  team?: ConnectorTeam;
+};
+
+/** A single node in the people-first route visual. Built from a path's
+ *  `contact` / `orgConnector`, or from the investor (the end node). */
+export type RouteNode = {
+  label: string;
+  /** Present ⇒ in PL network → avatar + /members link. */
+  memberUid?: string;
+  /** For an org node in the PL network → logo + link to /teams/:uid. */
+  teamUid?: string;
+  logo?: string;
+  /** member = network person (avatar), external = known non-network person
+   *  (grey icon), org = company we can route through but person unknown. */
+  variant: 'member' | 'external' | 'org';
+};
+
+/** A PL portfolio team's profile, shown in-app when a path's team is tapped. */
+export type TeamProfile = {
+  uid: string;
+  name: string;
+  tagline: string;
+  about: string;
+  sectors: SectorTag[];
+  stage: StageFocus;
+  website: string;
+  pl_invested_at: string;
+  leads: ContactPerson[];
+};
+
+export type MockInvestor = {
+  investor_id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  firm: string;
+  title: string;
+  sector_tags: SectorTag[];
+  stage_focus: StageFocus;
+  check_size_range: CheckSizeRange;
+  investor_type: InvestorType;
+  engagement_tier: EngagementTier;
+  relationship: WarmIntroTier;
+  best_proximity_code: string | null;
+  has_path: boolean;
+  /** Lists this investor currently belongs to (by ListRef.id). Mutated locally. */
+  list_ids: string[];
+  paths: MockPath[];
+
+  // ── Extra fields rendered only in the detail drawer (issue: same drawer on tap) ──
+  email_status: EmailStatus;
+  source: InvestorSource;
+  linkedin_url?: string;
+  firm_domain?: string;
+  geo_focus?: string;
+  fund_thesis?: string;
+  aum_range: AumRange;
+  lab_os_profile?: LabOsProfileRef | null;
+  outreach: {
+    touches: number;
+    opened: number;
+    clicked: number;
+    registered: number;
+    first_sent_date: string;
+    last_sent_date: string;
+  };
+};
+
+// Two lists only, mirroring production ("v1: Neuro + Gold") so devs can grab it.
+export const MOCK_LISTS: ListRef[] = [
+  { id: 'neuro-lp', name: 'Neuro LP pipeline' },
+  { id: 'gold', name: 'Gold tier VCs' },
+];
+
+export const DEFAULT_LIST_ID = 'neuro-lp';
+
+/** Full `InvestorList` records so the prototype can reuse the production
+ *  `ListPicker` component verbatim (it renders member_count + is_graphed). */
+export const MOCK_INVESTOR_LISTS: InvestorList[] = [
+  {
+    id: 'neuro-lp',
+    slug: 'neuro-lp',
+    name: 'Neuro LP pipeline',
+    description: 'Neurotech-focused LPs and funds.',
+    is_graphed: true,
+    member_count: 10,
+  },
+  { id: 'gold', slug: 'gold', name: 'Gold tier VCs', description: 'Top-priority VC targets.', is_graphed: true, member_count: 3 },
+];
+
+/** Team profiles keyed by teamUid (the `team.teamUid` on a path). */
+export const MOCK_TEAM_PROFILES: Record<string, TeamProfile> = {
+  'modular-globe': {
+    uid: 'modular-globe',
+    name: 'Modular Globe',
+    tagline: 'Composable infrastructure for neuro data pipelines',
+    about:
+      'Modular Globe builds the data-orchestration layer used by neurotech labs to move signal data from device to model. PL led the seed round in 2024.',
+    sectors: ['neurotech', 'infrastructure'],
+    stage: 'seed',
+    website: 'modularglobe.xyz',
+    pl_invested_at: '2024-06',
+    leads: [
+      { name: 'Maya Chen', role: 'CEO & Co-founder', email: 'maya@modularglobe.xyz', linkedin: 'maya-chen', telegram: 'mayachen', memberUid: 'maya-chen' },
+      { name: 'Arjun Patel', role: 'CTO & Co-founder', email: 'arjun@modularglobe.xyz', linkedin: 'arjun-patel', memberUid: 'arjun-patel' },
+    ],
+  },
+  'helios-robotics': {
+    uid: 'helios-robotics',
+    name: 'Helios Robotics',
+    tagline: 'Autonomous field robotics for energy infrastructure',
+    about:
+      'Helios builds inspection robots for solar and grid infrastructure. Vertex Frontier led the seed; PL co-invested.',
+    sectors: ['robotics', 'ai'],
+    stage: 'seed',
+    website: 'heliosrobotics.io',
+    pl_invested_at: '2024-11',
+    leads: [
+      { name: 'Devon Okoye', role: 'CEO & Founder', email: 'devon@heliosrobotics.io', linkedin: 'devon-okoye', telegram: 'devonokoye', memberUid: 'devon-okoye' },
+      { name: 'Sofia Marchetti', role: 'COO', email: 'sofia@heliosrobotics.io', linkedin: 'sofia-marchetti', memberUid: 'sofia-marchetti' },
+    ],
+  },
+  'tidal-energy': {
+    uid: 'tidal-energy',
+    name: 'Tidal Energy',
+    tagline: 'Grid-scale tidal power systems',
+    about: 'Tidal Energy develops modular tidal turbines for coastal grids. A PL portfolio team since 2023.',
+    sectors: ['climate', 'frontier-tech'],
+    stage: 'series-a',
+    website: 'tidalenergy.co',
+    pl_invested_at: '2023-09',
+    leads: [{ name: 'Priya Anand', role: 'CEO & Founder', email: 'priya@tidalenergy.co', memberUid: 'priya-anand' }],
+  },
+};
+
+// Chain-node helpers (keep the route data below terse + readable). Logos are
+// real assets from the demoday landing set so the badges show actual marks.
+const LOGOS = '/icons/demoday/landing/logos';
+const PL: ChainNode = { label: 'Protocol Labs', kind: 'org', logo: `${LOGOS}/Protocol%20Labs.svg` };
+const org = (label: string, logo?: string): ChainNode => ({ label, kind: 'org', logo });
+const team = (label: string, teamUid: string, logo?: string): ChainNode => ({ label, kind: 'team', teamUid, logo });
+
+/** Is the investor themselves in the PL network (has a LabOS member profile)? */
+export function isInvestorInNetwork(inv: MockInvestor): boolean {
+  return inv.lab_os_profile?.type === 'member';
+}
+
+/** The investor as the end node of a people-first route. */
+export function investorNode(inv: MockInvestor): RouteNode {
+  const inNet = isInvestorInNetwork(inv);
+  return {
+    label: `${inv.first_name} ${inv.last_name}`,
+    memberUid: inNet ? inv.lab_os_profile?.uid : undefined,
+    variant: inNet ? 'member' : 'external',
+  };
+}
+
+/** The connector node for a path: a network person (avatar), a known non-network
+ *  person (grey icon), or an org we can route through but person-unknown. */
+export function connectorNode(path: MockPath): RouteNode | null {
+  if (path.orgConnector)
+    return {
+      label: path.orgConnector.name,
+      variant: 'org',
+      teamUid: path.orgConnector.teamUid,
+      logo: path.orgConnector.logo,
+    };
+  if (path.contact) {
+    return {
+      label: path.contact.name,
+      memberUid: path.contact.memberUid,
+      variant: path.contact.memberUid ? 'member' : 'external',
+    };
+  }
+  return null;
+}
+
+/** The 2-step chain for a path: the closest connector → the target investor.
+ *  Both shown so the row reads "reach X, who connects to {investor}". */
+export function pathChainNodes(path: MockPath, inv: MockInvestor): RouteNode[] {
+  const connector = connectorNode(path);
+  return connector ? [connector, investorNode(inv)] : [];
+}
+
+// ── Connector-case path factory ─────────────────────────────────────────────
+// Every path-having investor gets the same three connector states so the drawer
+// demonstrates all of them: member known (network person), organization unknown
+// (external firm, person unknown), member unknown (known person not in the
+// network). Ordered warmest → coldest. The investor's own firm is the chain
+// end-org.
+let _pathId = 9000;
+const nextPathId = () => (_pathId += 1);
+
+function fourCasePaths(firstName: string, firm: string, leadWithOrg = false): MockPath[] {
+  const firmOrg = org(firm, `${LOGOS}/Framework.svg`);
+
+  // Member known — PL-network founder.
+  const memberKnown: Omit<MockPath, 'id' | 'rank'> = {
+    proximity_code: 'F+1A',
+    caliber_confidence: 0.9,
+    score: 0.86,
+    connector_type: 'F',
+    explanation: `Alicia Mer (Modular Globe, PL portfolio) knows ${firstName} well and can broker a warm intro.`,
+    chain: [PL, team('Modular Globe', 'modular-globe', '/icons/technology/filecoin.svg'), firmOrg],
+    contact: {
+      name: 'Alicia Mer',
+      role: 'CEO & Co-founder',
+      email: 'alicia@modularglobe.xyz',
+      linkedin: 'alicia-mer',
+      telegram: 'aliciamer',
+      memberUid: 'alicia-mer',
+      teams: [
+        { name: 'Modular Globe', teamUid: 'modular-globe' },
+        { name: 'NeuroBridge Labs', teamUid: 'neurobridge-labs' },
+      ],
+    },
+  };
+
+  // Organization unknown — external firm, person unknown.
+  const orgUnknown: Omit<MockPath, 'id' | 'rank'> = {
+    proximity_code: 'VC+1B',
+    caliber_confidence: 0.55,
+    score: 0.5,
+    connector_type: 'VC',
+    explanation: `Pico Ventures co-invests with ${firm}; someone there can broker an intro — we haven't identified who yet.`,
+    chain: [PL, org('Pico Ventures', `${LOGOS}/Multicoin.svg`), firmOrg],
+    orgConnector: {
+      name: 'Pico Ventures',
+      description: 'Reach out to the firm and ask to be routed to the partner who covers this mandate.',
+      tags: ['Org connection', 'Person unknown'],
+      email: 'intros@picoventures.com',
+      website: 'picoventures.com',
+    },
+  };
+
+  // Member unknown — known person, NOT in the PL network.
+  const memberUnknown: Omit<MockPath, 'id' | 'rank'> = {
+    proximity_code: 'VC+2B',
+    caliber_confidence: 0.4,
+    score: 0.42,
+    connector_type: 'VC',
+    explanation: `James Whitfield at Electric Capital has co-invested alongside ${firm}. He is not in the PL network, so reach out directly.`,
+    chain: [PL, org('Electric Capital', `${LOGOS}/ElectricCapital.svg`), firmOrg],
+    contact: {
+      name: 'James Whitfield',
+      role: 'Partner',
+      email: 'james@electriccapital.com',
+      linkedin: 'james-whitfield',
+      teams: [{ name: 'Electric Capital', teamUid: 'electric-capital' }],
+    },
+  };
+
+  // Warmest first. `leadWithOrg` surfaces the org-unknown node as the best path
+  // (so it shows in the table) for the rows we want to demo it on.
+  const ordered = leadWithOrg
+    ? [orgUnknown, memberKnown, memberUnknown]
+    : [memberKnown, orgUnknown, memberUnknown];
+  return ordered.map((p, i) => ({ ...p, id: nextPathId(), rank: i + 1 }));
+}
+
+const BASE_MEMBERS: MockInvestor[] = [
+  {
+    investor_id: 'inv-lena',
+    first_name: 'Lena',
+    last_name: 'Hoffmann',
+    email: 'lena@catalystbio.vc',
+    email_status: 'verified',
+    source: 'W26',
+    linkedin_url: 'https://www.linkedin.com/in/lena-hoffmann',
+    firm_domain: 'catalystbio.vc',
+    geo_focus: 'US / EU',
+    fund_thesis: 'Early-stage neurotech and computational biology with a translational angle.',
+    aum_range: '100-500M',
+    lab_os_profile: { type: 'member', uid: 'lena-hoffmann', slug: 'lena-hoffmann', name: 'Lena Hoffmann' },
+    outreach: {
+      touches: 4,
+      opened: 3,
+      clicked: 2,
+      registered: 1,
+      first_sent_date: '2025-11-02',
+      last_sent_date: '2026-03-14',
+    },
+    firm: 'Catalyst Bio',
+    title: 'Partner',
+    sector_tags: ['neurotech', 'biotech'],
+    stage_focus: 'seed',
+    check_size_range: '1M-5M',
+    investor_type: 'fund',
+    engagement_tier: 'T2_clicked',
+    relationship: 'co_invested',
+    best_proximity_code: 'F+1A',
+    has_path: true,
+    list_ids: ['neuro-lp', 'gold'],
+    paths: [
+      {
+        id: 101,
+        rank: 1,
+        proximity_code: 'F+1A',
+        caliber_confidence: 0.92,
+        score: 0.88,
+        connector_type: 'F',
+        explanation:
+          'Alicia Mer co-founded Modular Globe (PL portfolio) and works closely with Mei Chen, who knows Lena well — a two-person founder route is the warmest path.',
+        chain: [PL, team('Modular Globe', 'modular-globe', '/icons/technology/filecoin.svg'), org('Catalyst Bio', `${LOGOS}/Archetype.svg`)],
+        contact: {
+          name: 'Alicia Mer',
+          role: 'CEO & Co-founder',
+          email: 'alicia@modularglobe.xyz',
+          linkedin: 'alicia-mer',
+          telegram: 'aliciamer',
+          memberUid: 'alicia-mer',
+          // A connector can sit in several PL teams — shown as chips in the drawer.
+          teams: [
+            { name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' },
+            { name: 'NeuroBridge Labs', teamUid: 'neurobridge-labs', logo: '/icons/technology/ipfs.svg' },
+          ],
+        },
+        team: {
+          name: 'Modular Globe',
+          teamUid: 'modular-globe',
+          leads: [
+            { name: 'Mei Chen', role: 'Head of BD · Modular Globe', email: 'mei@modularglobe.xyz', linkedin: 'mei-chen', memberUid: 'mei-chen', teams: [{ name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' }] },
+          ],
+        },
+      },
+      {
+        // Org-led: we know the firm can route an intro, but not WHO yet.
+        id: 104,
+        rank: 2,
+        proximity_code: 'VC+1B',
+        caliber_confidence: 0.6,
+        score: 0.62,
+        connector_type: 'VC',
+        explanation: 'Pico Ventures co-invested in two Catalyst Bio rounds, so someone there can broker an intro to Lena — we just haven’t identified the specific partner yet.',
+        chain: [PL, org('Pico Ventures', `${LOGOS}/Multicoin.svg`), org('Catalyst Bio', `${LOGOS}/Archetype.svg`)],
+        orgConnector: {
+          name: 'Pico Ventures',
+          description: 'Reach out to the firm and ask to be routed to the partner who covers Catalyst Bio co-investments.',
+          tags: ['Org connection', 'Person unknown'],
+          email: 'intros@picoventures.com',
+          website: 'picoventures.com',
+        },
+      },
+      {
+        id: 102,
+        rank: 3,
+        proximity_code: 'VC+2B',
+        caliber_confidence: 0.61,
+        score: 0.54,
+        connector_type: 'VC',
+        explanation: 'James Whitfield at Electric Capital has co-invested alongside Catalyst Bio and can broker an intro. He is not in the PL network, so reach out directly.',
+        chain: [PL, org('Electric Capital', `${LOGOS}/ElectricCapital.svg`), org('Catalyst Bio', `${LOGOS}/Archetype.svg`)],
+        contact: {
+          name: 'James Whitfield',
+          role: 'Partner',
+          email: 'james@electriccapital.com',
+          linkedin: 'james-whitfield',
+          teams: [{ name: 'Electric Capital', teamUid: 'electric-capital' }],
+        },
+      },
+      {
+        id: 103,
+        rank: 3,
+        proximity_code: 'PL+2B',
+        caliber_confidence: 0.4,
+        score: 0.38,
+        connector_type: 'PL',
+        explanation: 'Rina Calabrese on the PL partnerships team has a second-degree relationship she can warm up.',
+        chain: [PL, org('Catalyst Bio', `${LOGOS}/Archetype.svg`)],
+        contact: {
+          name: 'Rina Calabrese',
+          role: 'Partnerships Lead · Protocol Labs',
+          email: 'rina@protocol.ai',
+          linkedin: 'rina-calabrese',
+          memberUid: 'rina-calabrese',
+        },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-marcus',
+    first_name: 'Marcus',
+    last_name: 'True',
+    email: 'marcus@vertexfrontier.com',
+    email_status: 'verified',
+    source: 'OpenVC',
+    linkedin_url: 'https://www.linkedin.com/in/marcus-true',
+    firm_domain: 'vertexfrontier.com',
+    geo_focus: 'US',
+    fund_thesis: 'Frontier AI, robotics, and the infrastructure layer underneath them.',
+    aum_range: '500M-1B',
+    lab_os_profile: null,
+    outreach: {
+      touches: 3,
+      opened: 2,
+      clicked: 1,
+      registered: 0,
+      first_sent_date: '2025-12-09',
+      last_sent_date: '2026-02-20',
+    },
+    firm: 'Vertex Frontier',
+    title: 'Principal',
+    sector_tags: ['ai', 'robotics', 'infrastructure'],
+    stage_focus: 'seed',
+    check_size_range: '500K-1M',
+    investor_type: 'fund',
+    engagement_tier: 'T3_opened',
+    relationship: 'co_invested',
+    best_proximity_code: 'F+1A',
+    has_path: true,
+    list_ids: ['neuro-lp', 'gold'],
+    paths: [
+      {
+        id: 201,
+        rank: 1,
+        proximity_code: 'F+1A',
+        caliber_confidence: 0.9,
+        score: 0.85,
+        connector_type: 'F',
+        explanation:
+          'Devon Okoye founded Helios Robotics (PL portfolio). Vertex Frontier led the Helios seed, so Devon can intro Marcus directly.',
+        chain: [PL, team('Helios Robotics', 'helios-robotics', '/icons/technology/ipfs.svg'), org('Vertex Frontier', `${LOGOS}/BlueYard.svg`)],
+        contact: {
+          name: 'Devon Okoye',
+          role: 'CEO & Founder',
+          email: 'devon@heliosrobotics.io',
+          linkedin: 'devon-okoye',
+          telegram: 'devonokoye',
+          memberUid: 'devon-okoye',
+          teams: [{ name: 'Helios Robotics', teamUid: 'helios-robotics' }],
+        },
+        team: {
+          name: 'Helios Robotics',
+          teamUid: 'helios-robotics',
+          leads: [
+            { name: 'Devon Okoye', role: 'CEO & Founder', email: 'devon@heliosrobotics.io', linkedin: 'devon-okoye', telegram: 'devonokoye', memberUid: 'devon-okoye' },
+            { name: 'Sofia Marchetti', role: 'COO', email: 'sofia@heliosrobotics.io', linkedin: 'sofia-marchetti', memberUid: 'sofia-marchetti' },
+          ],
+        },
+      },
+      {
+        id: 202,
+        rank: 2,
+        proximity_code: 'VC+1B',
+        caliber_confidence: 0.7,
+        score: 0.66,
+        connector_type: 'VC',
+        explanation: 'Co-invested with Multicoin Capital, who can pass along a warm note.',
+        chain: [PL, org('Multicoin Capital', `${LOGOS}/Multicoin.svg`), org('Vertex Frontier', `${LOGOS}/BlueYard.svg`)],
+        contact: { name: 'Nina Brandt', role: 'GP', email: 'nina@multicoin.capital', linkedin: 'nina-brandt', memberUid: 'nina-brandt', teams: [{ name: 'Multicoin Capital', teamUid: 'multicoin-capital' }] },
+      },
+      {
+        id: 203,
+        rank: 3,
+        proximity_code: 'JB+2B',
+        caliber_confidence: 0.5,
+        score: 0.45,
+        connector_type: 'JB',
+        explanation: 'CoinFund co-invested alongside Vertex Frontier; a PL member there can broker the note.',
+        chain: [PL, org('CoinFund', `${LOGOS}/CoinFund.svg`), org('Vertex Frontier', `${LOGOS}/BlueYard.svg`)],
+        contact: { name: 'Theo Lindqvist', role: 'Partner', email: 'theo@coinfund.io', linkedin: 'theo-lindqvist', memberUid: 'theo-lindqvist', teams: [{ name: 'CoinFund', teamUid: 'coinfund' }] },
+      },
+      {
+        id: 204,
+        rank: 4,
+        proximity_code: 'O+2B',
+        caliber_confidence: 0.3,
+        score: 0.31,
+        connector_type: 'O',
+        explanation: 'A weaker secondary route through a conference acquaintance.',
+        chain: [PL, org('Vertex Frontier', `${LOGOS}/BlueYard.svg`)],
+        contact: { name: 'Ada Brooks', role: 'Advisor', email: 'ada@brooks.partners', linkedin: 'ada-brooks', memberUid: 'ada-brooks', teams: [{ name: 'Vertex Frontier', teamUid: 'vertex-frontier' }] },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-soren',
+    first_name: 'Soren',
+    last_name: 'Vibe',
+    email: 'soren@northlight.capital',
+    email_status: 'catch_all',
+    source: 'Dealroom',
+    linkedin_url: 'https://www.linkedin.com/in/soren-vibe',
+    firm_domain: 'northlight.capital',
+    geo_focus: 'EU',
+    fund_thesis: 'Series A climate and frontier-tech with hardware depth.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: {
+      touches: 2,
+      opened: 2,
+      clicked: 1,
+      registered: 0,
+      first_sent_date: '2026-01-15',
+      last_sent_date: '2026-04-02',
+    },
+    firm: 'Northlight Capital',
+    title: 'General Partner',
+    sector_tags: ['climate', 'frontier-tech'],
+    stage_focus: 'series-a',
+    check_size_range: '5M+',
+    investor_type: 'fund',
+    engagement_tier: 'T2_clicked',
+    relationship: 'engaged',
+    best_proximity_code: 'VC+1A',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        id: 301,
+        rank: 1,
+        proximity_code: 'VC+1A',
+        caliber_confidence: 0.84,
+        score: 0.79,
+        connector_type: 'VC',
+        explanation: 'Northlight co-led a round with Polychain Capital, a close PL co-investor — a strong VC intro.',
+        chain: [PL, org('Polychain Capital', `${LOGOS}/PolychainCapital.svg`), org('Northlight Capital', `${LOGOS}/Framework.svg`)],
+        contact: {
+          name: 'Talia Rosen',
+          role: 'Partner',
+          email: 'talia@polychain.capital',
+          linkedin: 'talia-rosen',
+          memberUid: 'talia-rosen',
+          teams: [{ name: 'Polychain Capital', teamUid: 'polychain-capital' }],
+        },
+      },
+      {
+        id: 302,
+        rank: 2,
+        proximity_code: 'F+2B',
+        caliber_confidence: 0.55,
+        score: 0.49,
+        connector_type: 'F',
+        explanation: 'Two hops via a founder Soren previously backed.',
+        chain: [PL, team('Tidal Energy', 'tidal-energy', '/icons/technology/drand.svg'), org('Northlight Capital', `${LOGOS}/Framework.svg`)],
+        contact: {
+          name: 'Priya Anand',
+          role: 'CEO & Founder',
+          email: 'priya@tidalenergy.co',
+          linkedin: 'priya-anand',
+          telegram: 'priyaanand',
+          memberUid: 'priya-anand',
+          teams: [{ name: 'Tidal Energy', teamUid: 'tidal-energy' }],
+        },
+        team: {
+          name: 'Tidal Energy',
+          teamUid: 'tidal-energy',
+          leads: [
+            { name: 'Priya Anand', role: 'CEO & Founder', email: 'priya@tidalenergy.co', linkedin: 'priya-anand', telegram: 'priyaanand', memberUid: 'priya-anand' },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-priya',
+    first_name: 'Priya',
+    last_name: 'Nadar',
+    email: 'priya.nadar@gmail.com',
+    email_status: 'unverified',
+    source: 'Exa',
+    linkedin_url: 'https://www.linkedin.com/in/priya-nadar',
+    geo_focus: 'US',
+    fund_thesis: 'Pre-seed DeSci and biotech, writing small angel checks.',
+    aum_range: 'unknown',
+    lab_os_profile: null,
+    outreach: {
+      touches: 1,
+      opened: 0,
+      clicked: 0,
+      registered: 0,
+      first_sent_date: '2026-02-28',
+      last_sent_date: '2026-02-28',
+    },
+    firm: 'Angel',
+    title: 'Angel investor',
+    // Sector not captured for this angel (shows "—"); stage is known.
+    sector_tags: [],
+    stage_focus: 'pre-seed',
+    check_size_range: '<100K',
+    investor_type: 'angel',
+    engagement_tier: 'T4_cold',
+    relationship: 'cold_match',
+    best_proximity_code: 'JB+2B',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        id: 401,
+        rank: 1,
+        proximity_code: 'JB+2B',
+        caliber_confidence: 0.48,
+        score: 0.42,
+        connector_type: 'JB',
+        explanation: 'Sana Iqbal co-chairs a DeSci working group at Hashed with Priya and can make a soft intro.',
+        chain: [PL, org('Hashed', `${LOGOS}/Hashed.svg`), org('Angel', `${LOGOS}/SVAngel.svg`)],
+        contact: { name: 'Sana Iqbal', role: 'DeSci Lead', email: 'sana@hashed.com', linkedin: 'sana-iqbal', memberUid: 'sana-iqbal', teams: [{ name: 'Hashed', teamUid: 'hashed' }] },
+      },
+      {
+        id: 402,
+        rank: 2,
+        proximity_code: 'F+2B',
+        caliber_confidence: 0.4,
+        score: 0.36,
+        connector_type: 'F',
+        explanation: 'Arjun Patel (Modular Globe, PL portfolio) knows Priya from a DeSci hackathon and can vouch.',
+        chain: [PL, team('Modular Globe', 'modular-globe', '/icons/technology/filecoin.svg'), org('Angel', `${LOGOS}/SVAngel.svg`)],
+        contact: {
+          name: 'Arjun Patel',
+          role: 'CTO & Co-founder',
+          email: 'arjun@modularglobe.xyz',
+          linkedin: 'arjun-patel',
+          memberUid: 'arjun-patel',
+          teams: [{ name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' }],
+        },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-hannah',
+    first_name: 'Hannah',
+    last_name: 'Berg',
+    email: 'hannah@bergfamilyoffice.com',
+    email_status: 'verified',
+    source: 'Visible',
+    linkedin_url: 'https://www.linkedin.com/in/hannah-berg',
+    firm_domain: 'bergfamilyoffice.com',
+    geo_focus: 'US / Global',
+    fund_thesis: 'Later-stage climate and consumer; opportunistic family-office mandate.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: {
+      touches: 3,
+      opened: 2,
+      clicked: 0,
+      registered: 0,
+      first_sent_date: '2025-10-21',
+      last_sent_date: '2026-03-30',
+    },
+    firm: 'Berg Family Office',
+    title: 'Director of Investments',
+    sector_tags: ['climate', 'consumer'],
+    stage_focus: 'series-b+',
+    check_size_range: '5M+',
+    investor_type: 'family_office',
+    engagement_tier: 'T3_opened',
+    relationship: 'engaged',
+    best_proximity_code: 'O+1B',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        // Org-led best path: we know the advisory firm can route an intro to the
+        // Berg family office, but not which person — surfaces an org node in the table.
+        id: 501,
+        rank: 1,
+        proximity_code: 'O+1B',
+        caliber_confidence: 0.5,
+        score: 0.5,
+        connector_type: 'O',
+        explanation: 'Stonebridge Advisors advises the Berg family office — someone there can make the intro, but we haven’t pinned down who yet.',
+        chain: [PL, org('Stonebridge Advisors', `${LOGOS}/Eniac.svg`), org('Berg Family Office', `${LOGOS}/Eniac.svg`)],
+        orgConnector: {
+          name: 'Stonebridge Advisors',
+          description: 'Reach out to the advisory firm and ask for the partner who covers the Berg mandate.',
+          tags: ['Org connection', 'Person unknown'],
+          email: 'intros@stonebridge.com',
+          website: 'stonebridge.com',
+        },
+      },
+      {
+        id: 502,
+        rank: 2,
+        proximity_code: 'PL+2B',
+        caliber_confidence: 0.36,
+        score: 0.34,
+        connector_type: 'PL',
+        explanation: 'Rina Calabrese (PL partnerships) also has a second-degree line to the Berg office.',
+        chain: [PL, org('Berg Family Office', `${LOGOS}/Eniac.svg`)],
+        contact: { name: 'Rina Calabrese', role: 'Partnerships Lead', email: 'rina@protocol.ai', linkedin: 'rina-calabrese', memberUid: 'rina-calabrese' },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-tomas',
+    first_name: 'Tomás',
+    last_name: 'Reyes',
+    email: 'tomas@syndicate.xyz',
+    email_status: 'catch_all',
+    source: 'RootData',
+    geo_focus: 'LATAM',
+    fund_thesis: 'Seed gaming and crypto via a rolling syndicate.',
+    aum_range: '<50M',
+    lab_os_profile: null,
+    outreach: {
+      touches: 0,
+      opened: 0,
+      clicked: 0,
+      registered: 0,
+      first_sent_date: '',
+      last_sent_date: '',
+    },
+    firm: 'Reyes Syndicate',
+    title: 'Lead',
+    // Sparse external record — no sector or stage captured yet (shows "—" in table).
+    sector_tags: [],
+    stage_focus: 'unknown',
+    check_size_range: '100-500K',
+    investor_type: 'syndicate',
+    engagement_tier: 'T4_cold',
+    relationship: 'cold_match',
+    best_proximity_code: null,
+    has_path: false,
+    list_ids: ['neuro-lp'],
+    paths: [],
+  },
+  {
+    investor_id: 'inv-wei',
+    first_name: 'Wei',
+    last_name: 'Chen',
+    email: 'wei@coinbase.com',
+    email_status: 'verified',
+    source: 'OpenVC',
+    linkedin_url: 'https://www.linkedin.com/in/wei-chen',
+    firm_domain: 'coinbase.com',
+    geo_focus: 'US / Asia',
+    fund_thesis: 'Crypto infrastructure and onchain consumer apps.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: { touches: 3, opened: 2, clicked: 1, registered: 0, first_sent_date: '2025-12-01', last_sent_date: '2026-03-10' },
+    firm: 'Coinbase Ventures',
+    title: 'Investment Partner',
+    sector_tags: ['crypto', 'infrastructure'],
+    stage_focus: 'series-a',
+    check_size_range: '1M-5M',
+    investor_type: 'fund',
+    engagement_tier: 'T2_clicked',
+    relationship: 'co_invested',
+    best_proximity_code: 'VC+1A',
+    has_path: true,
+    list_ids: ['neuro-lp', 'gold'],
+    paths: [
+      {
+        id: 701,
+        rank: 1,
+        proximity_code: 'VC+1A',
+        caliber_confidence: 0.86,
+        score: 0.8,
+        connector_type: 'VC',
+        explanation: 'Coinbase Ventures co-invested with PL in two onchain-infra rounds — a direct partner intro is warm.',
+        chain: [PL, org('Coinbase Ventures', `${LOGOS}/Coinbase.svg`), org('Coinbase Ventures', `${LOGOS}/Coinbase.svg`)],
+        contact: {
+          name: 'Priyanka Rao',
+          role: 'Investment Partner',
+          email: 'priyanka@coinbase.com',
+          linkedin: 'priyanka-rao',
+          memberUid: 'priyanka-rao',
+          teams: [{ name: 'Coinbase Ventures', teamUid: 'coinbase-ventures' }],
+        },
+      },
+      {
+        id: 702,
+        rank: 2,
+        proximity_code: 'F+1B',
+        caliber_confidence: 0.66,
+        score: 0.6,
+        connector_type: 'F',
+        explanation: 'Devon Okoye (Helios Robotics, PL portfolio) raised from Coinbase Ventures and can intro Wei directly.',
+        chain: [PL, team('Helios Robotics', 'helios-robotics', '/icons/technology/ipfs.svg'), org('Coinbase Ventures', `${LOGOS}/Coinbase.svg`)],
+        contact: {
+          name: 'Devon Okoye',
+          role: 'CEO & Founder',
+          email: 'devon@heliosrobotics.io',
+          linkedin: 'devon-okoye',
+          telegram: 'devonokoye',
+          memberUid: 'devon-okoye',
+          teams: [{ name: 'Helios Robotics', teamUid: 'helios-robotics', logo: '/icons/technology/ipfs.svg' }],
+        },
+      },
+      {
+        id: 703,
+        rank: 3,
+        proximity_code: 'VC+2B',
+        caliber_confidence: 0.5,
+        score: 0.45,
+        connector_type: 'VC',
+        explanation: 'Coinbase Ventures co-invested with Multicoin; a PL member there can pass a note.',
+        chain: [PL, org('Multicoin Capital', `${LOGOS}/Multicoin.svg`), org('Coinbase Ventures', `${LOGOS}/Coinbase.svg`)],
+        contact: { name: 'Nina Brandt', role: 'GP', email: 'nina@multicoin.capital', linkedin: 'nina-brandt', memberUid: 'nina-brandt', teams: [{ name: 'Multicoin Capital', teamUid: 'multicoin-capital' }] },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-lukas',
+    first_name: 'Lukas',
+    last_name: 'Brandt',
+    email: 'lukas@galaxy.com',
+    email_status: 'verified',
+    source: 'Dealroom',
+    linkedin_url: 'https://www.linkedin.com/in/lukas-brandt',
+    firm_domain: 'galaxy.com',
+    geo_focus: 'EU',
+    fund_thesis: 'Digital assets, mining, and compute infrastructure.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: { touches: 2, opened: 1, clicked: 0, registered: 0, first_sent_date: '2026-01-20', last_sent_date: '2026-02-15' },
+    firm: 'Galaxy',
+    title: 'Principal',
+    sector_tags: ['crypto', 'infrastructure'],
+    stage_focus: 'series-b+',
+    check_size_range: '5M+',
+    investor_type: 'fund',
+    engagement_tier: 'T3_opened',
+    relationship: 'engaged',
+    best_proximity_code: 'F+2B',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        id: 801,
+        rank: 1,
+        proximity_code: 'F+2B',
+        caliber_confidence: 0.58,
+        score: 0.52,
+        connector_type: 'F',
+        explanation: 'Maya Chen (Modular Globe, PL portfolio) previously raised from Galaxy and can broker an intro to Lukas.',
+        chain: [PL, team('Modular Globe', 'modular-globe', '/icons/technology/filecoin.svg'), org('Galaxy', `${LOGOS}/Galaxy.svg`)],
+        contact: {
+          name: 'Maya Chen',
+          role: 'CEO & Co-founder',
+          email: 'maya@modularglobe.xyz',
+          linkedin: 'maya-chen',
+          telegram: 'mayachen',
+          memberUid: 'maya-chen',
+          // A connector can sit in several PL teams — shown as chips in the drawer.
+          teams: [
+            { name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' },
+            { name: 'NeuroBridge Labs', teamUid: 'neurobridge-labs', logo: '/icons/technology/ipfs.svg' },
+          ],
+        },
+        team: {
+          name: 'Modular Globe',
+          teamUid: 'modular-globe',
+          leads: [
+            { name: 'Maya Chen', role: 'CEO & Co-founder', email: 'maya@modularglobe.xyz', linkedin: 'maya-chen', telegram: 'mayachen', memberUid: 'maya-chen', teams: [{ name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' }, { name: 'NeuroBridge Labs', teamUid: 'neurobridge-labs', logo: '/icons/technology/ipfs.svg' }] },
+            { name: 'Arjun Patel', role: 'CTO & Co-founder', email: 'arjun@modularglobe.xyz', linkedin: 'arjun-patel', memberUid: 'arjun-patel', teams: [{ name: 'Modular Globe', teamUid: 'modular-globe', logo: '/icons/technology/filecoin.svg' }] },
+          ],
+        },
+      },
+      {
+        id: 802,
+        rank: 2,
+        proximity_code: 'VC+2B',
+        caliber_confidence: 0.5,
+        score: 0.44,
+        connector_type: 'VC',
+        explanation: 'Galaxy co-invested with CoinFund, a PL co-investor who can pass along a warm note.',
+        chain: [PL, org('CoinFund', `${LOGOS}/CoinFund.svg`), org('Galaxy', `${LOGOS}/Galaxy.svg`)],
+        contact: { name: 'Owen Park', role: 'General Partner', email: 'owen@coinfund.io', linkedin: 'owen-park', memberUid: 'owen-park', teams: [{ name: 'CoinFund', teamUid: 'coinfund' }] },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-sofiak',
+    first_name: 'Sofia',
+    last_name: 'Klein',
+    email: 'sofia@panteracapital.com',
+    email_status: 'unverified',
+    source: 'RootData',
+    linkedin_url: 'https://www.linkedin.com/in/sofia-klein',
+    firm_domain: 'panteracapital.com',
+    geo_focus: 'US',
+    fund_thesis: 'Early-stage crypto and frontier compute.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: { touches: 0, opened: 0, clicked: 0, registered: 0, first_sent_date: '', last_sent_date: '' },
+    firm: 'Pantera Capital',
+    title: 'Partner',
+    sector_tags: ['crypto', 'frontier-tech'],
+    stage_focus: 'seed',
+    check_size_range: '1M-5M',
+    investor_type: 'fund',
+    engagement_tier: 'T4_cold',
+    relationship: 'cold_match',
+    best_proximity_code: null,
+    has_path: false,
+    list_ids: ['neuro-lp'],
+    paths: [],
+  },
+  {
+    investor_id: 'inv-dmitri',
+    first_name: 'Dmitri',
+    last_name: 'Sokolov',
+    email: 'dmitri@jumpcrypto.com',
+    email_status: 'catch_all',
+    source: 'Exa',
+    linkedin_url: 'https://www.linkedin.com/in/dmitri-sokolov',
+    firm_domain: 'jumpcrypto.com',
+    geo_focus: 'Global',
+    fund_thesis: 'Market infrastructure, trading, and protocol-level bets.',
+    aum_range: '1B+',
+    lab_os_profile: null,
+    outreach: { touches: 1, opened: 1, clicked: 0, registered: 0, first_sent_date: '2026-02-05', last_sent_date: '2026-02-05' },
+    firm: 'Jump Crypto',
+    title: 'Vice President',
+    sector_tags: ['crypto', 'ai'],
+    stage_focus: 'series-a',
+    check_size_range: '5M+',
+    investor_type: 'fund',
+    engagement_tier: 'T3_opened',
+    relationship: 'engaged',
+    best_proximity_code: 'VC+2B',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        id: 1001,
+        rank: 1,
+        proximity_code: 'VC+2B',
+        caliber_confidence: 0.5,
+        score: 0.46,
+        connector_type: 'VC',
+        explanation: 'Two hops out via a shared LP that co-invests with Jump — a softer VC route.',
+        chain: [PL, org('Jump Crypto', `${LOGOS}/Jump.svg`), org('Jump Crypto', `${LOGOS}/Jump.svg`)],
+        contact: {
+          name: 'Elena Fischer',
+          role: 'Partner',
+          email: 'elena@jumpcrypto.com',
+          linkedin: 'elena-fischer',
+          teams: [{ name: 'Jump Crypto', teamUid: 'jump-crypto' }],
+        },
+      },
+      {
+        id: 1002,
+        rank: 2,
+        proximity_code: 'F+1B',
+        caliber_confidence: 0.62,
+        score: 0.55,
+        connector_type: 'F',
+        explanation: 'Priya Anand (Tidal Energy, PL portfolio) previously raised from Jump and can broker an intro.',
+        chain: [PL, team('Tidal Energy', 'tidal-energy', '/icons/technology/drand.svg'), org('Jump Crypto', `${LOGOS}/Jump.svg`)],
+        contact: {
+          name: 'Priya Anand',
+          role: 'CEO & Founder',
+          email: 'priya@tidalenergy.co',
+          linkedin: 'priya-anand',
+          telegram: 'priyaanand',
+          memberUid: 'priya-anand',
+          teams: [{ name: 'Tidal Energy', teamUid: 'tidal-energy', logo: '/icons/technology/drand.svg' }],
+        },
+      },
+    ],
+  },
+  {
+    investor_id: 'inv-yuki',
+    first_name: 'Yuki',
+    last_name: 'Tanaka',
+    email: 'yuki@northstar.vc',
+    email_status: 'verified',
+    source: 'OpenVC',
+    linkedin_url: 'https://www.linkedin.com/in/yuki-tanaka',
+    firm_domain: 'northstar.vc',
+    geo_focus: 'Asia',
+    fund_thesis: 'Seed deep-tech and neurotech across APAC.',
+    aum_range: '500M-1B',
+    lab_os_profile: null,
+    outreach: { touches: 1, opened: 1, clicked: 0, registered: 0, first_sent_date: '2026-02-10', last_sent_date: '2026-02-10' },
+    firm: 'Northstar Ventures',
+    title: 'Partner',
+    sector_tags: ['neurotech', 'frontier-tech'],
+    stage_focus: 'seed',
+    check_size_range: '1M-5M',
+    investor_type: 'fund',
+    engagement_tier: 'T3_opened',
+    relationship: 'engaged',
+    best_proximity_code: 'F+1B',
+    has_path: true,
+    list_ids: ['neuro-lp'],
+    paths: [
+      {
+        // Org-led, but the org is a PL-network TEAM: logo + clickable to its
+        // profile, person still unknown.
+        id: 1101,
+        rank: 1,
+        proximity_code: 'F+1B',
+        caliber_confidence: 0.6,
+        score: 0.6,
+        connector_type: 'F',
+        explanation:
+          'Modular Globe (PL portfolio) is connected to Yuki — open the team to find the right person to broker the intro.',
+        chain: [PL, team('Modular Globe', 'modular-globe', '/icons/technology/filecoin.svg'), org('Northstar Ventures', `${LOGOS}/BlueYard.svg`)],
+        orgConnector: {
+          name: 'Modular Globe',
+          teamUid: 'modular-globe',
+          logo: '/icons/technology/filecoin.svg',
+          description: 'A Modular Globe team member can broker the intro — open the team profile to find who.',
+          tags: ['Team connection', 'Person unknown'],
+          email: 'team@modularglobe.xyz',
+          website: 'modularglobe.xyz',
+        },
+      },
+    ],
+  },
+];
+
+// Standardize: every investor that has a path shows the three connector cases
+// (member known · org unknown · member unknown). Cold investors (no path) are
+// left untouched. best_proximity_code is pinned to the warmest case so the table
+// badge matches the drawer's best path.
+// These rows lead with the org-unknown node (so it surfaces in the table) — they
+// land at the 2nd (Brandt) and 4th (Hoffmann) rows once proximity ties and the
+// table sorts by last name.
+const ORG_LEAD_ROWS = new Set(['inv-lukas', 'inv-lena']);
+export const MOCK_MEMBERS: MockInvestor[] = BASE_MEMBERS.map((m) =>
+  m.has_path
+    ? { ...m, best_proximity_code: 'F+1A', paths: fourCasePaths(m.first_name, m.firm, ORG_LEAD_ROWS.has(m.investor_id)) }
+    : m,
+);

--- a/prototypes/registry.ts
+++ b/prototypes/registry.ts
@@ -22,6 +22,14 @@ export const prototypeRegistry: PrototypeEntry[] = [
     category: 'Gantry',
     load: () => import('./entries/gantry-saved-draft-item/GantrySavedDraftItemPrototype'),
   },
+  {
+    key: 'warm-intros-filter-update',
+    title: 'Warm intros update',
+    description:
+      'People-first warm-intros workspace: connector states (in-network / external / org-unknown), per-investor paths, and an investor drawer with sticky header.',
+    category: 'Investor DB',
+    load: () => import('./entries/warm-intros-filter-update/WarmIntrosFilterUpdatePrototype'),
+  },
   // TODO: prototype not built yet — folder entries/warm-intros-side-drawer-improvements/ is missing.
   // Re-enable this entry once WarmIntrosSideDrawerPrototype.tsx exists (the import below breaks the build otherwise).
   // {


### PR DESCRIPTION
Added path nodes (table): each connector node now shows its state via icon:
1. Profile avatar - person is in the PL network
2. User icon - known person, not in the network
3. Org icon - we know the company can connect, but not who yet

Changes Drawer: mirrors the same three states
1. In-network person - PL profile, contacts, and the team(s) they belong to
2. Org-level — the organization with tags (person unknown) + contacts
3. Out-of-network person - contacts only
4. Sticky investor header - stays visible while the founder reviews the paths.

Other decisions:
- Dropped the node chain inside the drawer.
- Removed the collapsible row.
- Filters condensed into a single row for a more compact view.
- Mobile - fully adapted; cards replace the table.