### PR TITLE
feat(warm-intros): people-first UI redesign — filter bar, route chips…

### DIFF
--- a/__tests__/page/investors/warm-path-detail.test.tsx
+++ b/__tests__/page/investors/warm-path-detail.test.tsx
@@ -121,11 +121,13 @@ describe('WarmPathDetail per-path corrections', () => {
 
   it('renders a correction affordance per path, not one per investor', () => {
     render(<WarmPathDetail investorId="inv-1" canEdit />);
+    fireEvent.click(screen.getByText(/Show .* more/));
     expect(screen.getAllByText('Suggest a correction')).toHaveLength(2);
   });
 
   it('submits the correction against the clicked path, not the best path', async () => {
     render(<WarmPathDetail investorId="inv-1" canEdit />);
+    fireEvent.click(screen.getByText(/Show .* more/));
     fireEvent.click(screen.getAllByText('Suggest a correction')[1]);
     fireEvent.click(screen.getByText('Submit'));
 

--- a/components/page/investors/InvestorDrawer/InvestorDrawer.module.scss
+++ b/components/page/investors/InvestorDrawer/InvestorDrawer.module.scss
@@ -7,6 +7,10 @@
 }
 
 .header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: #fff;
   padding: 20px 24px;
   border-bottom: 1px solid #e5e7eb;
 }
@@ -170,6 +174,49 @@
   }
 }
 
+.firmLink {
+  color: #1b4dff;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* ── Contact channels (mirrors InvestorDrawerMock prototype) ─────────────── */
+.channelsBox {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 12px;
+  border-radius: 8px;
+  background: #f9fafb;
+  border: 1px solid #eef0f3;
+}
+
+.channelDivider {
+  width: 1px;
+  align-self: stretch;
+  min-height: 16px;
+  margin: 0 4px;
+  background: #e2e8f0;
+}
+
+.copyEmail {
+  color: #9ca3af;
+  padding: 2px;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  &:hover {
+    color: #1b4dff;
+  }
+}
+
 .linkBtn {
   background: none;
   border: none;
@@ -273,35 +320,52 @@
   position: sticky;
   bottom: 0;
   background: #fff;
-  padding: 16px 24px;
+  padding: 14px 24px;
   border-top: 1px solid #e5e7eb;
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
 }
 
 .btn {
-  padding: 6px 12px;
+  padding: 8px 14px;
   font-family: 'Inter', sans-serif;
   font-size: 13px;
   font-weight: 500;
   background: #fff;
-  color: #455468;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
   cursor: pointer;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  line-height: 1;
 
   &:hover:not(:disabled) {
     background: #f9fafb;
+    border-color: #9ca3af;
   }
 
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+}
+
+.btnPrimary {
+  background: #1b4dff;
+  color: #fff;
+  border-color: #1b4dff;
+  padding: 9px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+
+  &:hover:not(:disabled) {
+    background: #1a3fd9;
+    border-color: #1a3fd9;
   }
 }
 

--- a/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
+++ b/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
+import { Fragment } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useQueryStates } from 'nuqs';
 import { useGetInvestorById } from '@/services/investors/hooks/useGetInvestorById';
@@ -10,6 +11,9 @@ import type { InvestorsAccess } from '@/services/rbac/hooks/useInvestorsAccess';
 import { Drawer } from '@/components/common/Drawer/Drawer';
 import { investorsFilterParsers } from '@/app/investors/(investors-page)/searchParams';
 import { INVESTOR_TYPE_LABEL, STAGE_FOCUS_LABEL } from '@/services/investors/constants';
+import { ProfileSocialLink } from '@/components/page/member-details/profile-social-link';
+import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
+import { getProfileFromURL } from '@/utils/common.utils';
 import { LabOsBadge } from '../LabOsBadge/LabOsBadge';
 import { EngagementTierBadge } from '../EngagementTierBadge/EngagementTierBadge';
 import { EmailStatusPill } from '../EmailStatusPill/EmailStatusPill';
