### PR TITLE
feat(investors): warm-path summary graph + lighter cards

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,155 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,160 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,172 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,107 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,143 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/__tests__/page/investors/path-summary-graph.test.tsx
+++ b/__tests__/page/investors/path-summary-graph.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { PathSummaryGraph, buildCaption } from '@/components/page/investors/PathSummaryGraph/PathSummaryGraph';
+import type { PathfinderPath } from '@/services/investors/types';
+
+function path(overrides: Partial<PathfinderPath>): PathfinderPath {
+  return {
+    id: 1,
+    target_investor_id: 'inv-1',
+    connector_type: 'F',
+    hops: 1,
+    caliber: 'A',
+    proximity_code: 'F+1A',
+    score: 0.62,
+    caliber_confidence: 0.9,
+    hop_chain: { nodes: [], edges: [], explanation: '' },
+    rank: 1,
+    corrections: [],
+    ...overrides,
+  };
+}
+
+describe('PathSummaryGraph', () => {
+  it('renders nothing when there is no best path', () => {
+    const { container } = render(<PathSummaryGraph bestPath={null} investorName="Lena Hoffmann" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the contact inside the Protocol Labs node and links members', () => {
+    render(
+      <PathSummaryGraph
+        bestPath={path({ contact: { name: 'Alicia Mer', member_uid: 'alicia-mer' } })}
+        investorName="Lena Hoffmann"
+      />,
+    );
+    expect(screen.getByText('Protocol Labs')).toBeInTheDocument();
+    expect(screen.getByText('Alicia Mer')).toBeInTheDocument();
+    expect(screen.getByText('Lena Hoffmann')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Alicia Mer/ })).toHaveAttribute('href', '/members/alicia-mer');
+  });
+
+  it('falls back to the org connector with an unknown-contact mark', () => {
+    render(
+      <PathSummaryGraph
+        bestPath={path({ contact: undefined, org_connector: { name: 'Pico Ventures' } })}
+        investorName="Lena Hoffmann"
+      />,
+    );
+    expect(screen.getByText('Pico Ventures')).toBeInTheDocument();
+    expect(screen.getByLabelText('contact unknown')).toBeInTheDocument();
+  });
+
+  it('renders a plain Protocol Labs node when no connector is resolved', () => {
+    render(<PathSummaryGraph bestPath={path({})} investorName="Lena Hoffmann" />);
+    expect(screen.getByText('Protocol Labs')).toBeInTheDocument();
+    expect(screen.queryByLabelText('contact unknown')).not.toBeInTheDocument();
+  });
+
+  it('shows the tie score and relative last-email in the caption', () => {
+    const recent = new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString();
+    render(<PathSummaryGraph bestPath={path({ score: 0.62 })} investorName="Lena" lastEmailAt={recent} />);
+    expect(screen.getByText(/tie 0\.62 · last email .*ago/)).toBeInTheDocument();
+  });
+});
+
+describe('buildCaption', () => {
+  it('omits the tie segment for a non-finite or out-of-range score', () => {
+    expect(buildCaption(NaN)).toBe('');
+    expect(buildCaption(1.5)).toBe('');
+  });
+
+  it('shows only the tie segment when no last-email date is present', () => {
+    expect(buildCaption(0.62)).toBe('tie 0.62');
+    expect(buildCaption(0.62, null)).toBe('tie 0.62');
+  });
+
+  it('omits the last-email segment for a future date (no dangling separator)', () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString();
+    expect(buildCaption(0.62, future)).toBe('tie 0.62');
+  });
+});

