### PR TITLE
LAB-2088 [Digest] Add toggle to disable network news in digest email

### DIFF
--- a/analytics/settings.analytics.ts
+++ b/analytics/settings.analytics.ts
@@ -198,6 +198,10 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_SAVE_FAILED, params);
   }
 
+  function onForumDigestNetworkNewsToggleClicked(params: Record<any, boolean>) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_NETWORK_NEWS_TOGGLE_CLICKED, params);
+  }
+
   function onSubscribeToPlNewsletterChange(params: Record<any, boolean>) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_SUBSCRIBE_TO_NEWSLETTER_CHANGE, params);
   }
@@ -236,6 +240,7 @@ export const useSettingsAnalytics = () => {
     onRecommendationEmailFeedbackClicked,
     onForumDigestOptionSelect,
     onForumDigestSaveFailed,
+    onForumDigestNetworkNewsToggleClicked,
     onSubscribeToPlNewsletterChange,
     onSubscribeToDemoDayUpdatesChange,
     onDemoDayUpdatesNotificationToggleClicked,

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.module.scss
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.module.scss
@@ -1,4 +1,5 @@
 @import 'components/form/FormSelect/FormSelect.module.scss';
+@import 'components/form/FormSwitch/FormSwitch.module';
 
 .root {
   display: flex;
@@ -39,4 +40,38 @@
   align-items: flex-start;
   gap: var(--spacing-sm, 12px);
   align-self: stretch;
+}
+
+.toggleSection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-4xs, 4px);
+  align-self: stretch;
+
+  padding: var(--spacing-md, 16px);
+  border-radius: var(--corner-radius-xl, 12px);
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  background: var(--background-base-white, #fff);
+}
+
+.toggle {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  color: var(--foreground-neutral-secondary, #455468);
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 24px; /* 150% */
+  letter-spacing: -0.3px;
+}
+
+.desc {
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 22px; /* 157.143% */
+  letter-spacing: -0.2px;
 }

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
@@ -6,6 +6,7 @@ import s from './ForumDigest.module.scss';
 import { ForumDigestSettings, useGetForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import { IUserInfo } from '@/types/shared.types';
 import { Field } from '@base-ui-components/react/field';
+import { Switch } from '@base-ui-components/react/switch';
 import { clsx } from 'clsx';
 import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
 import dynamic from 'next/dynamic';
@@ -141,6 +142,22 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
     }
   };
 
+  const handleNewsChange = (checked: boolean) => {
+    if (!userInfo.uid || !data) {
+      return;
+    }
+
+    mutate({
+      uid: userInfo.uid,
+      payload: {
+        ...data,
+        forumDigestNewsEnabled: checked,
+      },
+    });
+
+    analytics.onForumDigestNetworkNewsToggleClicked({ forumDigestNewsEnabled: checked });
+  };
+
   return (
     <div className={s.root}>
       <div className={s.header}>Forum Digest</div>
@@ -246,6 +263,25 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
             }}
           />
         </Field.Root>
+        {data?.forumDigestEnabled && (
+          <div className={s.toggleSection}>
+            <label className={clsx(s.Label, s.toggle)}>
+              Include Network News
+              <Switch.Root
+                className={s.Switch}
+                checked={data?.forumDigestNewsEnabled ?? true}
+                onCheckedChange={handleNewsChange}
+              >
+                <Switch.Thumb className={s.Thumb}>
+                  <div className={s.dot} />
+                </Switch.Thumb>
+              </Switch.Root>
+            </label>
+            <div className={s.desc}>
+              Get the latest news from teams across the network included in your digest email.
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/services/forum/hooks/useGetForumDigestSettings.ts
+++ b/services/forum/hooks/useGetForumDigestSettings.ts
@@ -5,6 +5,7 @@ import { ForumQueryKeys } from '@/services/forum/constants';
 export type ForumDigestSettings = {
   forumDigestEnabled: boolean;
   forumDigestFrequency: 1 | 7;
+  forumDigestNewsEnabled: boolean;
   forumDigestLastSentAt: null;
   memberExternalId: null;
   memberUid: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -217,6 +217,7 @@ export const SETTINGS_ANALYTICS_EVENTS = {
   SETTINGS_SUBSCRIBE_TO_NEWSLETTER_CHANGE: 'settings-subscribe-to-newsletter-change',
   FORUM_DIGEST_OPTION_SELECTED: 'settings-forum-digest-option-selected',
   FORUM_DIGEST_SAVE_FAILED: 'settings-forum-digest-save-failed',
+  FORUM_DIGEST_NETWORK_NEWS_TOGGLE_CLICKED: 'settings-forum-digest-network-news-toggle-clicked',
   SETTINGS_SUBSCRIBE_TO_DEMO_DAY_UPDATES_CHANGE: 'settings-subscribe-to-demo-day-updates-change',
   SETTINGS_DEMO_DAY_UPDATES_NOTIFICATION_TOGGLE_CLICKED: 'settings-demo-day-updates-notification-toggle-clicked',
 };


### PR DESCRIPTION
## Ticket

[LAB-2088](https://linear.app/plrs-labos/issue/LAB-2088/digest-add-toggle-to-disable-network-news-in-digest-email)

### Screenshot

<img width="703" height="513" alt="Screenshot 2026-07-06 at 1 06 39 PM" src="https://github.com/user-attachments/assets/eef3e6ea-b3c5-4064-8048-5ec49721e9a3" />