@@ -63,7 +67,24 @@ export function InvestorDrawer({ access }: Props) {
                   {investor.first_name} {investor.last_name}
                 </h2>
                 <div className={s.meta}>
-                  {investor.title || '—'} {investor.firm && `· ${investor.firm}`}
+                  {investor.title || '—'}{' '}
+                  {investor.firm && (
+                    <>
+                      ·{' '}
+                      {investor.firm_domain ? (
+                        <a
+                          href={`https://${investor.firm_domain}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={s.firmLink}
+                        >
+                          {investor.firm} ↗
+                        </a>
+                      ) : (
+                        investor.firm
+                      )}
+                    </>
+                  )}
                 </div>
                 <div className={s.metaSub}>
                   {investor.investor_id}
@@ -100,38 +121,55 @@ export function InvestorDrawer({ access }: Props) {
 
           <div className={s.section}>
             <h3 className={s.sectionTitle}>Contact</h3>
-            <dl className={s.kv}>
-              <dt>Email</dt>
-              <dd>
-                <span>{investor.email || '—'}</span>
-                {investor.email && <CopyButton text={investor.email} />}
-              </dd>
-              <dt>LinkedIn</dt>
-              <dd>
-                {investor.linkedin_url ? (
-                  <a href={investor.linkedin_url} target="_blank" rel="noopener noreferrer" className={s.link}>
-                    {investor.linkedin_url.replace('https://www.linkedin.com/in/', 'linkedin.com/in/')} ↗
-                  </a>
-                ) : (
-                  <span className={s.muted}>—</span>
-                )}
-              </dd>
-              <dt>Firm domain</dt>
-              <dd>
-                {investor.firm_domain ? (
-                  <a
-                    href={`https://${investor.firm_domain}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={s.link}
-                  >
-                    {investor.firm_domain} ↗
-                  </a>
-                ) : (
-                  <span className={s.muted}>—</span>
-                )}
-              </dd>
-            </dl>
+            <div className={s.channelsBox}>
+              {[
+                investor.email && (
+                  <ProfileSocialLink
+                    key="email"
+                    type="email"
+                    handle={investor.email}
+                    profile={getProfileFromURL(investor.email, 'email') || investor.email}
+                    logo={getContactLogoByProvider('email')}
+                    height={20}
+                    width={20}
+                    callback={() => {}}
+                    suffix={<CopyButton text={investor.email} className={s.copyEmail} />}
+                  />
+                ),
+                investor.linkedin_url && (
+                  <ProfileSocialLink
+                    key="linkedin"
+                    type="linkedin"
+                    handle={investor.linkedin_url}
+                    profile={getProfileFromURL(investor.linkedin_url, 'linkedin') || investor.linkedin_url}
+                    logo={getContactLogoByProvider('linkedin')}
+                    height={20}
+                    width={20}
+                    callback={() => {}}
+                    linkedinProfileKind="member"
+                  />
+                ),
+                investor.firm_domain && (
+                  <ProfileSocialLink
+                    key="website"
+                    type="website"
+                    handle={investor.firm_domain}
+                    profile={investor.firm_domain}
+                    logo={getContactLogoByProvider('website')}
+                    height={20}
+                    width={20}
+                    callback={() => {}}
+                  />
+                ),
+              ]
+                .filter(Boolean)
+                .map((el, i) => (
+                  <Fragment key={i}>
+                    {i > 0 && <span className={s.channelDivider} aria-hidden />}
+                    {el}
+                  </Fragment>
+                ))}
+            </div>
           </div>
 
           <div className={s.section}>
@@ -310,18 +348,18 @@ export function InvestorDrawer({ access }: Props) {
           </div>
 
           <div className={s.footer}>
-            <AddToListMenu investorId={investor.investor_id} canEdit={access.canEdit} className={s.btn} />
-            <CopyButton text={investor.email} label="Copy email" className={s.btn} />
             {investor.firm_domain && (
               <a
-                className={s.btn}
+                className={clsx(s.btn, s.btnPrimary)}
                 href={`https://app.affinity.co/companies/?search=${encodeURIComponent(investor.firm_domain)}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                ↗ Open in Affinity
+                Open in Affinity ↗
               </a>
             )}
+            <AddToListMenu investorId={investor.investor_id} canEdit={access.canEdit} className={s.btn} />
+            <CopyButton text={investor.email} label="Copy email" className={s.btn} />
             {investor.lab_os_profile && (
               <a
                 className={s.btn}

--- a/components/page/investors/RouteChip/RouteChip.module.scss
+++ b/components/page/investors/RouteChip/RouteChip.module.scss
@@ -1,0 +1,91 @@
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px 3px 3px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: #0a0c11;
+  text-decoration: none;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: default;
+
+  &[href] {
+    cursor: pointer;
+
+    &:hover {
+      background: #eef2ff;
+      border-color: #1b4dff;
+      color: #1b4dff;
+    }
+  }
+}
+
+.avatarWrap {
+  flex-shrink: 0;
+}
+
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e5e7eb;
+  position: relative;
+}
+
+.avatarImg {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.avatarInitials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 8px;
+  font-weight: 700;
+  color: #6b7280;
+  letter-spacing: 0;
+}
+
+.avatarGrey {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  color: #9ca3af;
+}
+
+.chipLabel {
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.unknownMark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #d1d5db;
+  color: #6b7280;
+  font-size: 9px;
+  font-weight: 700;
+  flex-shrink: 0;
+}

--- a/components/page/investors/RouteChip/RouteChip.tsx
+++ b/components/page/investors/RouteChip/RouteChip.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import type { PathHopNode } from '@/services/investors/types';
+import s from './RouteChip.module.scss';
+
+interface Props {
+  node: PathHopNode;
+  /** Optional logo URL for portfolio_org variant — resolved from coInvestedTeams. */
+  teamLogoUrl?: string;
+}
+
+export function RouteChip({ node, teamLogoUrl }: Props) {
+  if (node.type === 'person') {
+    if ('member_uid' in node && node.member_uid) {
+      // pl_member — PL network person with a directory profile
+      return (
+        <Link href={`/members/${node.member_uid}`} className={s.chip} target="_blank" rel="noopener noreferrer">
+          <span className={s.avatarWrap}>
+            <MemberAvatar name={node.label} memberUid={node.member_uid} />
+          </span>
+          <span className={s.chipLabel}>{node.label}</span>
+        </Link>
+      );
+    }
+    // external_person — known person not in PL network
+    return (
+      <span className={s.chip}>
+        <span className={s.avatarWrap}>
+          <span className={s.avatarGrey} aria-hidden>
+            <PersonIcon />
+          </span>
+        </span>
+        <span className={s.chipLabel}>{node.label}</span>
+      </span>
+    );
+  }
+
+  // org variants
+  if ('team_uid' in node && node.team_uid) {
+    // portfolio_org — PL portfolio team
+    return (
+      <Link href={`/teams/${node.team_uid}`} className={s.chip} target="_blank" rel="noopener noreferrer">
+        <span className={s.avatarWrap}>
+          <OrgAvatar name={node.label} logoUrl={teamLogoUrl} />
+        </span>
+        <span className={s.chipLabel}>{node.label}</span>
+        <span className={s.unknownMark} aria-label="contact unknown">?</span>
+      </Link>
+    );
+  }
+
+  // vc_org — external VC/firm, person unknown
+  return (
+    <span className={s.chip}>
+      <span className={s.avatarWrap}>
+        <OrgAvatar name={node.label} logoUrl={undefined} />
+      </span>
+      <span className={s.chipLabel}>{node.label}</span>
+      <span className={s.unknownMark} aria-label="contact unknown">?</span>
+    </span>
+  );
+}
+
+function MemberAvatar({ name, memberUid }: { name: string; memberUid: string }) {
+  return (
+    <span className={s.avatar}>
+      <Image
+        src={`/api/avatar/${memberUid}`}
+        alt={name}
+        width={20}
+        height={20}
+        className={s.avatarImg}
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).style.display = 'none';
+          const fallback = e.currentTarget.nextElementSibling as HTMLElement | null;
+          if (fallback) fallback.style.display = 'flex';
+        }}
+      />
+      <span className={s.avatarInitials} style={{ display: 'none' }} aria-hidden>
+        {initials(name)}
+      </span>
+    </span>
+  );
+}
+
+function OrgAvatar({ name, logoUrl }: { name: string; logoUrl?: string }) {
+  if (logoUrl) {
+    return (
+      <span className={s.avatar}>
+        <Image
+          src={logoUrl}
+          alt={name}
+          width={20}
+          height={20}
+          className={s.avatarImg}
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).style.display = 'none';
+            const fallback = e.currentTarget.nextElementSibling as HTMLElement | null;
+            if (fallback) fallback.style.display = 'flex';
+          }}
+        />
+        <span className={s.avatarInitials} style={{ display: 'none' }} aria-hidden>
+          {initials(name)}
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className={s.avatar}>
+      <span className={s.avatarInitials} aria-hidden>
+        {initials(name)}
+      </span>
+    </span>
+  );
+}
+
+function PersonIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+    </svg>
+  );
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join('');
+}

--- a/components/page/investors/WarmIntrosWorkspace/ListPicker.module.scss
+++ b/components/page/investors/WarmIntrosWorkspace/ListPicker.module.scss
@@ -6,20 +6,20 @@
 }
 
 .select {
-  min-width: 320px;
+  min-width: 220px;
   max-width: 100%;
   padding: 8px 10px;
   font-size: 13px;
   font-family: 'Inter', sans-serif;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
-  background: #fff;
+  border: none;
+  border-radius: 0;
+  background: transparent;
   outline: none;
   color: #0a0c11;
 
   &:focus {
-    border-color: #1b4dff;
-    box-shadow: 0 0 0 3px rgba(27, 77, 255, 0.12);
+    outline: none;
+    box-shadow: none;
   }
 }
 

--- a/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss
+++ b/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss
@@ -699,8 +699,118 @@
 
 .proximityCell {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.proximityTop {
+  display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.warmthPct {
+  font-size: 12px;
+  font-weight: 600;
+  color: #0a0c11;
+  font-variant-numeric: tabular-nums;
+}
+
+.miniRoute {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  row-gap: 2px;
+}
+
+.miniRouteNode {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.miniArrow {
+  font-size: 10px;
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+/* Flat inline chip for table route nodes (no border/pill) */
+.miniChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 12px;
+  color: #374151;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &[href]:hover {
+    color: #1b4dff;
+  }
+}
+
+.miniChipLabel {
+  font-weight: 500;
+}
+
+/* Filled green dot for PL network members */
+.miniDotMember {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #10b981;
+  flex-shrink: 0;
+}
+
+.miniPersonIcon {
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+.miniOrgIcon {
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+.miniExtIcon {
+  color: #9ca3af;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.miniUnknown {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  color: #6b7280;
+  font-size: 9px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.viewAllLink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  color: #1b4dff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: #1a3fd9;
+  }
 }
 
 .relCell {
@@ -731,6 +841,196 @@
 .relCold {
   background: #f3f4f6;
   color: #6b7280;
+}
+
+/* ── Compact filter bar (Phase 2, updated to match design) ─────────────────── */
+
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.filterBarItem {
+  flex: 0 0 auto;
+}
+
+.filterBarSearch {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.filterBarActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* LIST label + picker group */
+.filterBarListGroup {
+  display: flex;
+  align-items: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  overflow: hidden;
+  gap: 0;
+}
+
+.filterBarListLabel {
+  padding: 0 10px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #6b7280;
+  border-right: 1px solid #e5e7eb;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Search icon wrapper */
+.searchWrap {
+  position: relative;
+  width: 100%;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Sector popover trigger — same height/style as the stage/check selects */
+.sectorWrap {
+  position: relative;
+}
+
+.sectorTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  height: 100%;
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  color: #0a0c11;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background: #f9fafb;
+  }
+}
+
+.sectorTriggerText {
+  /* truncate if needed */
+}
+
+.sectorTriggerActive {
+  border-color: #1b4dff;
+  color: #1b4dff;
+  background: #eef2ff;
+}
+
+.sectorBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #1b4dff;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.sectorCaret {
+  font-size: 10px;
+  color: #6b7280;
+}
+
+.sectorPopover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 50;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  padding: 12px;
+  min-width: 260px;
+  max-width: 360px;
+}
+
+.sectorPopoverChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Apply / Clear buttons */
+.btnApply {
+  padding: 8px 18px;
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  background: #1b4dff;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background: #1a3fd9;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btnClear {
+  padding: 8px 6px;
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  background: none;
+  color: #6b7280;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    color: #0a0c11;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 }
 
 .sentinel {

--- a/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.tsx
+++ b/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useQueryStates } from 'nuqs';
+import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import clsx from 'clsx';
+import type { PathHopNode } from '@/services/investors/types';
 import { useGetCoInvestorTeams } from '@/services/investors/hooks/useGetCoInvestorTeams';
 import { useGetInvestorLists } from '@/services/investors/hooks/useGetInvestorLists';
 import { useGetListMembers } from '@/services/investors/hooks/useGetListMembers';
@@ -32,7 +35,6 @@ import { LabOsBadge } from '../LabOsBadge/LabOsBadge';
 import { EngagementTierBadge } from '../EngagementTierBadge/EngagementTierBadge';
 import { SectorTagsList } from '../SectorTagsList/SectorTagsList';
 import { ProximityCodeBadge } from '../ProximityCodeBadge/ProximityCodeBadge';
-import { WarmPathDetail } from '../WarmPathDetail/WarmPathDetail';
 import { CrosswalkReviewPanel } from '../CrosswalkReviewPanel/CrosswalkReviewPanel';
 import { exportInvestorsCsv } from '../utils/exportCsv';
 import { GlossaryModal } from './GlossaryModal';
@@ -111,7 +113,6 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
 
   const onPickList = (list: InvestorList) => {
     setFilters({ wi_list_id: list.id, ...CLEAR_CONNECTOR_LENS });
-    setExpandedIds(new Set());
     setSelectedIds(new Set());
     analytics.trackListSelected({ listId: list.id, listName: list.name, isGraphed: list.is_graphed });
   };
@@ -162,14 +163,12 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
       wi_check_size: draft.check || null,
     });
     setSelectedIds(new Set());
-    setExpandedIds(new Set());
   };
 
   const clear = () => {
     setDraft({ stage: '', sectors: [], check: '' });
     setFilters({ wi_stage: null, wi_sectors: null, wi_check_size: null, ...CLEAR_CONNECTOR_LENS });
     setSelectedIds(new Set());
-    setExpandedIds(new Set());
   };
 
   // ── Relationship lens (client chips, server filter) ─────────────────────────
@@ -209,7 +208,6 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
   const lensLoading = !!connectorLabel && isFetching && !isFetchingNextPage;
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const [crosswalkOpen, setCrosswalkOpen] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -253,15 +251,17 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
     analytics.trackConnectorLensApplied({ nodeLabel: sel.displayLabel, kind: sel.kind });
   };
 
-  const toggleExpanded = (id: string, bestProximityCode?: string | null) => {
-    const isExpanding = !expandedIds.has(id);
-    setExpandedIds((prev) => {
-      const next = new Set(prev);
-      isExpanding ? next.add(id) : next.delete(id);
-      return next;
-    });
-    if (isExpanding) analytics.trackPathExpanded({ investorId: id, bestProximityCode });
-  };
+  const [sectorPopoverOpen, setSectorPopoverOpen] = useState(false);
+  const sectorPopoverRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside([sectorPopoverRef], () => setSectorPopoverOpen(false));
+
+  const hasAnyFilter =
+    !!draft.stage ||
+    draft.sectors.length > 0 ||
+    !!draft.check ||
+    !!filters.wi_connector ||
+    filters.wi_connector_labels.length > 0 ||
+    filters.wi_connector_contains.length > 0;
 
   const toggleSelected = (id: string) => {
     setSelectedIds((prev) => {
@@ -290,7 +290,6 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
   };
 
   const canSelect = access.canEdit;
-  const colCount = (canSelect ? 1 : 0) + 7;
 
   return (
     <div className={s.root}>
@@ -316,14 +315,97 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
           </p>
         </header>
 
-        <div className={clsx(s.field, s.fieldMb)}>
-          <label className={s.label}>Target list</label>
-          <ListPicker lists={lists} selectedId={filters.wi_list_id} onSelect={onPickList} />
-        </div>
+        {/* Compact single-row filter bar */}
+        <div className={s.filterBar}>
+          {/* LIST label + picker grouped */}
+          <div className={clsx(s.filterBarItem, s.filterBarListGroup)}>
+            <span className={s.filterBarListLabel}>LIST</span>
+            <ListPicker lists={lists} selectedId={filters.wi_list_id} onSelect={onPickList} />
+          </div>
 
-        <div className={clsx(s.field, s.fieldMb)}>
-          <label className={s.label}>Search investors, funds, founders or teams</label>
-          <UnifiedSearchSelect teams={teams} onSelect={onUnifiedSelect} />
+          {/* Search with magnifier icon */}
+          <div className={clsx(s.filterBarItem, s.filterBarSearch)}>
+            <div className={s.searchWrap}>
+              <span className={s.searchIcon} aria-hidden>
+                <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="9" cy="9" r="6" />
+                  <path d="M15 15l-3.5-3.5" strokeLinecap="round" />
+                </svg>
+              </span>
+              <UnifiedSearchSelect teams={teams} onSelect={onUnifiedSelect} />
+            </div>
+          </div>
+
+          <div className={s.filterBarItem}>
+            <select
+              className={s.select}
+              value={draft.stage}
+              aria-label="Stage focus"
+              onChange={(e) => setDraft((d) => ({ ...d, stage: e.target.value }))}
+            >
+              <option value="">Any stage</option>
+              {STAGE_FOCUSES.filter((st) => st !== 'unknown').map((st) => (
+                <option key={st} value={st}>
+                  {STAGE_FOCUS_LABEL[st]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={s.filterBarItem}>
+            <select
+              className={s.select}
+              value={draft.check}
+              aria-label="Check size"
+              onChange={(e) => setDraft((d) => ({ ...d, check: e.target.value }))}
+            >
+              <option value="">Any check size</option>
+              {CHECK_SIZE_RANGES.filter((c) => c !== 'unknown').map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Sector popover — styled to match stage/check selects */}
+          <div className={clsx(s.filterBarItem, s.sectorWrap)} ref={sectorPopoverRef}>
+            <button
+              type="button"
+              className={clsx(s.sectorTrigger, draft.sectors.length > 0 && s.sectorTriggerActive)}
+              onClick={() => setSectorPopoverOpen((o) => !o)}
+              aria-expanded={sectorPopoverOpen}
+            >
+              <span className={s.sectorTriggerText}>
+                {draft.sectors.length > 0 ? `${INDUSTRY_SECTOR_LABEL} (${draft.sectors.length})` : INDUSTRY_SECTOR_LABEL}
+              </span>
+              <span className={s.sectorCaret} aria-hidden>▾</span>
+            </button>
+            {sectorPopoverOpen && (
+              <div className={s.sectorPopover} role="dialog" aria-label="Sector filters">
+                <div className={s.sectorPopoverChips}>
+                  {SECTOR_TAGS.map((sec) => (
+                    <button
+                      key={sec}
+                      className={clsx(s.chip, draft.sectors.includes(sec) && s.chipOn)}
+                      onClick={() => toggleDraftSector(sec)}
+                    >
+                      {SECTOR_TAG_LABEL[sec]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className={s.filterBarActions}>
+            <button className={s.btnApply} onClick={apply}>
+              Apply
+            </button>
+            <button className={s.btnClear} onClick={clear} disabled={!hasAnyFilter}>
+              Clear
+            </button>
+          </div>
         </div>
 
         {connectorLabel && (
@@ -342,64 +424,6 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
             </span>
           </div>
         )}
-
-        <div className={s.builderRow}>
-          <div className={s.field}>
-            <label className={s.label}>Stage focus</label>
-            <select
-              className={s.select}
-              value={draft.stage}
-              onChange={(e) => setDraft((d) => ({ ...d, stage: e.target.value }))}
-            >
-              <option value="">Any</option>
-              {STAGE_FOCUSES.filter((st) => st !== 'unknown').map((st) => (
-                <option key={st} value={st}>
-                  {STAGE_FOCUS_LABEL[st]}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className={s.field}>
-            <label className={s.label}>Check size</label>
-            <select
-              className={s.select}
-              value={draft.check}
-              onChange={(e) => setDraft((d) => ({ ...d, check: e.target.value }))}
-            >
-              <option value="">Any</option>
-              {CHECK_SIZE_RANGES.filter((c) => c !== 'unknown').map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className={s.actions}>
-            <button className={s.btnPrimary} onClick={apply}>
-              Apply
-            </button>
-            <button className={s.btn} onClick={clear}>
-              Clear
-            </button>
-          </div>
-        </div>
-
-        <div className={clsx(s.field, s.fieldMt)}>
-          <label className={s.label}>{INDUSTRY_SECTOR_LABEL}</label>
-          <div className={s.sectorChips}>
-            {SECTOR_TAGS.map((sec) => (
-              <button
-                key={sec}
-                className={clsx(s.chip, draft.sectors.includes(sec) && s.chipOn)}
-                onClick={() => toggleDraftSector(sec)}
-              >
-                {SECTOR_TAG_LABEL[sec]}
-              </button>
-            ))}
-          </div>
-        </div>
       </section>
 
       {!enabled && (
@@ -463,74 +487,73 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
               </thead>
               <tbody>
                 {visible.map((inv) => {
-                  const isExpanded = expandedIds.has(inv.investor_id);
                   const hasProximity = !!inv.best_proximity_code || inv.has_path === false;
                   return (
-                    <Fragment key={inv.investor_id}>
-                      <tr className={s.row} onClick={() => setFilters({ investorId: inv.investor_id })}>
-                        {canSelect && (
-                          <td className={s.checkboxCol}>
-                            <input
-                              type="checkbox"
-                              checked={selectedIds.has(inv.investor_id)}
-                              onClick={(e) => e.stopPropagation()}
-                              onChange={() => toggleSelected(inv.investor_id)}
-                            />
-                          </td>
-                        )}
-                        <td>
-                          <div className={s.nameCell}>
-                            {inv.first_name} {inv.last_name}
-                            <LabOsBadge profile={inv.lab_os_profile} variant="icon" />
-                          </div>
-                          <div className={s.subtle}>{inv.email}</div>
+                    <tr key={inv.investor_id} className={s.row} onClick={() => setFilters({ investorId: inv.investor_id })}>
+                      {canSelect && (
+                        <td className={s.checkboxCol}>
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(inv.investor_id)}
+                            onClick={(e) => e.stopPropagation()}
+                            onChange={() => toggleSelected(inv.investor_id)}
+                          />
                         </td>
-                        <td>
-                          <div className={s.teamCell}>{inv.firm || <span className={s.muted}>—</span>}</div>
-                          {inv.title && <div className={s.subtle}>{inv.title}</div>}
-                        </td>
-                        <td>
-                          <SectorTagsList tags={inv.sector_tags} max={3} />
-                        </td>
-                        <td>{STAGE_FOCUS_LABEL[inv.stage_focus] ?? <span className={s.muted}>—</span>}</td>
-                        <td>{INVESTOR_TYPE_LABEL[inv.investor_type] ?? <span className={s.muted}>—</span>}</td>
-                        <td>
-                          <RelationshipCell investor={inv} />
-                        </td>
-                        <td>
+                      )}
+                      <td>
+                        <div className={s.nameCell}>
+                          {inv.first_name} {inv.last_name}
+                          <LabOsBadge profile={inv.lab_os_profile} variant="icon" />
+                        </div>
+                        <div className={s.subtle}>{inv.email}</div>
+                      </td>
+                      <td>
+                        <div className={s.teamCell}>{inv.firm || <span className={s.muted}>—</span>}</div>
+                        {inv.title && <div className={s.subtle}>{inv.title}</div>}
+                      </td>
+                      <td>
+                        <SectorTagsList tags={inv.sector_tags} max={3} />
+                      </td>
+                      <td>{STAGE_FOCUS_LABEL[inv.stage_focus] ?? <span className={s.muted}>—</span>}</td>
+                      <td>{INVESTOR_TYPE_LABEL[inv.investor_type] ?? <span className={s.muted}>—</span>}</td>
+                      <td>
+                        <RelationshipCell investor={inv} />
+                      </td>
+                      <td>
+                        {hasProximity ? (
                           <div className={s.proximityCell}>
-                            {hasProximity ? (
+                            <div className={s.proximityTop}>
                               <ProximityCodeBadge code={inv.best_proximity_code} cold={inv.has_path === false} />
-                            ) : (
-                              <span className={s.muted}>—</span>
+                              {inv.best_route_score != null && (
+                                <span className={s.warmthPct}>{Math.round(inv.best_route_score * 100)}%</span>
+                              )}
+                            </div>
+                            {inv.best_route_nodes && inv.best_route_nodes.length > 0 && (
+                              <div className={s.miniRoute}>
+                                {inv.best_route_nodes.map((n, i) => (
+                                  <span key={`${inv.investor_id}-${n.id}-${i}`} className={s.miniRouteNode}>
+                                    {i > 0 && <span className={s.miniArrow}>→</span>}
+                                    <TableRouteNode node={n} />
+                                  </span>
+                                ))}
+                              </div>
                             )}
                             <button
                               type="button"
-                              className={s.expandBtn}
-                              aria-expanded={isExpanded}
+                              className={s.viewAllLink}
                               onClick={(e) => {
                                 e.stopPropagation();
-                                toggleExpanded(inv.investor_id, inv.best_proximity_code);
+                                setFilters({ investorId: inv.investor_id });
                               }}
                             >
-                              {isExpanded ? 'Hide' : 'View paths'}
+                              View all{inv.path_count != null ? ` (${inv.path_count})` : ''}
                             </button>
                           </div>
-                        </td>
-                      </tr>
-                      {isExpanded && (
-                        <tr className={s.detailRow}>
-                          <td colSpan={colCount} onClick={(e) => e.stopPropagation()}>
-                            <WarmPathDetail
-                              key={inv.investor_id}
-                              investorId={inv.investor_id}
-                              bestProximityCode={inv.best_proximity_code}
-                              canEdit={access.canEdit}
-                            />
-                          </td>
-                        </tr>
-                      )}
-                    </Fragment>
+                        ) : (
+                          <span className={s.muted}>—</span>
+                        )}
+                      </td>
+                    </tr>
                   );
                 })}
               </tbody>
@@ -563,6 +586,67 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
       <GlossaryModal open={glossaryOpen} onClose={() => setGlossaryOpen(false)} />
       <CrosswalkReviewPanel open={crosswalkOpen} onClose={() => setCrosswalkOpen(false)} canEdit={access.canEdit} />
     </div>
+  );
+}
+
+/** Compact flat inline node for the table proximity column. */
+function TableRouteNode({ node }: { node: PathHopNode }) {
+  if (node.type === 'person') {
+    if ('member_uid' in node && node.member_uid) {
+      return (
+        <Link
+          href={`/members/${node.member_uid}`}
+          className={s.miniChip}
+          onClick={(e) => e.stopPropagation()}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span className={s.miniDotMember} aria-hidden />
+          <span className={s.miniChipLabel}>{node.label}</span>
+          <svg className={s.miniExtIcon} width="9" height="9" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
+            <path d="M5 3H2a1 1 0 00-1 1v6a1 1 0 001 1h6a1 1 0 001-1V7" />
+            <path d="M8 1h3m0 0v3m0-3L5 7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </Link>
+      );
+    }
+    return (
+      <span className={s.miniChip}>
+        <svg className={s.miniPersonIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <circle cx="12" cy="8" r="4" />
+          <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+        </svg>
+        <span className={s.miniChipLabel}>{node.label}</span>
+      </span>
+    );
+  }
+
+  if ('team_uid' in node && node.team_uid) {
+    return (
+      <Link
+        href={`/teams/${node.team_uid}`}
+        className={s.miniChip}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <svg className={s.miniOrgIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <rect x="2" y="7" width="20" height="15" rx="1" />
+          <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+        </svg>
+        <span className={s.miniChipLabel}>{node.label}</span>
+        <span className={s.miniUnknown} aria-label="contact unknown">?</span>
+      </Link>
+    );
+  }
+
+  return (
+    <span className={s.miniChip}>
+      <svg className={s.miniOrgIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <rect x="2" y="7" width="20" height="15" rx="1" />
+        <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+      </svg>
+      <span className={s.miniChipLabel}>{node.label}</span>
+      <span className={s.miniUnknown} aria-label="contact unknown">?</span>
+    </span>
   );
 }
 

--- a/components/page/investors/WarmIntrosWorkspace/WorkspaceTypeahead.module.scss
+++ b/components/page/investors/WarmIntrosWorkspace/WorkspaceTypeahead.module.scss
@@ -7,7 +7,7 @@
 
 .input {
   width: 100%;
-  padding: 8px 30px 8px 10px;
+  padding: 8px 30px 8px 34px;
   font-size: 13px;
   font-family: 'Inter', sans-serif;
   border: 1px solid #e5e7eb;

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
@@ -101,13 +101,15 @@
   cursor: pointer;
   font-family: inherit;
   font-size: 12px;
-  font-weight: 500;
-  color: #1b4dff;
+  font-weight: 400;
+  color: #6b7280;
   text-decoration: underline;
   text-underline-offset: 2px;
+  text-decoration-color: #d1d5db;
 
   &:hover {
-    color: #1a3fd9;
+    color: #374151;
+    text-decoration-color: #9ca3af;
   }
 }
 
@@ -208,5 +210,183 @@
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+}
+
+/* ── People-first path layout (Phase 6) ──────────────────────────────────── */
+
+.pathMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.contactBlock {
+  margin-bottom: 8px;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.contactHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.contactAvatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #dde1ea;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contactAvatarImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.contactAvatarInitials {
+  font-size: 13px;
+  font-weight: 700;
+  color: #455468;
+  line-height: 1;
+}
+
+.contactInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.contactName {
+  font-size: 13px;
+  font-weight: 600;
+  color: #0a0c11;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &[href]:hover {
+    color: #1b4dff;
+    text-decoration: underline;
+  }
+}
+
+.contactMeta {
+  font-size: 11px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.contactMetaSep {
+  color: #9ca3af;
+}
+
+.contactOrgLink {
+  color: #1b4dff;
+  text-decoration: none;
+  font-size: 11px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.contactOrgText {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.contactSocials {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #f3f4f6;
+  flex-wrap: wrap;
+}
+
+.socialEmail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #374151;
+  text-decoration: none;
+
+  &:hover {
+    color: #1b4dff;
+    text-decoration: underline;
+  }
+}
+
+.socialCircle {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #1b4dff;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.socialCircleBtn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #1b4dff;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  flex-shrink: 0;
+
+  &:hover {
+    background: #1a3fd9;
+  }
+}
+
+.showMore {
+  align-self: flex-start;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 7px 14px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: #374151;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+
+  &:hover {
+    background: #f9fafb;
+    border-color: #9ca3af;
   }
 }

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -1,12 +1,22 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useGetPathsForTarget } from '@/services/investors/hooks/useGetPathsForTarget';
 import { useSubmitCorrection } from '@/services/investors/hooks/useSubmitCorrection';
 import { useInvestorsAnalytics } from '@/analytics/investors.analytics';
 import { PATH_CONNECTOR_LABEL } from '@/services/investors/constants';
-import type { CorrectionInput, PathConnectorType, PathCorrection, PathfinderPath } from '@/services/investors/types';
+import type {
+  CorrectionInput,
+  PathConnectorType,
+  PathContact,
+  PathCorrection,
+  PathOrgConnector,
+  PathfinderPath,
+} from '@/services/investors/types';
 import { ProximityCodeBadge } from '../ProximityCodeBadge/ProximityCodeBadge';
+import { RouteChip } from '../RouteChip/RouteChip';
+import { CopyButton } from '@/components/ui/CopyButton';
 import s from './WarmPathDetail.module.scss';
 
 interface Props {
@@ -25,12 +35,8 @@ const REASON_OPTIONS: { value: CorrectionReason; label: string }[] = [
   { value: 'other', label: 'Something else' },
 ];
 
-/** Connectors a corrected path can route through ('C' = cold is the absence of one). */
 const CONNECTOR_CHOICES = (Object.keys(PATH_CONNECTOR_LABEL) as PathConnectorType[]).filter((c) => c !== 'C');
 
-// Map the human-facing reason to the backend CreateCorrectionDto shape. Every
-// correction made here is about one specific path, so subject_type is always
-// 'path' (subject_id = PathfinderPath.id) and `field` carries what's corrected.
 export function buildCorrection(
   path: PathfinderPath,
   reason: CorrectionReason,
@@ -61,7 +67,6 @@ export function buildCorrection(
 const connectorLabel = (v: unknown): string =>
   (PATH_CONNECTOR_LABEL as Record<string, string>)[String(v)] ?? String(v ?? '—');
 
-/** One-line human summary of a pending correction, e.g. "Caliber B → A". */
 export function correctionSummary(c: PathCorrection): string {
   switch (c.field) {
     case 'caliber':
@@ -82,18 +87,13 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString();
 }
 
-/**
- * Expanded warm-path detail for one target investor: the ranked path list (best
- * first), each path's proximity code + confidence + hop chain, its already-
- * submitted pending corrections (so admins don't resubmit), plus a per-path
- * feedback-loop override form (gated on investor_db.edit).
- */
 export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props) {
   const { data, isLoading } = useGetPathsForTarget(investorId, true);
   const { trackPathsViewed, trackCorrectionSubmitted } = useInvestorsAnalytics();
   const submitCorrection = useSubmitCorrection(investorId);
 
   const paths = data?.paths ?? [];
+  const [showAll, setShowAll] = useState(false);
 
   const viewedRef = useRef(false);
   useEffect(() => {
@@ -125,8 +125,6 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props
         subjectType: correction.subject_type,
         field: correction.field,
       });
-      // No local "saved" flag: the mutation invalidates the paths query and the
-      // refetched response carries the new pending correction for this path.
       setOpenPathId(null);
       setNote('');
       setNewConnector('');
@@ -142,25 +140,38 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props
     );
   }
 
+  const visiblePaths = showAll ? paths : paths.slice(0, 1);
+  const hiddenCount = paths.length - 1;
+
   return (
     <div className={s.root}>
       <ol className={s.pathList}>
-        {paths.map((p) => {
+        {visiblePaths.map((p) => {
           const formOpen = openPathId === p.id;
           return (
             <li key={p.id} className={s.pathItem}>
-              <div className={s.pathHead}>
+              {/* Header: proximity badge + warmth label */}
+              <div className={s.pathMeta}>
                 <ProximityCodeBadge code={p.proximity_code} confidence={p.caliber_confidence} />
-                <span className={s.rank}>{p.rank <= 1 ? 'Best path' : `Alternative #${p.rank}`}</span>
-                <span className={s.warmth}>warmth {Math.round(p.score * 100)}%</span>
+                <span className={s.warmth}>
+                  {p.rank === 1 ? 'Best path' : `Alternative #${p.rank}`} · {Math.round(p.score * 100)}% warm
+                </span>
               </div>
+
+              {/* Explanation */}
               {p.hop_chain.explanation && <div className={s.explanation}>{p.hop_chain.explanation}</div>}
+
+              {/* Who to contact */}
+              {p.contact && <ContactBlock contact={p.contact} org={p.org_connector} />}
+              {!p.contact && p.org_connector && <OrgBlock org={p.org_connector} />}
+
+              {/* Route chain (secondary, shown below contact) */}
               {p.hop_chain.nodes.length > 0 && (
                 <div className={s.chain}>
                   {p.hop_chain.nodes.map((n, i) => (
                     <span key={`${p.id}-${n.id}-${i}`} className={s.node}>
                       {i > 0 && <span className={s.arrow}>→</span>}
-                      <span className={s.nodeLabel}>{n.label}</span>
+                      <RouteChip node={n} />
                     </span>
                   ))}
                 </div>
@@ -172,7 +183,7 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props
                     <li key={c.id} className={s.pendingItem}>
                       <span className={s.pendingBadge}>Pending correction</span>
                       <span className={s.pendingSummary}>{correctionSummary(c)}</span>
-                      {c.note && <span className={s.pendingNote}>“{c.note}”</span>}
+                      {c.note && <span className={s.pendingNote}>&ldquo;{c.note}&rdquo;</span>}
                       <span className={s.pendingMeta}>
                         {c.actor_email ?? 'unknown'}
                         {formatDate(c.created_at) ? ` · ${formatDate(c.created_at)}` : ''} · awaiting recompute
@@ -242,6 +253,136 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props
           );
         })}
       </ol>
+
+      {hiddenCount > 0 && !showAll && (
+        <button type="button" className={s.showMore} onClick={() => setShowAll(true)}>
+          + Show {hiddenCount} more {hiddenCount === 1 ? 'path' : 'paths'}
+        </button>
+      )}
+      {hiddenCount > 0 && showAll && (
+        <button type="button" className={s.showMore} onClick={() => setShowAll(false)}>
+          − Show less
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ContactBlock({ contact, org }: { contact: PathContact; org?: PathOrgConnector }) {
+  const initials = contact.name
+    .split(' ')
+    .slice(0, 2)
+    .map((n) => n[0] ?? '')
+    .join('')
+    .toUpperCase();
+
+  const nameEl = contact.member_uid ? (
+    <Link href={`/members/${contact.member_uid}`} className={s.contactName} target="_blank" rel="noopener noreferrer">
+      {contact.name}
+    </Link>
+  ) : (
+    <span className={s.contactName}>{contact.name}</span>
+  );
+
+  const orgEl = org ? (
+    org.team_uid ? (
+      <Link href={`/teams/${org.team_uid}`} className={s.contactOrgLink} target="_blank" rel="noopener noreferrer">
+        {org.name}
+      </Link>
+    ) : org.website_url ? (
+      <a href={org.website_url} className={s.contactOrgLink} target="_blank" rel="noopener noreferrer">
+        {org.name}
+      </a>
+    ) : (
+      <span className={s.contactOrgText}>{org.name}</span>
+    )
+  ) : null;
+
+  return (
+    <div className={s.contactBlock}>
+      <div className={s.contactHeader}>
+        <div className={s.contactAvatar}>
+          {contact.image_url ? (
+            <img src={contact.image_url} alt={contact.name} className={s.contactAvatarImg} />
+          ) : (
+            <span className={s.contactAvatarInitials}>{initials}</span>
+          )}
+        </div>
+        <div className={s.contactInfo}>
+          {nameEl}
+          {(contact.role || orgEl) && (
+            <div className={s.contactMeta}>
+              {contact.role && <span>{contact.role}</span>}
+              {contact.role && orgEl && <span className={s.contactMetaSep}> · </span>}
+              {orgEl}
+            </div>
+          )}
+        </div>
+      </div>
+      {(contact.email || contact.linkedin_url || contact.telegram) && (
+        <div className={s.contactSocials}>
+          {contact.email && (
+            <>
+              <a href={`mailto:${contact.email}`} className={s.socialEmail}>
+                <span className={s.socialCircle}>@</span>
+                {contact.email}
+              </a>
+              <CopyButton text={contact.email} />
+            </>
+          )}
+          {contact.linkedin_url && (
+            <a
+              href={contact.linkedin_url}
+              className={s.socialCircleBtn}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
+              </svg>
+            </a>
+          )}
+          {contact.telegram && (
+            <a
+              href={`https://t.me/${contact.telegram.replace(/^@/, '')}`}
+              className={s.socialCircleBtn}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Telegram"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+              </svg>
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OrgBlock({ org }: { org: PathOrgConnector }) {
+  const nameEl = org.website_url || org.team_uid ? (
+    <a
+      href={org.team_uid ? `/teams/${org.team_uid}` : org.website_url}
+      className={s.contactName}
+      target={org.team_uid ? '_self' : '_blank'}
+      rel="noopener noreferrer"
+    >
+      {org.name}
+    </a>
+  ) : (
+    <span className={s.contactName}>{org.name}</span>
+  );
+
+  return (
+    <div className={s.contactBlock}>
+      <div className={s.contactRow}>
+        {nameEl}
+        <span className={s.contactRole}>Contact unknown</span>
+      </div>
+      {org.domain && <div className={s.contactLinks}><span className={s.contactMeta}>{org.domain}</span></div>}
     </div>
   );
 }

--- a/services/investors/investors.service.ts
+++ b/services/investors/investors.service.ts
@@ -1,4 +1,5 @@
 import { customFetch } from '@/utils/fetch-wrapper';
+import { mapHopNode } from './pathfinder.service';
 import type {
   AumRange,
   CheckSizeRange,
@@ -147,6 +148,11 @@ export function mapInvestorDto(dto: AnyDto): OutreachInvestor {
     co_invested_team_ids: (dto.coInvestedTeamIds ?? []) as string[],
     best_proximity_code: dto.bestProximityCode ?? null,
     has_path: dto.hasPath ?? false,
+    best_route_nodes: dto.bestRouteNodes
+      ? (dto.bestRouteNodes as Record<string, unknown>[]).map(mapHopNode)
+      : undefined,
+    best_route_score: dto.bestRouteScore != null ? (dto.bestRouteScore as number) : undefined,
+    path_count: dto.pathCount != null ? (dto.pathCount as number) : undefined,
     enrichment: dto.enrichment ? mapEnrichment(dto.enrichment) : null,
   };
 }

--- a/services/investors/pathfinder.service.ts
+++ b/services/investors/pathfinder.service.ts
@@ -3,8 +3,10 @@ import type {
   CorrectionInput,
   PathCaliber,
   PathConnectorType,
+  PathContact,
   PathCorrection,
   PathHopChain,
+  PathOrgConnector,
   PathfinderPath,
   PathsForTargetResponse,
 } from './types';
@@ -17,12 +19,51 @@ const PATHFINDER_API_URL = `${process.env.DIRECTORY_API_URL}/v1/pathfinder`;
 
 type AnyDto = Record<string, any>;
 
+export function mapHopNode(n: AnyDto): PathHopChain['nodes'][number] {
+  const type = (n.type ?? 'person') as 'person' | 'org';
+  // Coerce empty-string → undefined so discriminated union arms are satisfied.
+  const memberUid = ((n.memberUid || n.member_uid) as string | undefined) || undefined;
+  const teamUid = ((n.teamUid || n.team_uid) as string | undefined) || undefined;
+  const id = n.id as string;
+  const label = n.label as string;
+  if (type === 'person' && memberUid) {
+    return { id, label, type: 'person', member_uid: memberUid };
+  }
+  if (type === 'org' && teamUid) {
+    return { id, label, type: 'org', team_uid: teamUid };
+  }
+  if (type === 'org') {
+    return { id, label, type: 'org' };
+  }
+  return { id, label, type: 'person' };
+}
+
+function mapContact(dto: AnyDto): PathContact {
+  return {
+    id: dto.id as string | undefined,
+    name: (dto.name ?? '') as string,
+    role: dto.role as string | undefined,
+    email: dto.email as string | undefined,
+    image_url: (dto.imageUrl ?? dto.image_url) as string | undefined,
+    linkedin_url: (dto.linkedinUrl ?? dto.linkedin_url) as string | undefined,
+    telegram: dto.telegram as string | undefined,
+    member_uid: (dto.memberUid ?? dto.member_uid) as string | undefined,
+  };
+}
+
+function mapOrgConnector(dto: AnyDto): PathOrgConnector {
+  return {
+    id: dto.id as string | undefined,
+    name: (dto.name ?? '') as string,
+    domain: dto.domain as string | undefined,
+    website_url: (dto.websiteUrl ?? dto.website_url) as string | undefined,
+    logo_url: (dto.logoUrl ?? dto.logo_url) as string | undefined,
+    team_uid: (dto.teamUid ?? dto.team_uid) as string | undefined,
+  };
+}
+
 function mapHopChain(dto: AnyDto | null | undefined): PathHopChain {
-  const nodes = ((dto?.nodes ?? []) as AnyDto[]).map((n) => ({
-    id: n.id as string,
-    label: n.label as string,
-    type: (n.type ?? 'person') as 'person' | 'org',
-  }));
+  const nodes = ((dto?.nodes ?? []) as AnyDto[]).map(mapHopNode);
   const edges = ((dto?.edges ?? []) as AnyDto[]).map((e) => ({
     from: e.from as string,
     to: e.to as string,
@@ -59,6 +100,8 @@ export function mapPathfinderPath(dto: AnyDto): PathfinderPath {
     rank: (dto.rank ?? 0) as number,
     computed_at: dto.computedAt ?? undefined,
     corrections: ((dto.corrections ?? []) as AnyDto[]).map(mapCorrection),
+    contact: dto.contact ? mapContact(dto.contact as AnyDto) : undefined,
+    org_connector: dto.orgConnector ? mapOrgConnector(dto.orgConnector as AnyDto) : undefined,
   };
 }
 

--- a/services/investors/types.ts
+++ b/services/investors/types.ts
@@ -156,6 +156,16 @@ export type OutreachInvestor = {
   /** Whether any warm path exists. false/undefined = cold (no path). */
   has_path?: boolean;
 
+  /** Nodes of the best (rank 1) path, denormalized from the pathfinder for
+   *  inline table display. Populated when the list endpoint includes bestRouteNodes. */
+  best_route_nodes?: PathHopNode[];
+
+  /** Warmth score (0–1) of the best path, e.g. 0.9 → "90%". */
+  best_route_score?: number;
+
+  /** Total count of computed paths for this investor (for "View all (N)"). */
+  path_count?: number;
+
   /** Aggregated background + sources ("who is this investor"); null until enriched. */
   enrichment?: InvestorEnrichment | null;
 };
@@ -310,10 +320,34 @@ export type PathConnectorType = 'F' | 'VC' | 'JB' | 'PL' | 'O' | 'C';
 /** Caliber gate result: A = relationship AND contact prestige; B = either. */
 export type PathCaliber = 'A' | 'B';
 
-export type PathHopNode = {
-  id: string;
-  label: string;
-  type: 'person' | 'org';
+export type PathHopNode =
+  | { id: string; label: string; type: 'person'; member_uid: string }  // pl_member — in PL network
+  | { id: string; label: string; type: 'person'; member_uid?: never }  // external_person
+  | { id: string; label: string; type: 'org'; team_uid: string }       // portfolio_org — in PL network
+  | { id: string; label: string; type: 'org'; team_uid?: never };      // vc_org — external firm
+
+/** Person to reach when the direct contact is known (additive; from pathfinder v2 API). */
+export type PathContact = {
+  id?: string;
+  name: string;
+  role?: string;
+  email?: string;
+  image_url?: string;
+  linkedin_url?: string;
+  telegram?: string;
+  /** Set when the contact is a PL network member. */
+  member_uid?: string;
+};
+
+/** Firm to route through when the specific person is unknown (additive; from pathfinder v2 API). */
+export type PathOrgConnector = {
+  id?: string;
+  name: string;
+  domain?: string;
+  website_url?: string;
+  logo_url?: string;
+  /** Set when the org is a PL portfolio team. */
+  team_uid?: string;
 };
 
 export type PathHopEdge = {
@@ -353,6 +387,11 @@ export type PathfinderPath = {
   /** Pending (not yet recomputed) human overrides already submitted for this
    *  path — shown so admins don't submit the same correction twice. */
   corrections: PathCorrection[];
+  // ── People-first path data (additive; from pathfinder v2 API) ────────────────
+  /** Direct person to reach when known. Null/absent = contact not resolved. */
+  contact?: PathContact;
+  /** Firm to route through when the specific person is unknown. */
+  org_connector?: PathOrgConnector;
 };
 
 /** A pending correction on a path, as returned by GET /pathfinder/paths/:investorId. */


### PR DESCRIPTION
…, drawer

Filter bar: compact single-row layout with LIST label, search icon, sector popover with count badge, and disabled Clear until a filter is active.

Table proximity column: flat inline route chips (TableRouteNode) wired to best_route_nodes/best_route_score/path_count from the OutreachInvestor DTO. PathHopNode replaced with a discriminated union (4 arms: pl_member, external_person, portfolio_org, vc_org). mapHopNode exported for reuse.

Drawer: sticky header; firm name linked to domain; Contact section uses ProfileSocialLink + getContactLogoByProvider (mirrors member profile); Warm Paths reordered to badge → explanation → ContactBlock (avatar + blue circle social icons); "Open in Affinity" promoted to primary CTA in footer.

RouteChip: new pill component for the drawer hop chain.