### PR TITLE
fix(investors): match LabOS arrow badge in InvestorDrawer to table

### DIFF
--- a/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.module.scss
@@ -517,8 +517,9 @@
   white-space: nowrap;
 
   &[href]:hover {
-    border-color: #9ca3af;
-    background: #f9fafb;
+    background: #eef2ff;
+    border-color: #1b4dff;
+    color: #1b4dff;
   }
 }
 
@@ -552,6 +553,18 @@
   font-weight: 500;
   color: #0a0c11;
   line-height: 1;
+}
+
+.rnArrow {
+  font-size: 11px;
+  color: #9ca3af;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.12s;
+
+  .rnChip[href]:hover & {
+    color: #1b4dff;
+  }
 }
 
 .showMore {

--- a/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
+++ b/components/page/investors/WarmPathDetail/WarmPathDetail.tsx
@@ -354,6 +354,7 @@ function RouteNodeChip({ node }: { node: RouteNode }) {
     return (
       <Link href={`/members/${node.memberUid}`} className={s.rnChip} target="_blank" rel="noopener noreferrer">
         {inner}
+        <span className={s.rnArrow} aria-hidden>↗</span>
       </Link>
     );
   }


### PR DESCRIPTION
## Summary
- Table path chips (`RouteChip`) show a `↗` arrow + blue hover state for nodes with a LabOS profile.
- `InvestorDrawer`'s warm-path list renders via the richer `RouteNodeChip` (`hop_chain.routeNodes`), which was missing both the arrow and the matching hover treatment.
- Ported the arrow icon and hover colors so drawer badges match the table.

## Test plan
- [ ] Open Warm Intros table, hover/inspect a path chip with a LabOS member — confirm arrow + blue hover.
- [ ] Open the same investor's drawer, confirm the path chip now shows the same arrow and hover state.