### PR TITLE
chore: rename tokens to PLAA on overview and incentive-model

### DIFF
--- a/components/page/aligement-assets/incentive-model/incentive-model.tsx
+++ b/components/page/aligement-assets/incentive-model/incentive-model.tsx
@@ -218,7 +218,7 @@ const CustomTooltip = ({
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           <span style={{ width: '7px', height: '7px', borderRadius: '50%', background: '#156ff7' }} />
           <span style={{ fontSize: '14px', color: '#475569', lineHeight: '20px' }}>
-            {data.tokens.toLocaleString()} AA tokens
+            {data.tokens.toLocaleString()} PLAA
           </span>
         </div>
       </div>
@@ -497,21 +497,21 @@ export default function IncentiveModel() {
           <h1 className="incentive-model__title">Incentive Model</h1>
           <div className="incentive-model__description">
             <p>
-              Each snapshot period, a pool of 10,000 tokens is available to reward participants who complete verified{' '}
+              Each snapshot period, a pool of 10,000 PLAA is available to reward participants who complete verified{' '}
               <Link href="https://directory.plnetwork.io/alignment-asset/activities" className="incentive-model__link" onClick={handleActivitiesLinkClick}>
                 Incentivized Activities
               </Link>
               . Participants collect points for each verified activity they complete during the snapshot period.
             </p>
             <p>
-              Each category receives a fixed allocation of the token pool. At the end of the period, tokens are distributed proportionally based on each participant&apos;s share of the total points collected in a single category—with up to 10,000 tokens allocated among all qualifying contributors.
+              Each category receives a fixed allocation of the PLAA pool. At the end of the period, PLAA is distributed proportionally based on each participant&apos;s share of the total points collected in a single category—with up to 10,000 PLAA allocated among all qualifying contributors.
             </p>
             <p>
-              When more people contribute in the same category, the token pool is more widely distributed; when activity
-              is lower in a category, more tokens are available per contributor.
+              When more people contribute in the same category, the PLAA pool is more widely distributed; when activity
+              is lower in a category, more PLAA is available per contributor.
             </p>
             <p>
-              Available token amounts and allocations for completing incentivized activities may also shift between snapshot periods as the experiment adapts
+              Available PLAA amounts and allocations for completing incentivized activities may also shift between snapshot periods as the experiment adapts
               to network activity and evolving needs.
             </p>
           </div>
@@ -522,7 +522,7 @@ export default function IncentiveModel() {
           <div className="incentive-model__chart-header">
             <div className="incentive-model__chart-info">
               <h2 className="incentive-model__chart-title">
-                Total Alignment Asset Points &amp; Tokens Collected by Category
+                Total Alignment Asset Points &amp; PLAA Collected by category
               </h2>
               <p className="incentive-model__chart-subtitle">
                 Showing data for: {currentRoundInfo?.month || 'February 2025'}
@@ -652,7 +652,7 @@ export default function IncentiveModel() {
               </div>
               <div className="incentive-model__legend-item">
                 <span className="incentive-model__legend-box incentive-model__legend-box--tokens" />
-                <span className="incentive-model__legend-text">Tokens</span>
+                <span className="incentive-model__legend-text">PLAA</span>
               </div>
           </div>
         {/* Chart and Legend Section */}
@@ -699,15 +699,15 @@ export default function IncentiveModel() {
             {/* Explanation List */}
             <ol className="incentive-model__explanation">
               <li>
-                Each category shows the points collected and tokens distributed for the selected month&apos;s snapshot.
+                Each category shows the points collected and PLAA distributed for the selected month&apos;s snapshot.
               </li>
               <li>
-                More points collected in a category = fewer tokens allocated per contributor in that category. Lower
-                activity in a category = larger token amounts per contributor.
+                More points collected in a category = fewer PLAA allocated per contributor in that category. Lower
+                activity in a category = larger PLAA amounts per contributor.
               </li>
               <li>
                 Toggle between months (and rounds) to see how activity and allocations shift over time, and hover over
-                any point to view exact values. Green = points; blue = tokens.
+                any point to view exact values. Green = points; blue = PLAA.
               </li>
             </ol>
 
@@ -722,7 +722,7 @@ export default function IncentiveModel() {
                 <Link href="/alignment-asset" className="incentive-model__tip-link" onClick={handleTipViewLinkClick}>
                   View
                 </Link>{' '}
-                which categories offer the highest token potential today.
+                which categories offer the highest PLAA potential today.
               </p>
             </div>
           </div>
@@ -741,7 +741,7 @@ export default function IncentiveModel() {
                 >
                   Learn more
                 </Link>
-                <span className="incentive-model__learn-more-body"> about how points convert to tokens</span>
+                <span className="incentive-model__learn-more-body"> about how points convert to PLAA</span>
               </p>
             </div>
           </div>

--- a/components/page/aligement-assets/overview/overview-page.tsx
+++ b/components/page/aligement-assets/overview/overview-page.tsx
@@ -20,7 +20,7 @@ const whyItems = [
     description: 'Your contributions become visible and valued across the ecosystem.',
   },
   {
-    title: 'Collect points that can convert to tokens for verified activities.',
+    title: 'Collect points that can convert to PLAA for verified activities.',
     description: 'Turn meaningful work into measurable outcomes.',
   },
   {
@@ -43,9 +43,9 @@ const whoRoles = [
 
 // Important details data
 const importantDetails = [
-  'Tokens are distributed based on verified contributions across the network.',
-  'Each category has a fixed token allocation.',
-  'All tokens are issued and managed by the trust.',
+  'PLAA are distributed based on verified contributions across the network.',
+  'Each category has a fixed PLAA allocation.',
+  'All PLAA is issued and managed by the trust.',
 ];
 
 // How section data
@@ -68,14 +68,14 @@ const howItems = [
     number: 3,
     title: 'Convert',
     description:
-      'Points may be converted into PLAA1 tokens issued by Surus Trust Company — providing tangible value tied to your contributions.',
+      'Points may be converted into PLAA issued by Surus Trust Company — providing tangible value tied to your contributions.',
     width: 'narrow',
   },
   {
     number: 4,
     title: 'Capitalize',
     description:
-      'Periodic token buyback auctions allow the Trust to purchase tokens, turning collective progress into value and rewarding participants over time.',
+      'Periodic buyback auctions allow the Trust to purchase PLAA, turning collective progress into value and rewarding participants over time.',
     width: 'wide',
   },
 ];
@@ -332,7 +332,7 @@ const Overview = () => {
               <span className="overview__content__how__learn-more__text">Learn more:</span>
               <p>
               Read the{' '}
-              <a href="/alignment-asset/faqs" className="overview__content__text__link" onClick={handleFaqLinkClick}>FAQ</a> for details on contributions, points, and tokens.
+              <a href="/alignment-asset/faqs" className="overview__content__text__link" onClick={handleFaqLinkClick}>FAQ</a> for details on contributions, points, and PLAA.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Aligns user-facing copy with the Content Update source of truth: shifts wording from "tokens" to "PLAA".

- Overview: 'tokens'/'PLAA1 tokens' -> 'PLAA'
- Incentive Model: 'tokens'/'AA tokens' -> 'PLAA'; 'by Category' -> 'by category'

Visible copy only (data keys/identifiers unchanged). Activities page has no token wording.
Target: release/plaa-v7.4 (UAT).