### PR TITLE
Fix team follow button/followers exclusivity and follower avatars

### DIFF
--- a/components/page/team-details/TeamDetails/TeamDetails.tsx
+++ b/components/page/team-details/TeamDetails/TeamDetails.tsx
@@ -85,8 +85,8 @@ export const TeamDetails = (props: Props) => {
     handleToggle: onFollowToggle,
   } = useTeamFollowToggle(team, team.isFollowed ?? false);
 
-  const showFollowButton = !isCurrentUserTeamMember;
   const showFollowers = isCurrentUserTeamMember || isAdmin;
+  const showFollowButton = !showFollowers;
 
   const followContent = (
     <>

--- a/components/page/team-details/TeamFollowBlock/TeamFollowBlock.module.scss
+++ b/components/page/team-details/TeamFollowBlock/TeamFollowBlock.module.scss
@@ -45,24 +45,6 @@
   }
 }
 
-.subAvatarFallback {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 2px solid #fff;
-  background: var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--foreground-neutral-secondary, #455468);
-
-  & + & {
-    margin-left: -10px;
-  }
-}
-
 .subAvatarPlaceholder {
   width: 28px;
   height: 28px;

--- a/components/page/team-details/TeamFollowBlock/TeamFollowBlock.tsx
+++ b/components/page/team-details/TeamFollowBlock/TeamFollowBlock.tsx
@@ -4,13 +4,32 @@ import { useState } from 'react';
 import Image from 'next/image';
 
 import { ITeam } from '@/types/teams.types';
-import type { ITeamFollowersResponse } from '@/types/follow.types';
+import type { ITeamFollowersResponse, ITeamFollower } from '@/types/follow.types';
 import { useTeamFollowers } from '@/services/follow/hooks/useTeamFollowers';
 import { useTeamAnalytics } from '@/analytics/teams.analytics';
 import { Tooltip } from '@/components/core/tooltip/tooltip';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 
 import { TeamFollowersModal } from './TeamFollowersModal';
 import s from './TeamFollowBlock.module.scss';
+
+const FollowerAvatar = ({ follower, className }: { follower: ITeamFollower; className: string }) => {
+  const defaultAvatarImage = getDefaultAvatar(follower.name);
+
+  return (
+    <img
+      key={follower.uid}
+      className={className}
+      src={follower.image || defaultAvatarImage}
+      alt=""
+      loading="lazy"
+      onError={(e) => {
+        e.currentTarget.onerror = null;
+        e.currentTarget.src = defaultAvatarImage;
+      }}
+    />
+  );
+};
 
 interface TeamFollowBlockProps {
   team: ITeam;
@@ -45,15 +64,7 @@ export function TeamFollowBlock({ team, initialFollowers }: TeamFollowBlockProps
       >
         <span className={s.subAvatars} aria-hidden="true">
           {previewAvatars.length > 0
-            ? previewAvatars.map((f) =>
-                f.image ? (
-                  <img key={f.uid} className={s.subAvatar} src={f.image} alt="" loading="lazy" />
-                ) : (
-                  <span key={f.uid} className={s.subAvatarFallback}>
-                    {f.name.charAt(0).toUpperCase()}
-                  </span>
-                ),
-              )
+            ? previewAvatars.map((f) => <FollowerAvatar key={f.uid} follower={f} className={s.subAvatar} />)
             : Array.from({ length: Math.min(followerCount, 3) }).map((_, i) => (
                 <span key={i} className={s.subAvatarPlaceholder} />
               ))}

--- a/components/page/team-details/TeamFollowBlock/TeamFollowersModal.module.scss
+++ b/components/page/team-details/TeamFollowBlock/TeamFollowersModal.module.scss
@@ -65,10 +65,6 @@
 }
 
 .row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
   border-radius: 8px;
 
   &:hover {
@@ -76,25 +72,20 @@
   }
 }
 
+.rowLink {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
 .rowAvatar {
   width: 32px;
   height: 32px;
   border-radius: 50%;
   object-fit: cover;
-  flex-shrink: 0;
-}
-
-.rowAvatarFallback {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: var(--border-neutral-subtle);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--foreground-neutral-secondary);
   flex-shrink: 0;
 }
 

--- a/components/page/team-details/TeamFollowBlock/TeamFollowersModal.tsx
+++ b/components/page/team-details/TeamFollowBlock/TeamFollowersModal.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import Link from 'next/link';
+
 import { Modal } from '@/components/common/Modal';
 import { useTeamFollowers } from '@/services/follow/hooks/useTeamFollowers';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import { PAGE_ROUTES } from '@/utils/constants';
 import s from './TeamFollowersModal.module.scss';
 
 interface TeamFollowersModalProps {
@@ -46,21 +50,30 @@ export function TeamFollowersModal({ teamUid, isOpen, onClose }: TeamFollowersMo
 
       {!isLoading && data && data.items.length > 0 && (
         <ul className={s.list}>
-          {data.items.map((follower) => (
-            <li key={follower.uid} className={s.row}>
-              {follower.image ? (
-                <img className={s.rowAvatar} src={follower.image} alt="" loading="lazy" />
-              ) : (
-                <div className={s.rowAvatarFallback} aria-hidden="true">
-                  {follower.name.charAt(0).toUpperCase()}
-                </div>
-              )}
-              <div className={s.rowText}>
-                <span className={s.rowName}>{follower.name}</span>
-                {follower.role && <span className={s.rowRole}>{follower.role}</span>}
-              </div>
-            </li>
-          ))}
+          {data.items.map((follower) => {
+            const defaultAvatarImage = getDefaultAvatar(follower.name);
+
+            return (
+              <li key={follower.uid} className={s.row}>
+                <Link href={`${PAGE_ROUTES.MEMBERS}/${follower.uid}`} className={s.rowLink} onClick={onClose}>
+                  <img
+                    className={s.rowAvatar}
+                    src={follower.image || defaultAvatarImage}
+                    alt=""
+                    loading="lazy"
+                    onError={(e) => {
+                      e.currentTarget.onerror = null;
+                      e.currentTarget.src = defaultAvatarImage;
+                    }}
+                  />
+                  <div className={s.rowText}>
+                    <span className={s.rowName}>{follower.name}</span>
+                    {follower.role && <span className={s.rowRole}>{follower.role}</span>}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       )}
     </Modal>


### PR DESCRIPTION
## Summary
- Hide the Follow button whenever the viewer is eligible to see the follower list (team members/admins), so the two never show at once.
- Follower avatars (in the header preview stack and the followers modal) now show the real image when present, falling back to the app's standard dicebear placeholder (with `onError` swap for broken URLs) instead of a hand-rolled letter initial.
- Clicking a follower row in the followers modal now navigates to that member's profile page.

## Test plan
- [ ] As a non-member/non-admin viewer, confirm the Follow button shows and the followers count/stack is hidden.
- [ ] As a team member or admin, confirm the followers stack/count shows and the Follow button is hidden.
- [ ] Open the followers modal and verify avatars render as images (real photo or generated placeholder), not letter initials.
- [ ] Click a follower row in the modal and confirm it navigates to `/members/{uid}` and closes the modal.