--- a/__tests__/page/investors/warm-path-detail.test.tsx
+++ b/__tests__/page/investors/warm-path-detail.test.tsx
@@ -122,13 +122,13 @@ describe('WarmPathDetail per-path corrections', () => {
   it('renders a correction affordance per path, not one per investor', () => {
     render(<WarmPathDetail investorId="inv-1" canEdit />);
     fireEvent.click(screen.getByText(/Show .* more/));
-    expect(screen.getAllByText('Suggest a correction')).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Suggest a correction' })).toHaveLength(2);
   });
 
   it('submits the correction against the clicked path, not the best path', async () => {
     render(<WarmPathDetail investorId="inv-1" canEdit />);
     fireEvent.click(screen.getByText(/Show .* more/));
-    fireEvent.click(screen.getAllByText('Suggest a correction')[1]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Suggest a correction' })[1]);
     fireEvent.click(screen.getByText('Submit'));
 
     await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
@@ -140,7 +140,7 @@ describe('WarmPathDetail per-path corrections', () => {
 
   it('requires a replacement connector before submitting wrong_connector', async () => {
     render(<WarmPathDetail investorId="inv-1" canEdit />);
-    fireEvent.click(screen.getAllByText('Suggest a correction')[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Suggest a correction' })[0]);
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'wrong_connector' } });
 
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -157,7 +157,7 @@ describe('WarmPathDetail per-path corrections', () => {
 
   it('hides correction affordances without edit permission', () => {
     render(<WarmPathDetail investorId="inv-1" canEdit={false} />);
-    expect(screen.queryByText('Suggest a correction')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Suggest a correction' })).not.toBeInTheDocument();
   });
 });
 
@@ -187,7 +187,7 @@ describe('pending corrections display', () => {
   it('shows pending corrections to viewers without edit permission', () => {
     render(<WarmPathDetail investorId="inv-1" canEdit={false} />);
     expect(screen.getAllByText('Pending correction')).toHaveLength(2);
-    expect(screen.queryByText('Suggest a correction')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Suggest a correction' })).not.toBeInTheDocument();
   });
 
   it('summarizes connector corrections with human labels', () => {
@@ -195,5 +195,34 @@ describe('pending corrections display', () => {
       'Connector Portfolio founder → JB rolodex',
     );
     expect(correctionSummary(correction({ field: 'note', note: 'x' }))).toBe('Note');
+  });
+});
+
+describe('WarmPathDetail contact details toggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides contact channels behind a toggle and reveals them on click', () => {
+    mockPaths.mockReturnValue([
+      path({
+        id: 10,
+        rank: 1,
+        contact: { name: 'Alicia Mer', member_uid: 'alicia-mer', email: 'alicia@modularglobe.xyz' },
+      }),
+    ]);
+    render(<WarmPathDetail investorId="inv-1" canEdit />);
+
+    expect(screen.queryByText('alicia@modularglobe.xyz')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Show contact/ }));
+    expect(screen.getByText('alicia@modularglobe.xyz')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Hide contact/ }));
+    expect(screen.queryByText('alicia@modularglobe.xyz')).not.toBeInTheDocument();
+  });
+
+  it('does not render the toggle when the contact has no channels', () => {
+    mockPaths.mockReturnValue([path({ id: 11, rank: 1, contact: { name: 'No Channels' } })]);
+    render(<WarmPathDetail investorId="inv-1" canEdit />);
+    expect(screen.queryByRole('button', { name: /Show contact/ })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/services/investors/pathfinder-resolve.test.ts
+++ b/__tests__/services/investors/pathfinder-resolve.test.ts
@@ -1,0 +1,76 @@
+import { resolveBestPath, resolveBestConnector } from '@/services/investors/pathfinder.service';
+import type { PathContact, PathOrgConnector, PathfinderPath } from '@/services/investors/types';
+
+function path(overrides: Partial<PathfinderPath>): PathfinderPath {
+  return {
+    id: 1,
+    target_investor_id: 'inv-1',
+    connector_type: 'F',
+    hops: 1,
+    caliber: 'A',
+    proximity_code: 'F+1A',
+    score: 0.5,
+    caliber_confidence: 0.9,
+    hop_chain: { nodes: [], edges: [], explanation: '' },
+    rank: 1,
+    corrections: [],
+    ...overrides,
+  };
+}
+
+const contact: PathContact = { name: 'Alicia Mer', member_uid: 'alicia-mer' };
+const org: PathOrgConnector = { name: 'Pico Ventures' };
+
+describe('resolveBestPath', () => {
+  it('returns null for an empty list', () => {
+    expect(resolveBestPath([])).toBeNull();
+  });
+
+  it('prefers the path with rank === 1, regardless of array order', () => {
+    const best = path({ id: 10, rank: 1, score: 0.4 });
+    const paths = [path({ id: 20, rank: 2, score: 0.9 }), best, path({ id: 30, rank: 3 })];
+    expect(resolveBestPath(paths)?.id).toBe(10);
+  });
+
+  it('falls back to highest score, then fewest hops, when no rank-1 exists', () => {
+    const paths = [
+      path({ id: 1, rank: 2, score: 0.6, hops: 2 }),
+      path({ id: 2, rank: 3, score: 0.8, hops: 3 }),
+      path({ id: 3, rank: 3, score: 0.8, hops: 1 }), // same score, fewer hops → wins
+    ];
+    expect(resolveBestPath(paths)?.id).toBe(3);
+  });
+
+  it('does not mutate the input array', () => {
+    const paths = [path({ id: 1, rank: 2, score: 0.2 }), path({ id: 2, rank: 3, score: 0.9 })];
+    const order = paths.map((p) => p.id);
+    resolveBestPath(paths);
+    expect(paths.map((p) => p.id)).toEqual(order);
+  });
+
+  it('treats a non-finite score as lowest in the tiebreak', () => {
+    const paths = [
+      path({ id: 1, rank: 5, score: NaN, hops: 1 }),
+      path({ id: 2, rank: 6, score: 0.1, hops: 3 }),
+    ];
+    expect(resolveBestPath(paths)?.id).toBe(2);
+  });
+});
+
+describe('resolveBestConnector', () => {
+  it('returns kind "none" for a null path', () => {
+    expect(resolveBestConnector(null)).toEqual({ kind: 'none' });
+  });
+
+  it('prefers a known contact (person) over an org connector', () => {
+    expect(resolveBestConnector(path({ contact, org_connector: org }))).toEqual({ kind: 'contact', contact });
+  });
+
+  it('falls back to the org connector when no contact is known', () => {
+    expect(resolveBestConnector(path({ org_connector: org }))).toEqual({ kind: 'org', org });
+  });
+
+  it('returns kind "none" when neither contact nor org is present', () => {
+    expect(resolveBestConnector(path({}))).toEqual({ kind: 'none' });
+  });
+});

--- a/__tests__/utils/formatTimeAgo.test.ts
+++ b/__tests__/utils/formatTimeAgo.test.ts
@@ -1,0 +1,30 @@
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+
+describe('formatTimeAgo', () => {
+  it('returns "" for null, undefined and empty input', () => {
+    expect(formatTimeAgo(null)).toBe('');
+    expect(formatTimeAgo(undefined)).toBe('');
+    expect(formatTimeAgo('')).toBe('');
+  });
+
+  it('returns "" for an unparseable date (Invalid Date does not throw)', () => {
+    expect(formatTimeAgo('not-a-date')).toBe('');
+  });
+
+  it('returns "" for a future date (never "in 3 weeks ago")', () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString();
+    expect(formatTimeAgo(future)).toBe('');
+  });
+
+  it('formats a past date with an "ago" suffix', () => {
+    const threeWeeksAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 21).toISOString();
+    const out = formatTimeAgo(threeWeeksAgo);
+    expect(out).not.toBe('');
+    expect(out).toMatch(/ago$/);
+  });
+
+  it('abbreviates recent durations', () => {
+    const twoHoursAgo = new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString();
+    expect(formatTimeAgo(twoHoursAgo)).toBe('2h ago');
+  });
+});

--- a/app/investors/(investors-page)/@content/page.module.scss
+++ b/app/investors/(investors-page)/@content/page.module.scss
@@ -6,7 +6,7 @@
 }
 
 .pageHeader {
-  padding: 24px 20px;
+  padding: 0 20px 24px;
 }
 
 .pageTitleRow {
@@ -54,7 +54,7 @@
 
 .body {
   flex: 1 1 auto;
-  padding: 0 20px;
+  padding: 0;
   display: flex;
   flex-direction: column;
 }

--- a/components/page/investors/InvestorDrawer/InvestorDrawer.module.scss
+++ b/components/page/investors/InvestorDrawer/InvestorDrawer.module.scss
@@ -27,13 +27,57 @@
   min-width: 0;
 }
 
+.nameRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
 .name {
-  margin: 0 0 4px;
+  margin: 0;
   font-family: 'Inter', sans-serif;
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -0.3px;
   color: #0a0c11;
+  width: fit-content;
+}
+
+.contactIcons {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.contactIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  opacity: 0.8;
+  transition: opacity 0.1s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.contactIconCopy {
+  color: #9ca3af;
+  padding: 2px;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    color: #1b4dff;
+  }
 }
 
 .meta {

--- a/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
+++ b/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
@@ -262,6 +262,8 @@ export function InvestorDrawer({ access }: Props) {
                 investorId={investor.investor_id}
                 bestProximityCode={investor.best_proximity_code}
                 canEdit={access.canEdit}
+                investorName={`${investor.first_name} ${investor.last_name}`.trim()}
+                lastEmailAt={investor.last_email_date}
               />
             </div>
           )}

--- a/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
+++ b/components/page/investors/InvestorDrawer/InvestorDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
-import { Fragment } from 'react';
+import Image from 'next/image';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useQueryStates } from 'nuqs';
 import { useGetInvestorById } from '@/services/investors/hooks/useGetInvestorById';
@@ -11,9 +11,7 @@ import type { InvestorsAccess } from '@/services/rbac/hooks/useInvestorsAccess';
 import { Drawer } from '@/components/common/Drawer/Drawer';
 import { investorsFilterParsers } from '@/app/investors/(investors-page)/searchParams';
 import { INVESTOR_TYPE_LABEL, STAGE_FOCUS_LABEL } from '@/services/investors/constants';
-import { ProfileSocialLink } from '@/components/page/member-details/profile-social-link';
 import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
-import { getProfileFromURL } from '@/utils/common.utils';
 import { LabOsBadge } from '../LabOsBadge/LabOsBadge';
 import { EngagementTierBadge } from '../EngagementTierBadge/EngagementTierBadge';
 import { EmailStatusPill } from '../EmailStatusPill/EmailStatusPill';
@@ -63,9 +61,44 @@ export function InvestorDrawer({ access }: Props) {
           <div className={s.header}>
             <div className={s.headerTop}>
               <div className={s.headerWho}>
-                <h2 className={s.name}>
-                  {investor.first_name} {investor.last_name}
-                </h2>
+                <div className={s.nameRow}>
+                  <h2 className={s.name}>
+                    {investor.first_name} {investor.last_name}
+                  </h2>
+                  <div className={s.contactIcons}>
+                    {investor.linkedin_url && (
+                      <a
+                        href={investor.linkedin_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={s.contactIcon}
+                        title="LinkedIn"
+                      >
+                        <Image src={getContactLogoByProvider('linkedin')} alt="LinkedIn" width={20} height={20} />
+                      </a>
+                    )}
+                    {investor.firm_domain && (
+                      <a
+                        href={`https://${investor.firm_domain}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={s.contactIcon}
+                        title={investor.firm_domain}
+                      >
+                        <Image src={getContactLogoByProvider('website')} alt="Website" width={20} height={20} />
+                      </a>
+                    )}
+                    {investor.email && (
+                      <>
+                        <a href={`mailto:${investor.email}`} className={s.contactIcon} title={investor.email}>
+                          <Image src={getContactLogoByProvider('email')} alt="Email" width={20} height={20} />
+                        </a>
+                        <CopyButton text={investor.email} className={s.contactIconCopy} />
+                      </>
+                    )}
+                    {investor.lab_os_profile && <LabOsBadge profile={investor.lab_os_profile} variant="chip" />}
+                  </div>
+                </div>
                 <div className={s.meta}>
                   {investor.title || '—'}{' '}
                   {investor.firm && (
@@ -100,10 +133,9 @@ export function InvestorDrawer({ access }: Props) {
               </button>
             </div>
             <div className={s.pillRow}>
-              <EngagementTierBadge tier={investor.engagement_tier} />
+              {investor.engagement_tier && <EngagementTierBadge tier={investor.engagement_tier} />}
               <EmailStatusPill status={investor.email_status} />
               <span className={s.sourcePill}>Source: {investor.source}</span>
-              {investor.lab_os_profile && <LabOsBadge profile={investor.lab_os_profile} variant="chip" />}
             </div>
           </div>
 
@@ -118,59 +150,6 @@ export function InvestorDrawer({ access }: Props) {
               )}
             </div>
           )}
-
-          <div className={s.section}>
-            <h3 className={s.sectionTitle}>Contact</h3>
-            <div className={s.channelsBox}>
-              {[
-                investor.email && (
-                  <ProfileSocialLink
-                    key="email"
-                    type="email"
-                    handle={investor.email}
-                    profile={getProfileFromURL(investor.email, 'email') || investor.email}
-                    logo={getContactLogoByProvider('email')}
-                    height={20}
-                    width={20}
-                    callback={() => {}}
-                    suffix={<CopyButton text={investor.email} className={s.copyEmail} />}
-                  />
-                ),
-                investor.linkedin_url && (
-                  <ProfileSocialLink
-                    key="linkedin"
-                    type="linkedin"
-                    handle={investor.linkedin_url}
-                    profile={getProfileFromURL(investor.linkedin_url, 'linkedin') || investor.linkedin_url}
-                    logo={getContactLogoByProvider('linkedin')}
-                    height={20}
-                    width={20}
-                    callback={() => {}}
-                    linkedinProfileKind="member"
-                  />
-                ),
-                investor.firm_domain && (
-                  <ProfileSocialLink
-                    key="website"
-                    type="website"
-                    handle={investor.firm_domain}
-                    profile={investor.firm_domain}
-                    logo={getContactLogoByProvider('website')}
-                    height={20}
-                    width={20}
-                    callback={() => {}}
-                  />
-                ),
-              ]
-                .filter(Boolean)
-                .map((el, i) => (
-                  <Fragment key={i}>
-                    {i > 0 && <span className={s.channelDivider} aria-hidden />}
-                    {el}
-                  </Fragment>
-                ))}
-            </div>
-          </div>
 
           <div className={s.section}>
             <h3 className={s.sectionTitle}>Investor profile</h3>

--- a/components/page/investors/PathSummaryGraph/PathSummaryGraph.module.scss
+++ b/components/page/investors/PathSummaryGraph/PathSummaryGraph.module.scss
@@ -1,0 +1,143 @@
+/* Palette matches the neighboring investor modules (RouteChip / WarmPathDetail)
+   which use raw hex; keep them consistent rather than introducing tokens here. */
+
+.root {
+  padding: 2px 2px 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid #eef0f3;
+  font-family: 'Inter', sans-serif;
+}
+
+.graph {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.plNode {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.plLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.plDivider {
+  width: 1px;
+  height: 16px;
+  background: #d1d5db;
+  flex-shrink: 0;
+}
+
+.connector {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: none;
+  color: inherit;
+
+  &[href]:hover .nodeLabel {
+    color: #1b4dff;
+    text-decoration: underline;
+  }
+}
+
+.investorNode {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px 3px 3px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+}
+
+.arrow {
+  color: #9ca3af;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.nodeLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: #0a0c11;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e5e7eb;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.avatarGrey {
+  color: #9ca3af;
+}
+
+.avatarImg {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.avatarFallback {
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: #9ca3af;
+}
+
+.avatarInitials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 8px;
+  font-weight: 700;
+  color: #6b7280;
+}
+
+.unknownMark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #d1d5db;
+  color: #6b7280;
+  font-size: 9px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.caption {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+}

--- a/components/page/investors/PathSummaryGraph/PathSummaryGraph.tsx
+++ b/components/page/investors/PathSummaryGraph/PathSummaryGraph.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import clsx from 'clsx';
+import Link from 'next/link';
+import { resolveBestConnector, type BestConnector } from '@/services/investors/pathfinder.service';
+import type { PathfinderPath } from '@/services/investors/types';
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { UsersThreeIcon } from '@/components/icons';
+import s from './PathSummaryGraph.module.scss';
+
+interface Props {
+  /** Rank-1 path (resolved in the parent). null → nothing renders. */
+  bestPath: PathfinderPath | null;
+  investorName: string;
+  /** Affinity last-email date (ISO); rendered as a relative time when present. */
+  lastEmailAt?: string | null;
+}
+
+/**
+ * Compact route summary atop the warm-path cards: a Protocol Labs node that
+ * carries the best connector inside it → the target investor, with a quiet
+ * "tie 0.62 · last email 21d ago" caption beneath. The connector is resolved
+ * from the rank-1 path (see resolveBestConnector), so it always matches the
+ * rank-1 card below.
+ */
+export function PathSummaryGraph({ bestPath, investorName, lastEmailAt }: Props) {
+  if (!bestPath) return null;
+
+  const connector = resolveBestConnector(bestPath);
+  const caption = buildCaption(bestPath.score, lastEmailAt);
+
+  return (
+    <div className={s.root}>
+      <div className={s.graph}>
+        <div className={s.plNode}>
+          <span className={s.plLabel}>Protocol Labs</span>
+          {connector.kind !== 'none' && (
+            <>
+              <span className={s.plDivider} aria-hidden />
+              <Connector connector={connector} />
+            </>
+          )}
+        </div>
+        <span className={s.arrow} aria-hidden>
+          →
+        </span>
+        <div className={s.investorNode}>
+          <span className={clsx(s.avatar, s.avatarGrey)} aria-hidden>
+            <span className={s.avatarInitials}>{initials(investorName)}</span>
+          </span>
+          <span className={s.nodeLabel} title={investorName}>
+            {investorName}
+          </span>
+        </div>
+      </div>
+      {caption && <div className={s.caption}>{caption}</div>}
+    </div>
+  );
+}
+
+function Connector({ connector }: { connector: Extract<BestConnector, { kind: 'contact' | 'org' }> }) {
+  if (connector.kind === 'contact') {
+    const { contact } = connector;
+    const kind = contact.member_uid ? 'member' : 'externalPerson';
+    const body = (
+      <>
+        <Avatar imageUrl={contact.image_url} name={contact.name} kind={kind} />
+        <span className={s.nodeLabel} title={contact.name}>
+          {contact.name}
+        </span>
+      </>
+    );
+    return contact.member_uid ? (
+      <Link className={s.connector} href={`/members/${contact.member_uid}`} target="_blank" rel="noopener noreferrer">
+        {body}
+      </Link>
+    ) : (
+      <span className={s.connector}>{body}</span>
+    );
+  }
+
+  const { org } = connector;
+  const body = (
+    <>
+      <Avatar imageUrl={org.logo_url} name={org.name} kind="org" />
+      <span className={s.nodeLabel} title={org.name}>
+        {org.name}
+      </span>
+      <span className={s.unknownMark} aria-label="contact unknown">
+        ?
+      </span>
+    </>
+  );
+  return org.team_uid ? (
+    <Link className={s.connector} href={`/teams/${org.team_uid}`} target="_blank" rel="noopener noreferrer">
+      {body}
+    </Link>
+  ) : (
+    <span className={s.connector}>{body}</span>
+  );
+}
+
+type AvatarKind = 'member' | 'externalPerson' | 'org';
+
+function Avatar({ imageUrl, name, kind }: { imageUrl?: string; name: string; kind: AvatarKind }) {
+  if (imageUrl) {
+    return (
+      <span className={s.avatar}>
+        <img
+          src={imageUrl}
+          alt=""
+          width={20}
+          height={20}
+          className={s.avatarImg}
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).style.display = 'none';
+            const fallback = e.currentTarget.nextElementSibling as HTMLElement | null;
+            if (fallback) fallback.style.display = 'flex';
+          }}
+        />
+        <span className={s.avatarFallback} style={{ display: 'none' }} aria-hidden>
+          <Glyph kind={kind} name={name} />
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className={clsx(s.avatar, kind === 'externalPerson' && s.avatarGrey)} aria-hidden>
+      <Glyph kind={kind} name={name} />
+    </span>
+  );
+}
+
+function Glyph({ kind, name }: { kind: AvatarKind; name: string }) {
+  if (kind === 'org') return <UsersThreeIcon width={12} height={12} />;
+  if (kind === 'externalPerson') return <PersonGlyph />;
+  return <span className={s.avatarInitials}>{initials(name)}</span>;
+}
+
+/** Plain person silhouette for a known contact who is not in the PL network. */
+function PersonGlyph() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+    </svg>
+  );
+}
+
+/** "tie 0.62 · last email 21d ago" — segments joined so a missing side never
+ *  leaves a dangling separator. tie only for a finite score in [0,1]. */
+export function buildCaption(score: number, lastEmailAt?: string | null): string {
+  const segments: string[] = [];
+  if (Number.isFinite(score) && score >= 0 && score <= 1) segments.push(`tie ${score.toFixed(2)}`);
+  const rel = formatTimeAgo(lastEmailAt);
+  if (rel) segments.push(`last email ${rel}`);
+  return segments.join(' · ');
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}

--- a/components/page/investors/RouteChip/RouteChip.module.scss
+++ b/components/page/investors/RouteChip/RouteChip.module.scss
@@ -4,7 +4,7 @@
   gap: 5px;
   padding: 3px 8px 3px 3px;
   border-radius: 999px;
-  background: #f3f4f6;
+  background: #fff;
   border: 1px solid #e5e7eb;
   font-family: 'Inter', sans-serif;
   font-size: 12px;

--- a/components/page/investors/RouteChip/RouteChip.tsx
+++ b/components/page/investors/RouteChip/RouteChip.tsx
@@ -18,7 +18,7 @@ export function RouteChip({ node, teamLogoUrl }: Props) {
       return (
         <Link href={`/members/${node.member_uid}`} className={s.chip} target="_blank" rel="noopener noreferrer">
           <span className={s.avatarWrap}>
-            <MemberAvatar name={node.label} memberUid={node.member_uid} />
+            <MemberAvatar name={node.label} />
           </span>
           <span className={s.chipLabel}>{node.label}</span>
         </Link>
@@ -46,7 +46,9 @@ export function RouteChip({ node, teamLogoUrl }: Props) {
           <OrgAvatar name={node.label} logoUrl={teamLogoUrl} />
         </span>
         <span className={s.chipLabel}>{node.label}</span>
-        <span className={s.unknownMark} aria-label="contact unknown">?</span>
+        <span className={s.unknownMark} aria-label="contact unknown">
+          ?
+        </span>
       </Link>
     );
   }
@@ -58,27 +60,17 @@ export function RouteChip({ node, teamLogoUrl }: Props) {
         <OrgAvatar name={node.label} logoUrl={undefined} />
       </span>
       <span className={s.chipLabel}>{node.label}</span>
-      <span className={s.unknownMark} aria-label="contact unknown">?</span>
+      <span className={s.unknownMark} aria-label="contact unknown">
+        ?
+      </span>
     </span>
   );
 }
 
-function MemberAvatar({ name, memberUid }: { name: string; memberUid: string }) {
+function MemberAvatar({ name }: { name: string }) {
   return (
     <span className={s.avatar}>
-      <Image
-        src={`/api/avatar/${memberUid}`}
-        alt={name}
-        width={20}
-        height={20}
-        className={s.avatarImg}
-        onError={(e) => {
-          (e.currentTarget as HTMLImageElement).style.display = 'none';
-          const fallback = e.currentTarget.nextElementSibling as HTMLElement | null;
-          if (fallback) fallback.style.display = 'flex';
-        }}
-      />
-      <span className={s.avatarInitials} style={{ display: 'none' }} aria-hidden>
+      <span className={s.avatarInitials} aria-hidden>
         {initials(name)}
       </span>
     </span>

--- a/components/page/investors/WarmIntrosWorkspace/AddToListButton.tsx
+++ b/components/page/investors/WarmIntrosWorkspace/AddToListButton.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { InvestorList } from '@/services/investors/types';
+import { PlusIcon } from '@/components/icons';
+import { useAddToList } from '@/services/investors/hooks/useAddToList';
+import s from './WarmIntrosWorkspace.module.scss';
+
+interface Props {
+  lists: InvestorList[];
+  investorIds: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AddToListButton({ lists, investorIds, open, onOpenChange }: Props) {
+  const { mutate } = useAddToList();
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onOpenChange(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open, onOpenChange]);
+
+  const addAll = (listId: string) => {
+    investorIds.forEach((investorId) => mutate({ listId, investorId }));
+    onOpenChange(false);
+  };
+
+  return (
+    <div className={s.addListWrap} ref={ref}>
+      <button
+        type="button"
+        className={s.btn}
+        disabled={investorIds.length === 0}
+        onClick={() => onOpenChange(!open)}
+      >
+        <span className={s.addListTriggerInner}>
+          <PlusIcon />
+          Add to list{investorIds.length > 0 ? ` (${investorIds.length})` : ''}
+        </span>
+      </button>
+      {open && (
+        <div className={s.addListMenu}>
+          <div className={s.addListHead}>Add to list</div>
+          {lists.map((l) => (
+            <button
+              key={l.id}
+              type="button"
+              className={s.addListItem}
+              onClick={() => addAll(l.id)}
+            >
+              {l.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss
+++ b/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss
@@ -184,6 +184,61 @@
   }
 }
 
+/* ── Add-to-list popover ─────────────────────────────────────── */
+
+.addListWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.addListTriggerInner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.addListMenu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 220px;
+  max-width: 90vw;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(14, 15, 17, 0.12);
+}
+
+.addListHead {
+  padding: 6px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #6b7280;
+}
+
+.addListItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  color: #0a0c11;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(14, 15, 17, 0.04);
+  }
+}
+
 .btnPrimary {
   @extend .btn;
   background: #1b4dff;
@@ -555,9 +610,30 @@
 }
 
 .checkboxCol {
-  width: 32px;
-  text-align: center;
+  width: 40px;
+  padding: 8px 6px 8px 16px;
+  background: #f8fafc;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+
+  @media (max-width: 1023px) {
+    position: static;
+  }
 }
+
+thead .checkboxCol {
+  top: 0;
+  z-index: 3;
+}
+
+tbody .checkboxCol {
+  background: #fff;
+}
+
+.row:hover .checkboxCol { background: #f8fafc; }
+.rowSelected .checkboxCol { background: #fff; }
+.rowSelected:hover .checkboxCol { background: #f8fafc; }
 
 .fitCol {
   width: 60px;
@@ -637,64 +713,110 @@
 }
 
 .tableWrap {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  overflow: hidden;
+  overflow: auto;
+  border-radius: 10px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
 }
 
 .table {
+  table-layout: fixed;
   width: 100%;
+  min-width: 1100px;
   border-collapse: separate;
   border-spacing: 0;
-  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
 }
 
-.table thead th {
-  padding: 9px 16px;
+/* ── Header ──────────────────────────────────────────────────── */
+
+.th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   text-align: left;
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  color: #6b7280;
-  background: #f9fafb;
-  border-bottom: 1px solid #f3f4f6;
+  padding: 16px;
+  font-weight: 500;
+  font-size: 12px;
+  color: #64748b;
   white-space: nowrap;
+  background: var(--background-neutral-soft-surface, #f9fafb);
 }
 
-.table tbody td {
-  padding: 11px 16px;
-  border-bottom: 1px solid #f3f4f6;
-  vertical-align: top;
+/* ── Frozen columns ──────────────────────────────────────────── */
+
+.frozenName {
+  position: sticky;
+  z-index: 1;
+  background: #fff;
+  box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.06);
+
+  @media (max-width: 1023px) {
+    position: static;
+    box-shadow: none;
+  }
 }
+
+.frozenNameNoCheckbox { left: 0; }
+.frozenNameWithCheckbox { left: 40px; }
+
+thead .frozenName {
+  top: 0;
+  z-index: 3;
+  background: #f8fafc;
+}
+
+.row:hover .frozenName { background: #f8fafc; }
+.rowSelected .frozenName { background: #fff; }
+.rowSelected:hover .frozenName { background: #f8fafc; }
+
+/* ── Rows ────────────────────────────────────────────────────── */
 
 .row {
   cursor: pointer;
   transition: background 0.08s;
-
-  &:hover {
-    background: #fafbfc;
-  }
+  background: #fff;
 }
+
+.row:hover { background: #f8fafc; }
+.rowSelected { background: #fff; }
+.rowSelected:hover { background: #f8fafc; }
+
+.td {
+  padding: 10px 16px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* ── Cells ───────────────────────────────────────────────────── */
 
 .nameCell {
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+.nameText {
   font-weight: 600;
-  color: #0a0c11;
+  font-size: 14px;
+  color: #0f172a;
+  line-height: 1.4;
 }
 
 .subtle {
-  font-size: 11px;
-  color: #6b7280;
-  margin-top: 1px;
+  font-size: 12px;
+  color: #64748b;
+  margin-top: 2px;
 }
 
 .teamCell {
   font-weight: 500;
-  color: #0a0c11;
+  color: #0f172a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .proximityCell {
@@ -710,12 +832,6 @@
   gap: 6px;
 }
 
-.warmthPct {
-  font-size: 12px;
-  font-weight: 600;
-  color: #0a0c11;
-  font-variant-numeric: tabular-nums;
-}
 
 .miniRoute {
   display: flex;
@@ -734,65 +850,6 @@
 .miniArrow {
   font-size: 10px;
   color: #9ca3af;
-  flex-shrink: 0;
-}
-
-/* Flat inline chip for table route nodes (no border/pill) */
-.miniChip {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  font-size: 12px;
-  color: #374151;
-  text-decoration: none;
-  white-space: nowrap;
-
-  &[href]:hover {
-    color: #1b4dff;
-  }
-}
-
-.miniChipLabel {
-  font-weight: 500;
-}
-
-/* Filled green dot for PL network members */
-.miniDotMember {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #10b981;
-  flex-shrink: 0;
-}
-
-.miniPersonIcon {
-  color: #9ca3af;
-  flex-shrink: 0;
-}
-
-.miniOrgIcon {
-  color: #9ca3af;
-  flex-shrink: 0;
-}
-
-.miniExtIcon {
-  color: #9ca3af;
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-.miniUnknown {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 13px;
-  height: 13px;
-  border-radius: 50%;
-  background: #e5e7eb;
-  color: #6b7280;
-  font-size: 9px;
-  font-weight: 700;
   flex-shrink: 0;
 }
 

--- a/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.tsx
+++ b/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
+import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { useQueryStates } from 'nuqs';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import clsx from 'clsx';
-import type { PathHopNode } from '@/services/investors/types';
 import { useGetCoInvestorTeams } from '@/services/investors/hooks/useGetCoInvestorTeams';
 import { useGetInvestorLists } from '@/services/investors/hooks/useGetInvestorLists';
 import { useGetListMembers } from '@/services/investors/hooks/useGetListMembers';
@@ -35,8 +34,10 @@ import { LabOsBadge } from '../LabOsBadge/LabOsBadge';
 import { EngagementTierBadge } from '../EngagementTierBadge/EngagementTierBadge';
 import { SectorTagsList } from '../SectorTagsList/SectorTagsList';
 import { ProximityCodeBadge } from '../ProximityCodeBadge/ProximityCodeBadge';
+import { RouteChip } from '../RouteChip/RouteChip';
 import { CrosswalkReviewPanel } from '../CrosswalkReviewPanel/CrosswalkReviewPanel';
 import { exportInvestorsCsv } from '../utils/exportCsv';
+import { AddToListButton } from './AddToListButton';
 import { GlossaryModal } from './GlossaryModal';
 import { ListPicker } from './ListPicker';
 import { CLEAR_CONNECTOR_LENS, selectionToConnectorFilter } from './connectorLensFilters';
@@ -208,6 +209,7 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
   const lensLoading = !!connectorLabel && isFetching && !isFetchingNextPage;
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [addListOpen, setAddListOpen] = useState(false);
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const [crosswalkOpen, setCrosswalkOpen] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -290,6 +292,123 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
   };
 
   const canSelect = access.canEdit;
+
+  const allChecked = visible.length > 0 && visible.every((i) => selectedIds.has(i.investor_id));
+  const someChecked = !allChecked && visible.some((i) => selectedIds.has(i.investor_id));
+  const toggleAll = () => {
+    if (allChecked) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        visible.forEach((i) => next.delete(i.investor_id));
+        return next;
+      });
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        visible.forEach((i) => next.add(i.investor_id));
+        return next;
+      });
+    }
+  };
+
+  const columns = useMemo<ColumnDef<OutreachInvestor>[]>(
+    () => [
+      {
+        id: 'investor',
+        header: 'Investor',
+        cell: ({ row }) => (
+          <>
+            <div className={s.nameCell}>
+              <span className={s.nameText}>
+                {row.original.first_name} {row.original.last_name}
+              </span>
+              <LabOsBadge profile={row.original.lab_os_profile} variant="icon" />
+            </div>
+            {row.original.email && <div className={s.subtle}>{row.original.email}</div>}
+          </>
+        ),
+      },
+      {
+        id: 'team',
+        header: 'Team',
+        cell: ({ row }) => (
+          <>
+            <div className={s.teamCell}>{row.original.firm || <span className={s.muted}>—</span>}</div>
+            {row.original.title && <div className={s.subtle}>{row.original.title}</div>}
+          </>
+        ),
+        size: 200,
+      },
+      {
+        id: 'sector',
+        header: INDUSTRY_SECTOR_LABEL,
+        cell: ({ row }) => <SectorTagsList tags={row.original.sector_tags} max={3} />,
+        size: 200,
+      },
+      {
+        id: 'stage',
+        header: 'Stage',
+        cell: ({ row }) => STAGE_FOCUS_LABEL[row.original.stage_focus] ?? <span className={s.muted}>—</span>,
+        size: 110,
+      },
+      {
+        id: 'type',
+        header: 'Type',
+        cell: ({ row }) => INVESTOR_TYPE_LABEL[row.original.investor_type] ?? <span className={s.muted}>—</span>,
+        size: 110,
+      },
+      {
+        id: 'relationship',
+        header: 'Relationship',
+        cell: ({ row }) => <RelationshipCell investor={row.original} />,
+        size: 130,
+      },
+      {
+        id: 'proximity',
+        header: 'Proximity',
+        cell: ({ row }) => {
+          const inv = row.original;
+          const hasProximity = !!inv.best_proximity_code || inv.has_path === false;
+          if (!hasProximity) return <span className={s.muted}>—</span>;
+          return (
+            <div className={s.proximityCell}>
+              <div className={s.proximityTop}>
+                <ProximityCodeBadge
+                  code={inv.best_proximity_code}
+                  cold={inv.has_path === false}
+                  confidence={inv.best_route_score ?? undefined}
+                />
+              </div>
+              {inv.best_route_nodes && inv.best_route_nodes.length > 0 && (
+                <div className={s.miniRoute}>
+                  {inv.best_route_nodes.map((n, i) => (
+                    <span key={`${inv.investor_id}-${n.id}-${i}`} className={s.miniRouteNode}>
+                      {i > 0 && <span className={s.miniArrow}>→</span>}
+                      <RouteChip node={n} />
+                    </span>
+                  ))}
+                </div>
+              )}
+              <button
+                type="button"
+                className={s.viewAllLink}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setFilters({ investorId: inv.investor_id });
+                }}
+              >
+                View all{inv.path_count != null ? ` (${inv.path_count})` : ''}
+              </button>
+            </div>
+          );
+        },
+        size: 300,
+      },
+    ],
+    [setFilters],
+  );
+
+  const table = useReactTable({ data: visible, columns, getCoreRowModel: getCoreRowModel() });
 
   return (
     <div className={s.root}>
@@ -377,9 +496,13 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
               aria-expanded={sectorPopoverOpen}
             >
               <span className={s.sectorTriggerText}>
-                {draft.sectors.length > 0 ? `${INDUSTRY_SECTOR_LABEL} (${draft.sectors.length})` : INDUSTRY_SECTOR_LABEL}
+                {draft.sectors.length > 0
+                  ? `${INDUSTRY_SECTOR_LABEL} (${draft.sectors.length})`
+                  : INDUSTRY_SECTOR_LABEL}
               </span>
-              <span className={s.sectorCaret} aria-hidden>▾</span>
+              <span className={s.sectorCaret} aria-hidden>
+                ▾
+              </span>
             </button>
             {sectorPopoverOpen && (
               <div className={s.sectorPopover} role="dialog" aria-label="Sector filters">
@@ -464,9 +587,17 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
                 ))}
               </div>
               {access.canEdit && (
-                <button className={s.btnPrimary} onClick={exportSelectedCsv} disabled={selectedIds.size === 0}>
-                  ⤓ Export CSV ({selectedIds.size})
-                </button>
+                <>
+                  <AddToListButton
+                    lists={lists ?? []}
+                    investorIds={[...selectedIds]}
+                    open={addListOpen}
+                    onOpenChange={setAddListOpen}
+                  />
+                  <button className={s.btnPrimary} onClick={exportSelectedCsv} disabled={selectedIds.size === 0}>
+                    ⤓ Export CSV ({selectedIds.size})
+                  </button>
+                </>
               )}
             </div>
           </div>
@@ -475,87 +606,77 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
             <table className={s.table}>
               <thead>
                 <tr>
-                  {canSelect && <th className={s.checkboxCol}></th>}
-                  <th>Investor</th>
-                  <th>Team</th>
-                  <th>{INDUSTRY_SECTOR_LABEL}</th>
-                  <th>Stage</th>
-                  <th>Type</th>
-                  <th>Relationship</th>
-                  <th>Proximity</th>
+                  {canSelect && (
+                    <th className={s.checkboxCol}>
+                      <input
+                        type="checkbox"
+                        checked={allChecked}
+                        ref={(el) => {
+                          if (el) el.indeterminate = someChecked;
+                        }}
+                        onChange={toggleAll}
+                      />
+                    </th>
+                  )}
+                  {table.getHeaderGroups()[0]?.headers.map((h) => (
+                    <th
+                      key={h.id}
+                      className={clsx(
+                        s.th,
+                        h.id === 'investor' && s.frozenName,
+                        h.id === 'investor' && (canSelect ? s.frozenNameWithCheckbox : s.frozenNameNoCheckbox),
+                      )}
+                      style={
+                        h.column.columnDef.size !== undefined
+                          ? { width: h.column.getSize(), maxWidth: h.column.getSize() }
+                          : undefined
+                      }
+                    >
+                      {flexRender(h.column.columnDef.header, h.getContext())}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
-                {visible.map((inv) => {
-                  const hasProximity = !!inv.best_proximity_code || inv.has_path === false;
-                  return (
-                    <tr key={inv.investor_id} className={s.row} onClick={() => setFilters({ investorId: inv.investor_id })}>
-                      {canSelect && (
-                        <td className={s.checkboxCol}>
-                          <input
-                            type="checkbox"
-                            checked={selectedIds.has(inv.investor_id)}
-                            onClick={(e) => e.stopPropagation()}
-                            onChange={() => toggleSelected(inv.investor_id)}
-                          />
-                        </td>
-                      )}
-                      <td>
-                        <div className={s.nameCell}>
-                          {inv.first_name} {inv.last_name}
-                          <LabOsBadge profile={inv.lab_os_profile} variant="icon" />
-                        </div>
-                        <div className={s.subtle}>{inv.email}</div>
+                {table.getRowModel().rows.map((row) => (
+                  <tr
+                    key={row.id}
+                    className={clsx(s.row, selectedIds.has(row.original.investor_id) && s.rowSelected)}
+                    onClick={(e) => {
+                      const t = e.target as HTMLElement;
+                      if (t.closest('input[type="checkbox"]') || t.closest('a') || t.closest('button')) return;
+                      setFilters({ investorId: row.original.investor_id });
+                    }}
+                  >
+                    {canSelect && (
+                      <td className={s.checkboxCol}>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(row.original.investor_id)}
+                          onChange={() => toggleSelected(row.original.investor_id)}
+                        />
                       </td>
-                      <td>
-                        <div className={s.teamCell}>{inv.firm || <span className={s.muted}>—</span>}</div>
-                        {inv.title && <div className={s.subtle}>{inv.title}</div>}
-                      </td>
-                      <td>
-                        <SectorTagsList tags={inv.sector_tags} max={3} />
-                      </td>
-                      <td>{STAGE_FOCUS_LABEL[inv.stage_focus] ?? <span className={s.muted}>—</span>}</td>
-                      <td>{INVESTOR_TYPE_LABEL[inv.investor_type] ?? <span className={s.muted}>—</span>}</td>
-                      <td>
-                        <RelationshipCell investor={inv} />
-                      </td>
-                      <td>
-                        {hasProximity ? (
-                          <div className={s.proximityCell}>
-                            <div className={s.proximityTop}>
-                              <ProximityCodeBadge code={inv.best_proximity_code} cold={inv.has_path === false} />
-                              {inv.best_route_score != null && (
-                                <span className={s.warmthPct}>{Math.round(inv.best_route_score * 100)}%</span>
-                              )}
-                            </div>
-                            {inv.best_route_nodes && inv.best_route_nodes.length > 0 && (
-                              <div className={s.miniRoute}>
-                                {inv.best_route_nodes.map((n, i) => (
-                                  <span key={`${inv.investor_id}-${n.id}-${i}`} className={s.miniRouteNode}>
-                                    {i > 0 && <span className={s.miniArrow}>→</span>}
-                                    <TableRouteNode node={n} />
-                                  </span>
-                                ))}
-                              </div>
-                            )}
-                            <button
-                              type="button"
-                              className={s.viewAllLink}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setFilters({ investorId: inv.investor_id });
-                              }}
-                            >
-                              View all{inv.path_count != null ? ` (${inv.path_count})` : ''}
-                            </button>
-                          </div>
-                        ) : (
-                          <span className={s.muted}>—</span>
+                    )}
+                    {row.getVisibleCells().map((cell) => (
+                      <td
+                        key={cell.id}
+                        className={clsx(
+                          s.td,
+                          cell.column.id === 'investor' && s.frozenName,
+                          cell.column.id === 'investor' &&
+                            (canSelect ? s.frozenNameWithCheckbox : s.frozenNameNoCheckbox),
                         )}
+                        style={
+                          cell.column.columnDef.size !== undefined
+                            ? { width: cell.column.getSize(), maxWidth: cell.column.getSize() }
+                            : undefined
+                        }
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </td>
-                    </tr>
-                  );
-                })}
+                    ))}
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -586,67 +707,6 @@ export function WarmIntrosWorkspace({ onCountChange }: Props) {
       <GlossaryModal open={glossaryOpen} onClose={() => setGlossaryOpen(false)} />
       <CrosswalkReviewPanel open={crosswalkOpen} onClose={() => setCrosswalkOpen(false)} canEdit={access.canEdit} />
     </div>
-  );
-}
-
-/** Compact flat inline node for the table proximity column. */
-function TableRouteNode({ node }: { node: PathHopNode }) {
-  if (node.type === 'person') {
-    if ('member_uid' in node && node.member_uid) {
-      return (
-        <Link
-          href={`/members/${node.member_uid}`}
-          className={s.miniChip}
-          onClick={(e) => e.stopPropagation()}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span className={s.miniDotMember} aria-hidden />
-          <span className={s.miniChipLabel}>{node.label}</span>
-          <svg className={s.miniExtIcon} width="9" height="9" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
-            <path d="M5 3H2a1 1 0 00-1 1v6a1 1 0 001 1h6a1 1 0 001-1V7" />
-            <path d="M8 1h3m0 0v3m0-3L5 7" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </Link>
-      );
-    }
-    return (
-      <span className={s.miniChip}>
-        <svg className={s.miniPersonIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-          <circle cx="12" cy="8" r="4" />
-          <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
-        </svg>
-        <span className={s.miniChipLabel}>{node.label}</span>
-      </span>
-    );
-  }
-
-  if ('team_uid' in node && node.team_uid) {
-    return (
-      <Link
-        href={`/teams/${node.team_uid}`}
-        className={s.miniChip}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <svg className={s.miniOrgIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-          <rect x="2" y="7" width="20" height="15" rx="1" />
-          <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
-        </svg>
-        <span className={s.miniChipLabel}>{node.label}</span>
-        <span className={s.miniUnknown} aria-label="contact unknown">?</span>
-      </Link>
-    );
-  }
-
-  return (
-    <span className={s.miniChip}>
-      <svg className={s.miniOrgIcon} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-        <rect x="2" y="7" width="20" height="15" rx="1" />
-        <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
-      </svg>
-      <span className={s.miniChipLabel}>{node.label}</span>
-      <span className={s.miniUnknown} aria-label="contact unknown">?</span>
-    </span>
   );
 }
 

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
@@ -500,6 +500,59 @@
   }
 }
 
+/* ── RouteNodeChip — richer v2 path node chip ────────────────────────────── */
+
+.rnChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px 3px 3px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  font-size: 12px;
+  color: #0a0c11;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &[href]:hover {
+    border-color: #9ca3af;
+    background: #f9fafb;
+  }
+}
+
+.rnAvatarWrap {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: #dde1ea;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rnAvatarImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.rnAvatarInitials {
+  font-size: 8px;
+  font-weight: 700;
+  color: #455468;
+  line-height: 1;
+}
+
+.rnLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: #0a0c11;
+  line-height: 1;
+}
+
 .showMore {
   align-self: flex-start;
   background: #fff;

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
@@ -23,10 +23,64 @@
 }
 
 .pathItem {
+  position: relative;
   padding: 10px 12px;
   background: #f9fafb;
   border: 1px solid #eef0f3;
   border-radius: 8px;
+}
+
+.correctionIcon {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(14, 15, 17, 0.04);
+    color: #455468;
+  }
+
+  &[aria-expanded='true'] {
+    background: rgba(27, 77, 255, 0.08);
+    color: #1b4dff;
+  }
+}
+
+.contactToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: #1b4dff;
+
+  svg {
+    transition: transform 0.15s ease;
+  }
+
+  &[aria-expanded='true'] svg {
+    transform: rotate(180deg);
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .pathHead {
@@ -221,6 +275,7 @@
   gap: 10px;
   flex-wrap: wrap;
   margin-top: 6px;
+  padding-right: 30px; // reserve room for the corner correction icon
 }
 
 .contactBlock {
@@ -239,8 +294,8 @@
 
 .contactAvatar {
   flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   background: #dde1ea;
   overflow: hidden;

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
@@ -109,12 +109,50 @@
   line-height: 1.5;
 }
 
+.chainRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
 .chain {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 4px;
-  margin-top: 6px;
+  flex: 1;
+}
+
+.detailsBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  svg {
+    transition: transform 0.15s ease;
+  }
+
+  &[aria-expanded='true'] svg {
+    transform: rotate(180deg);
+  }
+
+  &:hover {
+    background: #f9fafb;
+    border-color: #9ca3af;
+  }
 }
 
 .node {
@@ -365,6 +403,45 @@
 .contactOrgText {
   font-size: 11px;
   color: #6b7280;
+}
+
+.orgIcon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+}
+
+.orgNameRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.unknownPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  font-size: 11px;
+  color: #6b7280;
+  background: #fff;
+  white-space: nowrap;
+}
+
+.orgHint {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: #6b7280;
+  line-height: 1.45;
 }
 
 .contactSocials {

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -164,7 +164,7 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
 
   return (
     <div className={s.root}>
-      <PathSummaryGraph bestPath={bestPath} investorName={investorName ?? ''} lastEmailAt={lastEmailAt} />
+      {/*<PathSummaryGraph bestPath={bestPath} investorName={investorName ?? ''} lastEmailAt={lastEmailAt} />*/}
       <ol className={s.pathList}>
         {visiblePaths.map((p) => {
           const formOpen = openPathId === p.id;

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useGetPathsForTarget } from '@/services/investors/hooks/useGetPathsForTarget';
 import { useSubmitCorrection } from '@/services/investors/hooks/useSubmitCorrection';
+import { resolveBestPath } from '@/services/investors/pathfinder.service';
+import { PathSummaryGraph } from '../PathSummaryGraph/PathSummaryGraph';
 import { useInvestorsAnalytics } from '@/analytics/investors.analytics';
 import { PATH_CONNECTOR_LABEL } from '@/services/investors/constants';
 import type {
@@ -23,6 +25,10 @@ interface Props {
   investorId: string;
   bestProximityCode?: string | null;
   canEdit: boolean;
+  /** Investor display name — shown as the destination node in the summary graph. */
+  investorName?: string;
+  /** Affinity last-email date (ISO) — shown under the summary graph as a relative time. */
+  lastEmailAt?: string | null;
 }
 
 type CorrectionReason = 'caliber_too_high' | 'caliber_too_low' | 'wrong_connector' | 'path_invalid' | 'other';
@@ -87,12 +93,13 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString();
 }
 
-export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props) {
+export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investorName, lastEmailAt }: Props) {
   const { data, isLoading } = useGetPathsForTarget(investorId, true);
   const { trackPathsViewed, trackCorrectionSubmitted } = useInvestorsAnalytics();
   const submitCorrection = useSubmitCorrection(investorId);
 
-  const paths = data?.paths ?? [];
+  const paths = useMemo(() => data?.paths ?? [], [data]);
+  const bestPath = useMemo(() => resolveBestPath(paths), [paths]);
   const [showAll, setShowAll] = useState(false);
 
   const viewedRef = useRef(false);
@@ -145,6 +152,7 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit }: Props
 
   return (
     <div className={s.root}>
+      <PathSummaryGraph bestPath={bestPath} investorName={investorName ?? ''} lastEmailAt={lastEmailAt} />
       <ol className={s.pathList}>
         {visiblePaths.map((p) => {
           const formOpen = openPathId === p.id;

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -6,6 +6,7 @@ import { useGetPathsForTarget } from '@/services/investors/hooks/useGetPathsForT
 import { useSubmitCorrection } from '@/services/investors/hooks/useSubmitCorrection';
 import { resolveBestPath } from '@/services/investors/pathfinder.service';
 import { PathSummaryGraph } from '../PathSummaryGraph/PathSummaryGraph';
+import { ChevronDownIcon, PencilSimpleLineIcon } from '@/components/icons';
 import { useInvestorsAnalytics } from '@/analytics/investors.analytics';
 import { PATH_CONNECTOR_LABEL } from '@/services/investors/constants';
 import type {
@@ -110,6 +111,17 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
     }
   }, [data, investorId, bestProximityCode, trackPathsViewed]);
 
+  // Contact details are collapsed by default to reduce card density; tracked per
+  // path id so multiple expanded cards toggle independently. Reset for free on
+  // investor switch via the key={investor_id} remount in InvestorDrawer.
+  const [openContactIds, setOpenContactIds] = useState<Set<number>>(new Set());
+  const toggleContacts = (pathId: number) =>
+    setOpenContactIds((prev) => {
+      const next = new Set(prev); // new ref — mutating in place would not re-render
+      next.has(pathId) ? next.delete(pathId) : next.add(pathId);
+      return next;
+    });
+
   const [openPathId, setOpenPathId] = useState<number | null>(null);
   const [reason, setReason] = useState<CorrectionReason>('caliber_too_high');
   const [note, setNote] = useState('');
@@ -158,6 +170,19 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
           const formOpen = openPathId === p.id;
           return (
             <li key={p.id} className={s.pathItem}>
+              {/* Correction trigger — corner icon opening the same inline form */}
+              {canEdit && (
+                <button
+                  type="button"
+                  className={s.correctionIcon}
+                  aria-label="Suggest a correction"
+                  aria-expanded={formOpen}
+                  onClick={() => (formOpen ? setOpenPathId(null) : openFormFor(p.id))}
+                >
+                  <PencilSimpleLineIcon width={14} height={14} />
+                </button>
+              )}
+
               {/* Header: proximity badge + warmth label */}
               <div className={s.pathMeta}>
                 <ProximityCodeBadge code={p.proximity_code} confidence={p.caliber_confidence} />
@@ -170,7 +195,14 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
               {p.hop_chain.explanation && <div className={s.explanation}>{p.hop_chain.explanation}</div>}
 
               {/* Who to contact */}
-              {p.contact && <ContactBlock contact={p.contact} org={p.org_connector} />}
+              {p.contact && (
+                <ContactBlock
+                  contact={p.contact}
+                  org={p.org_connector}
+                  expanded={openContactIds.has(p.id)}
+                  onToggle={() => toggleContacts(p.id)}
+                />
+              )}
               {!p.contact && p.org_connector && <OrgBlock org={p.org_connector} />}
 
               {/* Route chain (secondary, shown below contact) */}
@@ -201,60 +233,53 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
                 </ul>
               )}
 
-              {canEdit && (
+              {canEdit && formOpen && (
                 <div className={s.correction}>
-                  {!formOpen && (
-                    <button type="button" className={s.linkBtn} onClick={() => openFormFor(p.id)}>
-                      Suggest a correction
-                    </button>
-                  )}
-                  {formOpen && (
-                    <div className={s.form}>
+                  <div className={s.form}>
+                    <select
+                      className={s.select}
+                      value={reason}
+                      onChange={(e) => setReason(e.target.value as CorrectionReason)}
+                    >
+                      {REASON_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                    {reason === 'wrong_connector' && (
                       <select
                         className={s.select}
-                        value={reason}
-                        onChange={(e) => setReason(e.target.value as CorrectionReason)}
+                        value={newConnector}
+                        onChange={(e) => setNewConnector(e.target.value as PathConnectorType | '')}
+                        aria-label="Correct connector"
                       >
-                        {REASON_OPTIONS.map((o) => (
-                          <option key={o.value} value={o.value}>
-                            {o.label}
+                        <option value="">Correct connector…</option>
+                        {CONNECTOR_CHOICES.filter((c) => c !== p.connector_type).map((c) => (
+                          <option key={c} value={c}>
+                            {PATH_CONNECTOR_LABEL[c]}
                           </option>
                         ))}
                       </select>
-                      {reason === 'wrong_connector' && (
-                        <select
-                          className={s.select}
-                          value={newConnector}
-                          onChange={(e) => setNewConnector(e.target.value as PathConnectorType | '')}
-                          aria-label="Correct connector"
-                        >
-                          <option value="">Correct connector…</option>
-                          {CONNECTOR_CHOICES.filter((c) => c !== p.connector_type).map((c) => (
-                            <option key={c} value={c}>
-                              {PATH_CONNECTOR_LABEL[c]}
-                            </option>
-                          ))}
-                        </select>
-                      )}
-                      <input
-                        className={s.input}
-                        placeholder="Add a note (optional)"
-                        value={note}
-                        onChange={(e) => setNote(e.target.value)}
-                      />
-                      <button
-                        type="button"
-                        className={s.btnPrimary}
-                        onClick={() => onSubmit(p)}
-                        disabled={submitCorrection.isPending || (reason === 'wrong_connector' && !newConnector)}
-                      >
-                        {submitCorrection.isPending ? 'Saving…' : 'Submit'}
-                      </button>
-                      <button type="button" className={s.linkBtn} onClick={() => setOpenPathId(null)}>
-                        Cancel
-                      </button>
-                    </div>
-                  )}
+                    )}
+                    <input
+                      className={s.input}
+                      placeholder="Add a note (optional)"
+                      value={note}
+                      onChange={(e) => setNote(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className={s.btnPrimary}
+                      onClick={() => onSubmit(p)}
+                      disabled={submitCorrection.isPending || (reason === 'wrong_connector' && !newConnector)}
+                    >
+                      {submitCorrection.isPending ? 'Saving…' : 'Submit'}
+                    </button>
+                    <button type="button" className={s.linkBtn} onClick={() => setOpenPathId(null)}>
+                      Cancel
+                    </button>
+                  </div>
                 </div>
               )}
             </li>
@@ -276,7 +301,18 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
   );
 }
 
-function ContactBlock({ contact, org }: { contact: PathContact; org?: PathOrgConnector }) {
+function ContactBlock({
+  contact,
+  org,
+  expanded,
+  onToggle,
+}: {
+  contact: PathContact;
+  org?: PathOrgConnector;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasChannels = !!(contact.email || contact.linkedin_url || contact.telegram);
   const initials = contact.name
     .split(' ')
     .slice(0, 2)
@@ -327,7 +363,13 @@ function ContactBlock({ contact, org }: { contact: PathContact; org?: PathOrgCon
           )}
         </div>
       </div>
-      {(contact.email || contact.linkedin_url || contact.telegram) && (
+      {hasChannels && (
+        <button type="button" className={s.contactToggle} onClick={onToggle} aria-expanded={expanded}>
+          <ChevronDownIcon width={14} height={14} />
+          {expanded ? 'Hide contact' : 'Show contact'}
+        </button>
+      )}
+      {hasChannels && expanded && (
         <div className={s.contactSocials}>
           {contact.email && (
             <>
@@ -371,18 +413,19 @@ function ContactBlock({ contact, org }: { contact: PathContact; org?: PathOrgCon
 }
 
 function OrgBlock({ org }: { org: PathOrgConnector }) {
-  const nameEl = org.website_url || org.team_uid ? (
-    <a
-      href={org.team_uid ? `/teams/${org.team_uid}` : org.website_url}
-      className={s.contactName}
-      target={org.team_uid ? '_self' : '_blank'}
-      rel="noopener noreferrer"
-    >
-      {org.name}
-    </a>
-  ) : (
-    <span className={s.contactName}>{org.name}</span>
-  );
+  const nameEl =
+    org.website_url || org.team_uid ? (
+      <a
+        href={org.team_uid ? `/teams/${org.team_uid}` : org.website_url}
+        className={s.contactName}
+        target={org.team_uid ? '_self' : '_blank'}
+        rel="noopener noreferrer"
+      >
+        {org.name}
+      </a>
+    ) : (
+      <span className={s.contactName}>{org.name}</span>
+    );
 
   return (
     <div className={s.contactBlock}>
@@ -390,7 +433,11 @@ function OrgBlock({ org }: { org: PathOrgConnector }) {
         {nameEl}
         <span className={s.contactRole}>Contact unknown</span>
       </div>
-      {org.domain && <div className={s.contactLinks}><span className={s.contactMeta}>{org.domain}</span></div>}
+      {org.domain && (
+        <div className={s.contactLinks}>
+          <span className={s.contactMeta}>{org.domain}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -194,27 +194,37 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
               {/* Explanation */}
               {p.hop_chain.explanation && <div className={s.explanation}>{p.hop_chain.explanation}</div>}
 
-              {/* Who to contact */}
-              {p.contact && (
-                <ContactBlock
-                  contact={p.contact}
-                  org={p.org_connector}
-                  expanded={openContactIds.has(p.id)}
-                  onToggle={() => toggleContacts(p.id)}
-                />
-              )}
-              {!p.contact && p.org_connector && <OrgBlock org={p.org_connector} />}
-
-              {/* Route chain (secondary, shown below contact) */}
+              {/* Route chain + trailing details toggle */}
               {p.hop_chain.nodes.length > 0 && (
-                <div className={s.chain}>
-                  {p.hop_chain.nodes.map((n, i) => (
-                    <span key={`${p.id}-${n.id}-${i}`} className={s.node}>
-                      {i > 0 && <span className={s.arrow}>→</span>}
-                      <RouteChip node={n} />
-                    </span>
-                  ))}
+                <div className={s.chainRow}>
+                  <div className={s.chain}>
+                    {p.hop_chain.nodes.map((n, i) => (
+                      <span key={`${p.id}-${n.id}-${i}`} className={s.node}>
+                        {i > 0 && <span className={s.arrow}>→</span>}
+                        <RouteChip node={n} />
+                      </span>
+                    ))}
+                  </div>
+                  {(p.contact || p.org_connector) && (
+                    <button
+                      type="button"
+                      className={s.detailsBtn}
+                      onClick={() => toggleContacts(p.id)}
+                      aria-expanded={openContactIds.has(p.id)}
+                    >
+                      {p.contact ? 'Contact details' : 'Organization details'}
+                      <ChevronDownIcon width={14} height={14} />
+                    </button>
+                  )}
                 </div>
+              )}
+
+              {/* Expanded detail card */}
+              {openContactIds.has(p.id) && p.contact && (
+                <ContactCard contact={p.contact} org={p.org_connector} />
+              )}
+              {openContactIds.has(p.id) && !p.contact && p.org_connector && (
+                <OrgCard org={p.org_connector} />
               )}
 
               {p.corrections.length > 0 && (
@@ -301,18 +311,7 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
   );
 }
 
-function ContactBlock({
-  contact,
-  org,
-  expanded,
-  onToggle,
-}: {
-  contact: PathContact;
-  org?: PathOrgConnector;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  const hasChannels = !!(contact.email || contact.linkedin_url || contact.telegram);
+function ContactCard({ contact, org }: { contact: PathContact; org?: PathOrgConnector }) {
   const initials = contact.name
     .split(' ')
     .slice(0, 2)
@@ -322,7 +321,7 @@ function ContactBlock({
 
   const nameEl = contact.member_uid ? (
     <Link href={`/members/${contact.member_uid}`} className={s.contactName} target="_blank" rel="noopener noreferrer">
-      {contact.name}
+      {contact.name} ↗
     </Link>
   ) : (
     <span className={s.contactName}>{contact.name}</span>
@@ -331,11 +330,11 @@ function ContactBlock({
   const orgEl = org ? (
     org.team_uid ? (
       <Link href={`/teams/${org.team_uid}`} className={s.contactOrgLink} target="_blank" rel="noopener noreferrer">
-        {org.name}
+        {org.name} ↗
       </Link>
     ) : org.website_url ? (
       <a href={org.website_url} className={s.contactOrgLink} target="_blank" rel="noopener noreferrer">
-        {org.name}
+        {org.name} ↗
       </a>
     ) : (
       <span className={s.contactOrgText}>{org.name}</span>
@@ -363,23 +362,8 @@ function ContactBlock({
           )}
         </div>
       </div>
-      {hasChannels && (
-        <button type="button" className={s.contactToggle} onClick={onToggle} aria-expanded={expanded}>
-          <ChevronDownIcon width={14} height={14} />
-          {expanded ? 'Hide contact' : 'Show contact'}
-        </button>
-      )}
-      {hasChannels && expanded && (
+      {(contact.email || contact.linkedin_url || contact.telegram) && (
         <div className={s.contactSocials}>
-          {contact.email && (
-            <>
-              <a href={`mailto:${contact.email}`} className={s.socialEmail}>
-                <span className={s.socialCircle}>@</span>
-                {contact.email}
-              </a>
-              <CopyButton text={contact.email} />
-            </>
-          )}
           {contact.linkedin_url && (
             <a
               href={contact.linkedin_url}
@@ -406,21 +390,29 @@ function ContactBlock({
               </svg>
             </a>
           )}
+          {contact.email && (
+            <>
+              <a href={`mailto:${contact.email}`} className={s.socialEmail}>
+                <span className={s.socialCircle}>@</span>
+                {contact.email}
+              </a>
+              <CopyButton text={contact.email} />
+            </>
+          )}
         </div>
       )}
     </div>
   );
 }
 
-function OrgBlock({ org }: { org: PathOrgConnector }) {
+function OrgCard({ org }: { org: PathOrgConnector }) {
   const nameEl =
-    org.website_url || org.team_uid ? (
-      <a
-        href={org.team_uid ? `/teams/${org.team_uid}` : org.website_url}
-        className={s.contactName}
-        target={org.team_uid ? '_self' : '_blank'}
-        rel="noopener noreferrer"
-      >
+    org.team_uid ? (
+      <Link href={`/teams/${org.team_uid}`} className={s.contactName} target="_blank" rel="noopener noreferrer">
+        {org.name}
+      </Link>
+    ) : org.website_url ? (
+      <a href={org.website_url} className={s.contactName} target="_blank" rel="noopener noreferrer">
         {org.name}
       </a>
     ) : (
@@ -429,15 +421,22 @@ function OrgBlock({ org }: { org: PathOrgConnector }) {
 
   return (
     <div className={s.contactBlock}>
-      <div className={s.contactRow}>
-        {nameEl}
-        <span className={s.contactRole}>Contact unknown</span>
-      </div>
-      {org.domain && (
-        <div className={s.contactLinks}>
-          <span className={s.contactMeta}>{org.domain}</span>
+      <div className={s.contactHeader}>
+        <div className={s.orgIcon} aria-hidden>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="2" y="7" width="20" height="14" rx="2" />
+            <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
+            <line x1="12" y1="12" x2="12" y2="12" />
+          </svg>
         </div>
-      )}
+        <div className={s.contactInfo}>
+          <div className={s.orgNameRow}>
+            {nameEl}
+            <span className={s.unknownPill}>Connection unknown</span>
+          </div>
+          <p className={s.orgHint}>This team can route the intro — reach out and ask for the right person.</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useQueryStates } from 'nuqs';
+import { investorsFilterParsers } from '@/app/investors/(investors-page)/searchParams';
 import { useGetPathsForTarget } from '@/services/investors/hooks/useGetPathsForTarget';
 import { useSubmitCorrection } from '@/services/investors/hooks/useSubmitCorrection';
 import { resolveBestPath } from '@/services/investors/pathfinder.service';
@@ -16,6 +18,7 @@ import type {
   PathCorrection,
   PathOrgConnector,
   PathfinderPath,
+  RouteNode,
 } from '@/services/investors/types';
 import { ProximityCodeBadge } from '../ProximityCodeBadge/ProximityCodeBadge';
 import { RouteChip } from '../RouteChip/RouteChip';
@@ -43,6 +46,11 @@ const REASON_OPTIONS: { value: CorrectionReason; label: string }[] = [
 ];
 
 const CONNECTOR_CHOICES = (Object.keys(PATH_CONNECTOR_LABEL) as PathConnectorType[]).filter((c) => c !== 'C');
+
+const LIST_ID_TO_TARGET_SET: Record<string, string> = {
+  'neuro-lp': 'neuro-fund-i',
+  'gold-coinvestors': 'gold-co-investors',
+};
 
 export function buildCorrection(
   path: PathfinderPath,
@@ -95,11 +103,18 @@ function formatDate(iso: string): string {
 }
 
 export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investorName, lastEmailAt }: Props) {
+  const [filters] = useQueryStates(investorsFilterParsers, { history: 'replace', shallow: true });
   const { data, isLoading } = useGetPathsForTarget(investorId, true);
   const { trackPathsViewed, trackCorrectionSubmitted } = useInvestorsAnalytics();
   const submitCorrection = useSubmitCorrection(investorId);
 
-  const paths = useMemo(() => data?.paths ?? [], [data]);
+  const paths = useMemo(() => {
+    const all = data?.paths ?? [];
+    const targetSet = filters.wi_list_id ? LIST_ID_TO_TARGET_SET[filters.wi_list_id] : null;
+    if (!targetSet) return all;
+    const filtered = all.filter((p) => p.target_set === targetSet);
+    return filtered.length > 0 ? filtered : all;
+  }, [data, filters.wi_list_id]);
   const bestPath = useMemo(() => resolveBestPath(paths), [paths]);
   const [showAll, setShowAll] = useState(false);
 
@@ -168,6 +183,7 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
       <ol className={s.pathList}>
         {visiblePaths.map((p) => {
           const formOpen = openPathId === p.id;
+
           return (
             <li key={p.id} className={s.pathItem}>
               {/* Correction trigger — corner icon opening the same inline form */}
@@ -195,15 +211,22 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
               {p.hop_chain.explanation && <div className={s.explanation}>{p.hop_chain.explanation}</div>}
 
               {/* Route chain + trailing details toggle */}
-              {p.hop_chain.nodes.length > 0 && (
+              {(p.hop_chain.routeNodes?.length || p.hop_chain.nodes.length > 0) && (
                 <div className={s.chainRow}>
                   <div className={s.chain}>
-                    {p.hop_chain.nodes.map((n, i) => (
-                      <span key={`${p.id}-${n.id}-${i}`} className={s.node}>
-                        {i > 0 && <span className={s.arrow}>→</span>}
-                        <RouteChip node={n} />
-                      </span>
-                    ))}
+                    {p.hop_chain.routeNodes
+                      ? p.hop_chain.routeNodes.map((n, i) => (
+                          <span key={`${p.id}-rn-${i}`} className={s.node}>
+                            {i > 0 && <span className={s.arrow}>→</span>}
+                            <RouteNodeChip node={n} />
+                          </span>
+                        ))
+                      : p.hop_chain.nodes.map((n, i) => (
+                          <span key={`${p.id}-${n.id}-${i}`} className={s.node}>
+                            {i > 0 && <span className={s.arrow}>→</span>}
+                            <RouteChip node={n} />
+                          </span>
+                        ))}
                   </div>
                   {(p.contact || p.org_connector) && (
                     <button
@@ -220,12 +243,8 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
               )}
 
               {/* Expanded detail card */}
-              {openContactIds.has(p.id) && p.contact && (
-                <ContactCard contact={p.contact} org={p.org_connector} />
-              )}
-              {openContactIds.has(p.id) && !p.contact && p.org_connector && (
-                <OrgCard org={p.org_connector} />
-              )}
+              {openContactIds.has(p.id) && p.contact && <ContactCard contact={p.contact} org={p.org_connector} />}
+              {openContactIds.has(p.id) && !p.contact && p.org_connector && <OrgCard org={p.org_connector} />}
 
               {p.corrections.length > 0 && (
                 <ul className={s.pendingList}>
@@ -309,6 +328,36 @@ export function WarmPathDetail({ investorId, bestProximityCode, canEdit, investo
       )}
     </div>
   );
+}
+
+function RouteNodeChip({ node }: { node: RouteNode }) {
+  const initials = node.label
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+
+  const inner = (
+    <>
+      <span className={s.rnAvatarWrap}>
+        {node.imageUrl ? (
+          <img src={node.imageUrl} alt={node.label} className={s.rnAvatarImg} />
+        ) : (
+          <span className={s.rnAvatarInitials}>{initials}</span>
+        )}
+      </span>
+      <span className={s.rnLabel}>{node.label}</span>
+    </>
+  );
+
+  if (node.memberUid) {
+    return (
+      <Link href={`/members/${node.memberUid}`} className={s.rnChip} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </Link>
+    );
+  }
+  return <span className={s.rnChip}>{inner}</span>;
 }
 
 function ContactCard({ contact, org }: { contact: PathContact; org?: PathOrgConnector }) {
@@ -406,24 +455,32 @@ function ContactCard({ contact, org }: { contact: PathContact; org?: PathOrgConn
 }
 
 function OrgCard({ org }: { org: PathOrgConnector }) {
-  const nameEl =
-    org.team_uid ? (
-      <Link href={`/teams/${org.team_uid}`} className={s.contactName} target="_blank" rel="noopener noreferrer">
-        {org.name}
-      </Link>
-    ) : org.website_url ? (
-      <a href={org.website_url} className={s.contactName} target="_blank" rel="noopener noreferrer">
-        {org.name}
-      </a>
-    ) : (
-      <span className={s.contactName}>{org.name}</span>
-    );
+  const nameEl = org.team_uid ? (
+    <Link href={`/teams/${org.team_uid}`} className={s.contactName} target="_blank" rel="noopener noreferrer">
+      {org.name}
+    </Link>
+  ) : org.website_url ? (
+    <a href={org.website_url} className={s.contactName} target="_blank" rel="noopener noreferrer">
+      {org.name}
+    </a>
+  ) : (
+    <span className={s.contactName}>{org.name}</span>
+  );
 
   return (
     <div className={s.contactBlock}>
       <div className={s.contactHeader}>
         <div className={s.orgIcon} aria-hidden>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <rect x="2" y="7" width="20" height="14" rx="2" />
             <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
             <line x1="12" y1="12" x2="12" y2="12" />

--- a/services/investors/investors.service.ts
+++ b/services/investors/investors.service.ts
@@ -154,6 +154,7 @@ export function mapInvestorDto(dto: AnyDto): OutreachInvestor {
     best_route_score: dto.bestRouteScore != null ? (dto.bestRouteScore as number) : undefined,
     path_count: dto.pathCount != null ? (dto.pathCount as number) : undefined,
     enrichment: dto.enrichment ? mapEnrichment(dto.enrichment) : null,
+    last_email_date: dto.lastEmailDate ?? null,
   };
 }
 

--- a/services/investors/pathfinder.service.ts
+++ b/services/investors/pathfinder.service.ts
@@ -105,6 +105,37 @@ export function mapPathfinderPath(dto: AnyDto): PathfinderPath {
   };
 }
 
+// ─── Best-path / best-connector resolution (pure, unit-tested) ──────────────────
+//
+// The summary graph and the rank-1 card both need "the best path". Resolve it
+// here, off `rank === 1`, NOT `paths[0]` — array order is not guaranteed to equal
+// rank order, and ranks can tie. Pure functions so they're testable in isolation
+// and the two surfaces stay in agreement.
+
+const pathScore = (p: PathfinderPath): number => (Number.isFinite(p.score) ? p.score : -Infinity);
+
+/** Best (rank-1) path for a target: prefer `rank === 1`, else highest score then
+ *  fewest hops. null for an empty list. Never mutates the input (the React Query
+ *  array is shared — sorting a copy). */
+export function resolveBestPath(paths: PathfinderPath[]): PathfinderPath | null {
+  if (!paths.length) return null;
+  return paths.find((p) => p.rank === 1) ?? [...paths].sort((a, b) => pathScore(b) - pathScore(a) || a.hops - b.hops)[0];
+}
+
+/** The connector shown inside the Protocol Labs node. Tagged union so the graph
+ *  renders off a clean discriminant and the "plain Protocol Labs" fallback is a
+ *  representable state, not an implicit null. */
+export type BestConnector =
+  | { kind: 'contact'; contact: PathContact }
+  | { kind: 'org'; org: PathOrgConnector }
+  | { kind: 'none' };
+
+export function resolveBestConnector(path: PathfinderPath | null): BestConnector {
+  if (path?.contact) return { kind: 'contact', contact: path.contact };
+  if (path?.org_connector) return { kind: 'org', org: path.org_connector };
+  return { kind: 'none' };
+}
+
 /** All ranked warm paths for a single target investor (best first). */
 export async function fetchPathsForTarget(investorId: string): Promise<PathsForTargetResponse> {
   const res = await customFetch(

--- a/services/investors/pathfinder.service.ts
+++ b/services/investors/pathfinder.service.ts
@@ -9,6 +9,7 @@ import type {
   PathOrgConnector,
   PathfinderPath,
   PathsForTargetResponse,
+  RouteNode,
 } from './types';
 
 // PL Path Finder read + corrections API. Reuses the Investor DB permissions
@@ -62,8 +63,30 @@ function mapOrgConnector(dto: AnyDto): PathOrgConnector {
   };
 }
 
+function mapRouteNode(dto: AnyDto): RouteNode {
+  return {
+    label: (dto.label ?? '') as string,
+    role: dto.role as string | undefined,
+    email: dto.email as string | undefined,
+    variant: (dto.variant ?? 'external') as 'member' | 'external',
+    imageUrl: (dto.imageUrl ?? dto.image_url) as string | undefined,
+    linkedin: dto.linkedin as string | undefined,
+    memberUid: (dto.memberUid ?? dto.member_uid) as string | undefined,
+    contacts: (dto.contacts as AnyDto[] | undefined)?.map((c) => ({
+      name: (c.name ?? '') as string,
+      role: c.role as string | undefined,
+      email: c.email as string | undefined,
+      source: c.source as string | undefined,
+      imageUrl: (c.imageUrl ?? c.image_url) as string | undefined,
+      linkedin: c.linkedin as string | undefined,
+      memberUid: (c.memberUid ?? c.member_uid) as string | undefined,
+    })),
+  };
+}
+
 function mapHopChain(dto: AnyDto | null | undefined): PathHopChain {
   const nodes = ((dto?.nodes ?? []) as AnyDto[]).map(mapHopNode);
+  const routeNodes = dto?.routeNodes ? ((dto.routeNodes as AnyDto[]).map(mapRouteNode)) : undefined;
   const edges = ((dto?.edges ?? []) as AnyDto[]).map((e) => ({
     from: e.from as string,
     to: e.to as string,
@@ -71,7 +94,7 @@ function mapHopChain(dto: AnyDto | null | undefined): PathHopChain {
     probability: (e.probability ?? 0) as number,
     evidence: (e.evidence ?? null) as string | null,
   }));
-  return { nodes, edges, explanation: (dto?.explanation ?? '') as string };
+  return { nodes, routeNodes, edges, explanation: (dto?.explanation ?? '') as string };
 }
 
 function mapCorrection(dto: AnyDto): PathCorrection {
@@ -90,6 +113,7 @@ export function mapPathfinderPath(dto: AnyDto): PathfinderPath {
   return {
     id: dto.id as number,
     target_investor_id: dto.targetInvestorId as string,
+    target_set: dto.targetSet as string | undefined,
     connector_type: (dto.connectorType ?? 'C') as PathConnectorType,
     hops: (dto.hops ?? 0) as number,
     caliber: (dto.caliber ?? null) as PathCaliber | null,
@@ -119,7 +143,9 @@ const pathScore = (p: PathfinderPath): number => (Number.isFinite(p.score) ? p.s
  *  array is shared — sorting a copy). */
 export function resolveBestPath(paths: PathfinderPath[]): PathfinderPath | null {
   if (!paths.length) return null;
-  return paths.find((p) => p.rank === 1) ?? [...paths].sort((a, b) => pathScore(b) - pathScore(a) || a.hops - b.hops)[0];
+  return (
+    paths.find((p) => p.rank === 1) ?? [...paths].sort((a, b) => pathScore(b) - pathScore(a) || a.hops - b.hops)[0]
+  );
 }
 
 /** The connector shown inside the Protocol Labs node. Tagged union so the graph

--- a/services/investors/types.ts
+++ b/services/investors/types.ts
@@ -326,10 +326,10 @@ export type PathConnectorType = 'F' | 'VC' | 'JB' | 'PL' | 'O' | 'C';
 export type PathCaliber = 'A' | 'B';
 
 export type PathHopNode =
-  | { id: string; label: string; type: 'person'; member_uid: string }  // pl_member — in PL network
-  | { id: string; label: string; type: 'person'; member_uid?: never }  // external_person
-  | { id: string; label: string; type: 'org'; team_uid: string }       // portfolio_org — in PL network
-  | { id: string; label: string; type: 'org'; team_uid?: never };      // vc_org — external firm
+  | { id: string; label: string; type: 'person'; member_uid: string } // pl_member — in PL network
+  | { id: string; label: string; type: 'person'; member_uid?: never } // external_person
+  | { id: string; label: string; type: 'org'; team_uid: string } // portfolio_org — in PL network
+  | { id: string; label: string; type: 'org'; team_uid?: never }; // vc_org — external firm
 
 /** Person to reach when the direct contact is known (additive; from pathfinder v2 API). */
 export type PathContact = {
@@ -363,8 +363,31 @@ export type PathHopEdge = {
   evidence: string | null;
 };
 
+/** A richer path node from the v2 pathfinder API — replaces generic org/person
+ *  labels with actual named people and their contact details. */
+export type RouteNode = {
+  label: string;
+  role?: string;
+  email?: string;
+  variant: 'member' | 'external';
+  imageUrl?: string;
+  linkedin?: string;
+  memberUid?: string;
+  contacts?: Array<{
+    name: string;
+    role?: string;
+    email?: string;
+    source?: string;
+    imageUrl?: string;
+    linkedin?: string;
+    memberUid?: string;
+  }>;
+};
+
 export type PathHopChain = {
   nodes: PathHopNode[];
+  /** Rich per-hop contacts (v2 API). When present, prefer over `nodes` for display. */
+  routeNodes?: RouteNode[];
   edges: PathHopEdge[];
   /** Plain-English description of the path, surfaced in the expanded row. */
   explanation: string;
@@ -374,6 +397,8 @@ export type PathHopChain = {
 export type PathfinderPath = {
   id: number;
   target_investor_id: string;
+  /** Slug of the investor list this path was computed for (e.g. "neuro-fund-i"). */
+  target_set?: string;
   connector_type: PathConnectorType;
   /** Social distance: 1 = direct, 2 = one intermediary, 3 = hard ceiling. */
   hops: number;

--- a/services/investors/types.ts
+++ b/services/investors/types.ts
@@ -168,6 +168,11 @@ export type OutreachInvestor = {
 
   /** Aggregated background + sources ("who is this investor"); null until enriched. */
   enrichment?: InvestorEnrichment | null;
+
+  /** Affinity "Last Email Date" (ISO). Surfaced under the warm-path summary graph
+   *  as a relative time ("last email ~3 weeks ago"). null/undefined until the
+   *  backend sends it — the clause is omitted when absent. */
+  last_email_date?: string | null;
 };
 
 /** A "Network investor" is just an OutreachInvestor with a non-null

--- a/utils/formatTimeAgo.ts
+++ b/utils/formatTimeAgo.ts
@@ -1,9 +1,22 @@
 import { formatDistanceToNow } from 'date-fns';
 
-export function formatTimeAgo(date: string | number): string {
+/**
+ * Abbreviated relative time, e.g. "3min ago", "5h ago", "3 weeks ago".
+ *
+ * Returns '' (so callers can omit the clause) for: null/undefined/empty input,
+ * an unparseable date (`new Date('x')` is Invalid Date — it does NOT throw, so
+ * the try/catch alone wouldn't catch it), and future dates (clock skew / bad
+ * data must never render "in 3 weeks ago").
+ */
+export function formatTimeAgo(date: string | number | null | undefined): string {
+  if (date == null || date === '') return '';
+  const d = new Date(date);
+  const t = d.getTime();
+  if (Number.isNaN(t)) return '';
+  if (t > Date.now()) return '';
   try {
     return (
-      formatDistanceToNow(new Date(date), { addSuffix: false })
+      formatDistanceToNow(d, { addSuffix: false })
         .replace('about ', '')
         .replace('less than a minute', '1min')
         .replace(' minutes', 'min')


### PR DESCRIPTION
## Summary

Iteration on the `/investors` warm-intros view per the latest UX spec and the in-repo prototype `prototypes/entries/warm-intros-filter-update/` (the design source of truth). This PR ships the **no-backend-needed core** (Phases 1–3); the backend-dependent drawer fields (Phase 4) are a deliberate follow-up.

**What's included**

- **Warm-path summary graph** (`PathSummaryGraph`): a compact Protocol Labs node that carries the rank-1 **best connector** inside it → the target investor, with a quiet `tie 0.62 · last email 21d ago` caption. Connector states: known contact (member avatar + link), org connector (logo/link + “?” mark), or plain “Protocol Labs” when none. Hidden when there are no paths.
- **Best-connector resolution** as pure, unit-tested helpers (`resolveBestPath` / `resolveBestConnector` → tagged `BestConnector` union) in `pathfinder.service.ts`. Resolves by `rank === 1` (tiebreak: score → hops), so the graph always matches the rank-1 card.
- **Lighter warm-path cards**: founder/org contact channels collapse behind a **Show contact / Hide contact** disclosure (independent per card, reset on investor switch, hidden when no channels); the “Suggest a correction” text trigger becomes a **corner icon** (`aria-label` + `aria-expanded`) opening the same inline form (hidden when `!canEdit`); smaller connector avatar.
- **Hardened `utils/formatTimeAgo`**: accepts `null`/`undefined`, guards `Invalid Date` (which doesn't throw) and future dates → returns `''` so callers can omit the clause.
- Optional `OutreachInvestor.last_email_date` (ISO) + mapper (graceful default).
