### PR TITLE
Copy and digest card fixes

### DIFF
--- a/prototypes/entries/follow-shared/FollowButton.module.scss
+++ b/prototypes/entries/follow-shared/FollowButton.module.scss
@@ -53,6 +53,17 @@
   }
 }
 
+// Follow (not-following) tertiary reads as a brand-blue CTA; the following
+// state keeps the quiet grey above.
+.tertiary.tertiaryFollow {
+  color: var(--foreground-brand-primary, #1b4dff);
+
+  &:hover {
+    color: var(--foreground-brand-primary, #1b4dff);
+    background: var(--transparent-brand-8, rgba(27, 77, 255, 0.08));
+  }
+}
+
 .icon {
   display: inline-flex;
   align-items: center;

--- a/prototypes/entries/follow-shared/FollowButton.tsx
+++ b/prototypes/entries/follow-shared/FollowButton.tsx
@@ -65,7 +65,12 @@ export function FollowButton({
         style={btnStyle}
         variant={btnVariant}
         underline={false}
-        className={clsx(s.btn, { [s.blockBtn]: block, [s.tertiary]: tertiary, [s.glossy]: glossy && !following && !secondary })}
+        className={clsx(s.btn, {
+          [s.blockBtn]: block,
+          [s.tertiary]: tertiary,
+          [s.tertiaryFollow]: tertiary && !following,
+          [s.glossy]: glossy && !following && !secondary,
+        })}
         onClick={onClick}
         aria-haspopup={following && caret ? 'menu' : undefined}
         aria-expanded={following && caret ? menuExpanded : undefined}

--- a/prototypes/entries/newsfeed-v0/DigestBanner.tsx
+++ b/prototypes/entries/newsfeed-v0/DigestBanner.tsx
@@ -13,9 +13,10 @@ interface Props {
 
 /**
  * Rail module: the network-news email digest, in two states.
- *  - Not subscribed → the gradient promo banner (from the In-App Notifications
- *    design, Figma node 1106:19180: brand-blue gradient, white title/subtitle,
- *    full-width white "Subscribe for Digest" DS button).
+ *  - Not subscribed → a low-key subscribe banner: soft brand tint, dark
+ *    title/subtitle, and a full-width filled-brand "Subscribe for Digest" DS
+ *    button that carries the emphasis (toned down from the original loud
+ *    brand-blue gradient promo).
  *  - Already subscribed → the same banner shape, greyed out, pointing to
  *    Settings (production's real digest control lives in Settings › email
  *    preferences) — no pitch spent on something they already have.
@@ -51,18 +52,17 @@ export function DigestBanner({ subscribed, onToggle }: Props) {
     <section className={local.digestPromo} aria-label="Subscribe to the news digest">
       <div className={local.digestPromoText}>
         <p className={local.digestPromoTitle}>Get notified about network news updates</p>
-        <p className={local.digestPromoBody}>A digest of raises, launches, and milestones from across the network, straight to your inbox.</p>
+        <p className={local.digestPromoBody}>A news digest covering raises, launches, and milestones across the network, straight to your inbox.</p>
       </div>
       <Button
         size="s"
-        style="border"
-        variant="neutral"
+        style="fill"
+        variant="primary"
         underline={false}
         className={local.digestPromoBtn}
         onClick={onToggle}
       >
         <span>Subscribe for Digest</span>
-        <ArrowRight />
       </Button>
     </section>
   );

--- a/prototypes/entries/newsfeed-v0/HeaderSearch.tsx
+++ b/prototypes/entries/newsfeed-v0/HeaderSearch.tsx
@@ -35,7 +35,7 @@ export function HeaderSearch({ open, value, onOpen, onChange, onBlur, fieldRef }
 
   return (
     <div className={local.headerSearchField} ref={fieldRef} onBlur={onBlur}>
-      <SearchInput value={value} onChange={onChange} placeholder="Search news, teams…" />
+      <SearchInput value={value} onChange={onChange} placeholder="Search by team or keyword…" />
     </div>
   );
 }

--- a/prototypes/entries/newsfeed-v0/NewsfeedV0.module.scss
+++ b/prototypes/entries/newsfeed-v0/NewsfeedV0.module.scss
@@ -336,17 +336,17 @@
 }
 
 /* ---------- Digest subscribe banner (fills V0's rail) ----------
-   Gradient promo from the In-App Notifications design (Figma node 1106:19180):
-   vertical brand-blue gradient, white title + subtitle, full-width white DS
-   button. The two gradient stops are the design's own literal blues. */
+   Toned down from the original brand-blue gradient promo: a soft brand tint with
+   a subtle brand border and dark text, so it reads as a quiet rail module rather
+   than a loud ad. The filled-brand DS button carries the emphasis instead. */
 .digestPromo {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 20px;
   padding: 20px;
   border-radius: 16px;
-  background: linear-gradient(180deg, #204bba 8%, #156ff7 66%);
-  box-shadow: 0 1px 1px 0 var(--transparent-dark-6, rgba(14, 15, 17, 0.06));
+  background: var(--transparent-brand-8, rgba(27, 77, 255, 0.06));
+  border: 1px solid var(--transparent-brand-16, rgba(27, 77, 255, 0.16));
 }
 
 .digestPromoText {
@@ -361,7 +361,7 @@
   line-height: 24px;
   font-weight: 600;
   letter-spacing: -0.4px;
-  color: #fff;
+  color: var(--foreground-neutral-primary, #0a0c11);
 }
 
 .digestPromoBody {
@@ -369,11 +369,11 @@
   font-size: 14px;
   line-height: 20px;
   letter-spacing: -0.2px;
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--foreground-neutral-secondary, #455468);
 }
 
-/* Full-width white pill — the DS border/neutral Button supplies bg, border,
-   #455468 text and the inset shadow; this just makes it fill and center. */
+/* Full-width filled-brand pill — the DS fill/primary Button supplies the brand
+   bg and white text; this just makes it fill and center. */
 .digestPromoBtn.digestPromoBtn {
   width: 100%;
   display: flex;

--- a/prototypes/entries/newsfeed-v0/NewsfeedV0Prototype.tsx
+++ b/prototypes/entries/newsfeed-v0/NewsfeedV0Prototype.tsx
@@ -320,7 +320,7 @@ export default function NewsfeedV0Prototype() {
             {/* Mobile only: the header has no room to expand inline, so the field
                 lives here as a permanent full-width row. Hidden on desktop. */}
             <div className={local.mobileSearchRow}>
-              <SearchInput value={query} onChange={handleSearch} placeholder="Search news, teams…" />
+              <SearchInput value={query} onChange={handleSearch} placeholder="Search by team or keyword…" />
             </div>
 
             {/* Constrain the tabs' underline to end at the news-card's right edge

--- a/prototypes/entries/newsfeed-v0/WhyFollowBanner.tsx
+++ b/prototypes/entries/newsfeed-v0/WhyFollowBanner.tsx
@@ -20,7 +20,7 @@ export function WhyFollowBanner() {
       </span>
       <header className={s.head}>
         <p className={local.railBlockTitle}>Stay in the loop</p>
-        <p className={s.lede}>Follow a team to pull its latest news and updates to the top of your feed.</p>
+        <p className={s.lede}>Follow teams to receive updates and announcements.</p>
       </header>
     </section>
   );


### PR DESCRIPTION
- Fixed search placeholder copy to “Search by team…”
- Changed the "Subscribe" card design to have a little less emphasis
- Changed copy for subscribe tile: news digest covering raises, launches…
- Removed arrow from Subscribe to Digest button
- Changed stay in the loop tile description to: follow teams to receive updates and announcements