### PR TITLE
feat: PostHog analytics for TeamNews search + digest subscribe fixes

### DIFF
--- a/__tests__/page/email-preferences/forum-digest.test.tsx
+++ b/__tests__/page/email-preferences/forum-digest.test.tsx
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ForumDigest } from '@/components/page/email-preferences/components/ForumDigest/ForumDigest';
+import type { ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
+import type { IUserInfo } from '@/types/shared.types';
+
+// react-select wrapped in next/dynamic({ ssr: false }) is complex to drive
+// through its real portal-rendered dropdown in jsdom. Mocked here with a
+// synchronous stub exposing each option as a plain button — these tests cover
+// handleChange's branches and analytics wiring, not react-select's own UI.
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => require('react-select').default,
+}));
+
+jest.mock('react-select', () => ({
+  __esModule: true,
+  default: ({
+    options,
+    onChange,
+  }: {
+    options: Array<{ label: string; value: string }>;
+    onChange: (value: { label: string; value: string }) => void;
+  }) => (
+    <div>
+      {options.map((opt) => (
+        <button key={opt.value} type="button" onClick={() => onChange(opt)}>
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const mockMutate = jest.fn();
+jest.mock('@/services/forum/hooks/useUpdateForumDigestSettings', () => ({
+  useUpdateForumDigestSettings: () => ({ mutate: mockMutate }),
+}));
+
+const mockGetForumDigestSettings = jest.fn();
+jest.mock('@/services/forum/hooks/useGetForumDigestSettings', () => ({
+  useGetForumDigestSettings: (...args: unknown[]) => mockGetForumDigestSettings(...args),
+}));
+
+const mockOnForumDigestOptionSelect = jest.fn();
+const mockOnForumDigestSaveFailed = jest.fn();
+jest.mock('@/analytics/settings.analytics', () => ({
+  useSettingsAnalytics: () => ({
+    onForumDigestOptionSelect: (...a: unknown[]) => mockOnForumDigestOptionSelect(...a),
+    onForumDigestSaveFailed: (...a: unknown[]) => mockOnForumDigestSaveFailed(...a),
+    onForumDigestNetworkNewsToggleClicked: jest.fn(),
+  }),
+}));
+
+const userInfo: IUserInfo = { uid: 'user-1' };
+
+const baseData: ForumDigestSettings = {
+  forumDigestEnabled: false,
+  forumDigestFrequency: 7,
+  forumDigestNewsEnabled: false,
+  forumDigestLastSentAt: null,
+  memberExternalId: null,
+  memberUid: 'user-1',
+};
+
+describe('ForumDigest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetForumDigestSettings.mockReturnValue({ data: baseData });
+  });
+
+  describe.each([
+    ['No Digest', 'no_digest'],
+    ['Daily Digest', 'daily'],
+    ['Weekly Digest', 'weekly'],
+  ])('%s branch', (optionLabel, attemptedFrequency) => {
+    it('calls mutate with the expected payload', () => {
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      fireEvent.click(screen.getByRole('button', { name: optionLabel }));
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onForumDigestOptionSelect(source: settings) on success, and not onForumDigestSaveFailed', () => {
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      fireEvent.click(screen.getByRole('button', { name: optionLabel }));
+
+      const options = mockMutate.mock.calls[0][1];
+      options.onSuccess();
+
+      expect(mockOnForumDigestOptionSelect).toHaveBeenCalledWith(expect.objectContaining({ source: 'settings' }));
+      expect(mockOnForumDigestSaveFailed).not.toHaveBeenCalled();
+    });
+
+    it('fires onForumDigestSaveFailed(source: settings) on failure, and not onForumDigestOptionSelect', () => {
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      fireEvent.click(screen.getByRole('button', { name: optionLabel }));
+
+      const options = mockMutate.mock.calls[0][1];
+      options.onError();
+
+      expect(mockOnForumDigestSaveFailed).toHaveBeenCalledWith({ attemptedFrequency, source: 'settings' });
+      expect(mockOnForumDigestOptionSelect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/page/home/news-rail.test.tsx
+++ b/__tests__/page/home/news-rail.test.tsx
@@ -71,7 +71,7 @@ describe('NewsRail', () => {
     expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
   });
 
-  it('calls the forum-digest mutation with weekly frequency when an authenticated user subscribes', () => {
+  it('calls the forum-digest mutation with weekly frequency when an authenticated user subscribes, and fires onForumDigestOptionSelect(source: home-feed) once it succeeds', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
     mockUseForumAccess.mockReturnValue({ hasAccess: true, isLoading: false });
     mockGetForumDigestSettings.mockReturnValue({
@@ -87,9 +87,32 @@ describe('NewsRail', () => {
       },
       expect.anything(),
     );
+
+    // mockMutate is a bare jest.fn() — it doesn't auto-invoke onSuccess/onError,
+    // so the mutation's outcome must be simulated manually.
+    const options = mockMutate.mock.calls[0][1];
+    options.onSuccess();
+
     expect(mockOnForumDigestOptionSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ forumDigestEnabled: true, forumDigestFrequency: 7 }),
+      expect.objectContaining({ forumDigestEnabled: true, forumDigestFrequency: 7, source: 'home-feed' }),
     );
+    expect(mockOnForumDigestSaveFailed).not.toHaveBeenCalled();
+  });
+
+  it('fires onForumDigestSaveFailed(source: home-feed) on mutation failure, and does not also fire onForumDigestOptionSelect', () => {
+    mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
+    mockUseForumAccess.mockReturnValue({ hasAccess: true, isLoading: false });
+    mockGetForumDigestSettings.mockReturnValue({
+      data: { forumDigestEnabled: false, forumDigestFrequency: 7, memberUid: 'user-1' },
+    });
+    render(<NewsRail />);
+    fireEvent.click(screen.getByRole('button', { name: 'Subscribe for Digest' }));
+
+    const options = mockMutate.mock.calls[0][1];
+    options.onError();
+
+    expect(mockOnForumDigestSaveFailed).toHaveBeenCalledWith({ attemptedFrequency: 'weekly', source: 'home-feed' });
+    expect(mockOnForumDigestOptionSelect).not.toHaveBeenCalled();
   });
 
   it('shows the subscribed card with a link to Settings once forumDigestEnabled is true, instead of the promo card', () => {

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -18,6 +18,7 @@ const mockOnTabClicked = jest.fn();
 const mockOnCategoryClicked = jest.fn();
 const mockOnLoadMoreClicked = jest.fn();
 const mockOnCardClicked = jest.fn();
+const mockOnTeamNewsSearch = jest.fn();
 
 jest.mock('@/analytics/team-news.analytics', () => ({
   useTeamNewsAnalytics: () => ({
@@ -25,6 +26,7 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsCategoryClicked: (...a: unknown[]) => mockOnCategoryClicked(...a),
     onTeamNewsLoadMoreClicked: (...a: unknown[]) => mockOnLoadMoreClicked(...a),
     onTeamNewsCardClicked: (...a: unknown[]) => mockOnCardClicked(...a),
+    onTeamNewsSearch: (...a: unknown[]) => mockOnTeamNewsSearch(...a),
   }),
 }));
 
@@ -513,6 +515,83 @@ describe('TeamNews', () => {
       act(() => jest.advanceTimersByTime(700));
       expect(getMobileInput()).toHaveValue('lattice');
       expect(screen.getByRole('link', { name: 'Lattice Compute' })).toBeInTheDocument();
+      jest.useRealTimers();
+    });
+
+    it('fires onTeamNewsSearch once the debounce settles, with the typed value, narrowed result count, and current tab/category', () => {
+      jest.useFakeTimers();
+      renderTeamNews(<TeamNews groups={searchGroups} />);
+      fireEvent.change(getMobileInput(), { target: { value: 'lattice' } });
+      act(() => jest.advanceTimersByTime(700));
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledWith('lattice', 1, 'All', 'all');
+      jest.useRealTimers();
+    });
+
+    it('does not fire onTeamNewsSearch when the query is cleared', () => {
+      jest.useFakeTimers();
+      renderTeamNews(<TeamNews groups={searchGroups} />);
+      const input = getMobileInput();
+      fireEvent.change(input, { target: { value: 'lattice' } });
+      act(() => jest.advanceTimersByTime(700));
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledTimes(1);
+
+      fireEvent.change(input, { target: { value: '' } });
+      act(() => jest.advanceTimersByTime(700));
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledTimes(1); // still just the one call from above
+      jest.useRealTimers();
+    });
+
+    it('does not re-fire onTeamNewsSearch merely from switching tabs with an already-set query', () => {
+      jest.useFakeTimers();
+      const dhrAcme = { ...acme, uid: 'acme-dhr', focusAreas: ['Digital Human Rights'] };
+      const groupsWithTabs: ITeamNewsGroup[] = [
+        { focusArea: FA_AI, total: 3, items: [lattice, acme, filecoin] },
+        { focusArea: FA_DHR, total: 1, items: [dhrAcme] },
+      ];
+      renderTeamNews(<TeamNews groups={groupsWithTabs} />);
+      fireEvent.change(getMobileInput(), { target: { value: 'acme' } });
+      act(() => jest.advanceTimersByTime(700));
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledTimes(1); // tab switch alone must not trigger a second call
+      jest.useRealTimers();
+    });
+
+    it('reports resultCount/currentTab scoped to the tab active when the search fires, not the tab at mount (latest-ref correctness)', () => {
+      jest.useFakeTimers();
+      const dhrOnly = {
+        ...makeItem('dhr-unique', 'MILESTONE', ['Digital Human Rights']),
+        teamUid: 'team-dhr-only',
+        teamName: 'DHR Only Team',
+        tags: ['unique-dhr-tag'],
+      };
+      const groupsWithTabs: ITeamNewsGroup[] = [
+        { focusArea: FA_AI, total: 3, items: [lattice, acme, filecoin] },
+        { focusArea: FA_DHR, total: 1, items: [dhrOnly] },
+      ];
+      renderTeamNews(<TeamNews groups={groupsWithTabs} />);
+
+      // Switch to the DHR tab BEFORE searching — the search's resultCount/tab
+      // should reflect DHR, not the AI/"All" tab active when the component mounted.
+      fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
+      fireEvent.change(getMobileInput(), { target: { value: 'unique-dhr-tag' } });
+      act(() => jest.advanceTimersByTime(700));
+
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledWith('unique-dhr-tag', 1, 'Digital Human Rights', 'all');
+      jest.useRealTimers();
+    });
+
+    it('truncates searchValue to 100 characters before reporting it', () => {
+      jest.useFakeTimers();
+      renderTeamNews(<TeamNews groups={searchGroups} />);
+      const longQuery = 'a'.repeat(150);
+      fireEvent.change(getMobileInput(), { target: { value: longQuery } });
+      act(() => jest.advanceTimersByTime(700));
+
+      expect(mockOnTeamNewsSearch).toHaveBeenCalledWith(longQuery.slice(0, 100), 0, 'All', 'all');
+      const [reportedValue] = mockOnTeamNewsSearch.mock.calls[0];
+      expect(reportedValue).toHaveLength(100);
       jest.useRealTimers();
     });
   });

--- a/analytics/settings.analytics.ts
+++ b/analytics/settings.analytics.ts
@@ -2,6 +2,13 @@ import { IAnalyticsUserInfo } from '@/types/shared.types';
 import { SETTINGS_ANALYTICS_EVENTS } from '@/utils/constants';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { usePostHog } from 'posthog-js/react';
+import type { ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
+
+export type ForumDigestAnalyticsSource = 'home-feed' | 'settings';
+
+export interface ForumDigestOptionSelectParams extends ForumDigestSettings {
+  source: ForumDigestAnalyticsSource;
+}
 
 export const useSettingsAnalytics = () => {
   const postHogProps = usePostHog();
@@ -190,11 +197,11 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.RECOMMENDATION_EMAIL_FEEDBACK_CLICKED, params);
   }
 
-  function onForumDigestOptionSelect(params: any) {
+  function onForumDigestOptionSelect(params: ForumDigestOptionSelectParams) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_OPTION_SELECTED, params);
   }
 
-  function onForumDigestSaveFailed(params: { attemptedFrequency: string }) {
+  function onForumDigestSaveFailed(params: { attemptedFrequency: string; source: ForumDigestAnalyticsSource }) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_SAVE_FAILED, params);
   }
 

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -122,6 +122,22 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
+  const onTeamNewsSearch = (
+    searchValue: string,
+    resultCount: number,
+    currentTab: string,
+    currentCategory: string,
+    source: TeamNewsAnalyticsSource = 'home',
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_SEARCH_REQUESTED, {
+      searchValue,
+      resultCount,
+      currentTab,
+      currentCategory,
+      source,
+    });
+  };
+
   return {
     onTeamNewsTabClicked,
     onTeamNewsCategoryClicked,
@@ -130,5 +146,6 @@ export const useTeamNewsAnalytics = () => {
     onTeamNewsCardClicked,
     onTeamNewsStartConversationClicked,
     onTeamNewsJoinDiscussionClicked,
+    onTeamNewsSearch,
   };
 };

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
@@ -82,13 +82,14 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
           payload: _payload,
         },
         {
+          onSuccess: () => {
+            analytics.onForumDigestOptionSelect({ ..._payload, source: 'settings' });
+          },
           onError: () => {
-            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'no_digest' });
+            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'no_digest', source: 'settings' });
           },
         },
       );
-
-      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }
@@ -97,7 +98,7 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
       const _payload = {
         ...data,
         forumDigestEnabled: true,
-        forumDigestFrequency: 1,
+        forumDigestFrequency: 1 as const,
       };
 
       mutate(
@@ -106,13 +107,14 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
           payload: _payload,
         },
         {
+          onSuccess: () => {
+            analytics.onForumDigestOptionSelect({ ..._payload, source: 'settings' });
+          },
           onError: () => {
-            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'daily' });
+            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'daily', source: 'settings' });
           },
         },
       );
-
-      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }
@@ -121,7 +123,7 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
       const _payload = {
         ...data,
         forumDigestEnabled: true,
-        forumDigestFrequency: 7,
+        forumDigestFrequency: 7 as const,
       };
 
       mutate(
@@ -130,13 +132,14 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
           payload: _payload,
         },
         {
+          onSuccess: () => {
+            analytics.onForumDigestOptionSelect({ ..._payload, source: 'settings' });
+          },
           onError: () => {
-            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'weekly' });
+            analytics.onForumDigestSaveFailed({ attemptedFrequency: 'weekly', source: 'settings' });
           },
         },
       );
-
-      analytics.onForumDigestOptionSelect(_payload);
 
       return;
     }

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -45,6 +45,18 @@ function getSearchInputEl(container: HTMLDivElement | null): HTMLInputElement | 
   return container?.querySelector('input') ?? null;
 }
 
+// Shared by searchedItems' useMemo and handleSearch's synchronous result-count
+// computation, so the two never drift into different definitions of "matches".
+function matchesTeamNewsQuery(item: ITeamNewsItem, lowerCaseQuery: string): boolean {
+  if (!lowerCaseQuery) return true;
+  return (
+    item.teamName.toLowerCase().includes(lowerCaseQuery) ||
+    item.title.toLowerCase().includes(lowerCaseQuery) ||
+    (item.summary?.toLowerCase().includes(lowerCaseQuery) ?? false) ||
+    item.tags.some((t) => t.toLowerCase().includes(lowerCaseQuery))
+  );
+}
+
 interface TeamNewsProps {
   groups: ITeamNewsGroup[];
   pageSize?: number;
@@ -106,13 +118,7 @@ export const TeamNews = ({ groups, pageSize = 6, initialDigestSettings = null }:
   const searchedItems = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return filteredItems;
-    return filteredItems.filter(
-      (i) =>
-        i.teamName.toLowerCase().includes(q) ||
-        i.title.toLowerCase().includes(q) ||
-        (i.summary?.toLowerCase().includes(q) ?? false) ||
-        i.tags.some((t) => t.toLowerCase().includes(q)),
-    );
+    return filteredItems.filter((i) => matchesTeamNewsQuery(i, q));
   }, [filteredItems, query]);
 
   const clusters = useMemo(() => clusterByTeam(searchedItems), [searchedItems]);
@@ -159,14 +165,44 @@ export const TeamNews = ({ groups, pageSize = 6, initialDigestSettings = null }:
     analytics.onTeamNewsCardClicked(item, position >= 0 ? position : 0, 'home');
   };
 
+  // "Latest ref" pattern: lets handleSearch read current context synchronously
+  // without adding it to handleSearch's dependency array, which must stay
+  // empty (see the comment on handleSearch below). Refs are synced in an
+  // effect with no dependency array (runs after every render) rather than
+  // written during render, per this repo's react-hooks/refs lint rule.
+  const filteredItemsRef = useRef(filteredItems);
+  const activeTabRef = useRef(activeTab);
+  const activeCategoryRef = useRef(activeCategory);
+  const analyticsRef = useRef(analytics);
+  useEffect(() => {
+    filteredItemsRef.current = filteredItems;
+    activeTabRef.current = activeTab;
+    activeCategoryRef.current = activeCategory;
+    analyticsRef.current = analytics;
+  });
+
   // useCallback with empty deps is required here, not just tidy: SearchInput's
   // DebouncedInput recreates its internal debounce instance whenever this
   // function's identity changes, which orphans any in-flight debounce timer
   // rather than cancelling it — a stale timer can then overwrite text the
-  // user typed after an unrelated re-render (e.g. clicking Follow).
+  // user typed after an unrelated re-render (e.g. clicking Follow). This is
+  // also why resultCount/activeTab/activeCategory/analytics are read via the
+  // refs above rather than added here as dependencies.
   const handleSearch = useCallback((value: string) => {
     setQuery(value);
     setExpanded(false); // matches handleTab/handleCategory's reset-on-filter-change convention
+
+    const trimmed = value.trim();
+    if (!trimmed) return; // clearing a search isn't a search event
+    const q = trimmed.toLowerCase();
+    const resultCount = filteredItemsRef.current.filter((i) => matchesTeamNewsQuery(i, q)).length;
+    const truncatedSearchValue = value.length > 100 ? value.slice(0, 100) : value;
+    analyticsRef.current.onTeamNewsSearch(
+      truncatedSearchValue,
+      resultCount,
+      activeTabRef.current,
+      String(activeCategoryRef.current),
+    );
   }, []);
 
   const handleFieldBlur = useCallback((e: FocusEvent<HTMLDivElement>) => {

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.module.scss
@@ -22,9 +22,9 @@
   line-height: 20px;
   letter-spacing: -0.2px;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  //-webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden;
+  //overflow: hidden;
 }
 
 .expander {

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.module.scss
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.module.scss
@@ -66,49 +66,54 @@
   gap: 8px;
   padding: 20px;
 
-  box-shadow: 0 1px 1px 0 var(--transparent-dark-6, #0e0f110f);
-  background: linear-gradient(#204bba 8%, #156ff7 66%);
+  background: var(--transparent-brand-8, #1b4dff0f);
+  border: 1px solid var(--transparent-brand-16, #1b4dff29);
   border-radius: 16px;
 }
 
 .digestTitle {
+  letter-spacing: -.4px;
+  color: var(--foreground-neutral-primary, #0a0c11);
   margin: 0;
-  font-size: 15px;
+  font-size: 18px;
   font-weight: 600;
-  line-height: 20px;
-  letter-spacing: -0.2px;
-  color: #ffffff;
+  line-height: 24px;
 }
 
 .digestBody {
-  margin: 0 0 4px;
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 19px;
-  letter-spacing: -0.1px;
-  color: rgba(255, 255, 255, 0.8);
+  letter-spacing: -.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
 }
 
 .digestBtn {
-  display: flex;
-  align-items: center;
+  background: #1b4dff;
   justify-content: center;
+  align-items: center;
   gap: 6px;
   width: 100%;
-  height: 36px;
-  border: none;
+  display: flex;
+  letter-spacing: -.2px;
+  min-width: 72px;
+  padding: 8px 10px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #fff;
+  border: 1px solid #1b4dff;
   border-radius: 8px;
-  background: #ffffff;
-  color: #1b4dff;
   cursor: pointer;
-  font-size: 13px;
+  -webkit-appearance: none;
+  font-family: Inter, sans-serif;
   font-weight: 500;
-  line-height: 18px;
-  letter-spacing: -0.1px;
-  transition: background-color 0.15s ease;
+  transition: all .2s;
+  overflow: hidden;
+  margin-top: 8px;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.9);
+    background: #0f3cd9;
+    border-color: #0f3cd9;
   }
 }
 
@@ -134,10 +139,10 @@
   font-weight: 500;
   line-height: 18px;
   letter-spacing: -0.1px;
-  color: #1b4dff;
+  color: #6b7280;
   text-decoration: none;
 
   &:hover {
-    text-decoration: underline;
+    color: #374151;
   }
 }

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -86,33 +86,32 @@ export function NewsRail({ initialDigestSettings = null }: NewsRailProps) {
         <p className={s.whyBody}>Follow teams to receive updates and announcements.</p>
       </section>
 
-      {showDigest &&
-        (isSubscribed ? (
-          <section className={s.subscribedCard} aria-label="You're subscribed to the news digest">
-            <span className={s.iconBadge} aria-hidden="true">
-              <MailIcon />
-            </span>
-            <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
-            <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
-            <Link href="/settings/email" className={s.manageLink}>
-              <span>Manage in Settings</span>
+      {isSubscribed ? (
+        <section className={s.subscribedCard} aria-label="You're subscribed to the news digest">
+          <span className={s.iconBadge} aria-hidden="true">
+            <MailIcon />
+          </span>
+          <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
+          <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
+          <Link href="/settings/email" className={s.manageLink}>
+            <span>Manage in Settings</span>
+            <ArrowRight />
+          </Link>
+        </section>
+      ) : (
+        <section className={s.digestCard} aria-label="Subscribe to the news digest">
+          <p className={s.digestTitle}>Get notified about network news updates</p>
+          <p className={s.digestBody}>
+            A news digest covering raises, launches, and milestones across the network, straight to your inbox.
+          </p>
+          {isHydrated && (
+            <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
+              <span>Subscribe for Digest</span>
               <ArrowRight />
-            </Link>
-          </section>
-        ) : (
-          <section className={s.digestCard} aria-label="Subscribe to the news digest">
-            <p className={s.digestTitle}>Get notified about network news updates</p>
-            <p className={s.digestBody}>
-              A news digest covering raises, launches, and milestones across the network, straight to your inbox.
-            </p>
-            {isHydrated && (
-              <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
-                <span>Subscribe for Digest</span>
-                <ArrowRight />
-              </button>
-            )}
-          </section>
-        ))}
+            </button>
+          )}
+        </section>
+      )}
     </aside>
   );
 }

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -88,32 +88,33 @@ export function NewsRail({ initialDigestSettings = null }: NewsRailProps) {
         <p className={s.whyBody}>Follow teams to receive updates and announcements.</p>
       </section>
 
-      {isSubscribed ? (
-        <section className={s.subscribedCard} aria-label="You're subscribed to the news digest">
-          <span className={s.iconBadge} aria-hidden="true">
-            <MailIcon />
-          </span>
-          <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
-          <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
-          <Link href="/settings/email" className={s.manageLink}>
-            <span>Manage in Settings</span>
-            <ArrowRight />
-          </Link>
-        </section>
-      ) : (
-        <section className={s.digestCard} aria-label="Subscribe to the news digest">
-          <p className={s.digestTitle}>Get notified about network news updates</p>
-          <p className={s.digestBody}>
-            A news digest covering raises, launches, and milestones across the network, straight to your inbox.
-          </p>
-          {isHydrated && (
-            <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
-              <span>Subscribe for Digest</span>
+      {showDigest &&
+        (isSubscribed ? (
+          <section className={s.subscribedCard} aria-label="You're subscribed to the news digest">
+            <span className={s.iconBadge} aria-hidden="true">
+              <MailIcon />
+            </span>
+            <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
+            <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
+            <Link href="/settings/email" className={s.manageLink}>
+              <span>Manage in Settings</span>
               <ArrowRight />
-            </button>
-          )}
-        </section>
-      )}
+            </Link>
+          </section>
+        ) : (
+          <section className={s.digestCard} aria-label="Subscribe to the news digest">
+            <p className={s.digestTitle}>Get notified about network news updates</p>
+            <p className={s.digestBody}>
+              A news digest covering raises, launches, and milestones across the network, straight to your inbox.
+            </p>
+            {isHydrated && (
+              <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
+                <span>Subscribe for Digest</span>
+                <ArrowRight />
+              </button>
+            )}
+          </section>
+        ))}
     </aside>
   );
 }

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -71,9 +71,11 @@ export function NewsRail({ initialDigestSettings = null }: NewsRailProps) {
     const payload = { ...(data ?? defaultSettings), forumDigestEnabled: true, forumDigestFrequency: 7 as const };
     mutate(
       { uid: currentUser.uid, payload },
-      { onError: () => analytics.onForumDigestSaveFailed({ attemptedFrequency: 'weekly' }) },
+      {
+        onSuccess: () => analytics.onForumDigestOptionSelect({ ...payload, source: 'home-feed' }),
+        onError: () => analytics.onForumDigestSaveFailed({ attemptedFrequency: 'weekly', source: 'home-feed' }),
+      },
     );
-    analytics.onForumDigestOptionSelect(payload);
   };
 
   return (

--- a/components/ui/FollowButton/FollowButton.module.scss
+++ b/components/ui/FollowButton/FollowButton.module.scss
@@ -49,17 +49,19 @@
   flex-shrink: 0;
   border: none;
   background: none;
-  padding: 0;
+  padding: 2px 6px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
   line-height: 18px;
   letter-spacing: -0.1px;
-  color: #156ff7;
+  color: var(--foreground-brand-primary, #1b4dff);
   white-space: nowrap;
 
   &:hover:not(:disabled) {
-    text-decoration: underline;
+    color: var(--foreground-brand-primary, #1b4dff);
+    background: var(--transparent-brand-8, #1b4dff14);
   }
 
   &:disabled {
@@ -70,4 +72,9 @@
 
 .compactFollowing {
   color: #455468;
+
+  &:hover:not(:disabled) {
+    color: var(--foreground-neutral-primary, #0a0c11);
+    background: var(--transparent-dark-4, #0e0f110a);
+  }
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -586,6 +586,7 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_CARD_CLICKED: 'team-news-card-clicked',
   TEAM_NEWS_START_CONVERSATION_CLICKED: 'team-news-start-conversation-clicked',
   TEAM_NEWS_JOIN_DISCUSSION_CLICKED: 'team-news-join-discussion-clicked',
+  TEAM_NEWS_SEARCH_REQUESTED: 'team-news-search-requested',
 };
 
 export const FOLLOW_ANALYTICS_EVENTS = {


### PR DESCRIPTION
## Summary
- Adds `team-news-search-requested` analytics event, firing once the search debounce settles with the narrowed result count and current tab/category (`useTeamNewsAnalytics`)
- Fixes a digest-subscribe attribution gap: the home-feed "Subscribe for Digest" button (`NewsRail`) reused Settings > Email's `onForumDigestOptionSelect`/`onForumDigestSaveFailed` events with no way to tell the two entry points apart in PostHog — both now carry `source: 'home-feed' | 'settings'`
- Fixes a related pre-existing bug found during implementation: subscribing used to fire a "success" event unconditionally right after `mutate()`, even when the mutation later failed, so a single failed attempt double-fired both a success and a failure event. Now mutually exclusive via `onSuccess`/`onError`, across all 4 handler locations (`NewsRail` + `ForumDigest`'s 3 frequency branches)
- `params: any` on `onForumDigestOptionSelect` replaced with a proper typed interface; raw search text truncated to 100 chars before sending to PostHog
- Includes an earlier "fix: news ui" commit (NewsRail/FollowButton styling) already on this branch

## Testing
- 6 new analytics assertions in `team-news.test.tsx` (fires on debounce settle, skips on clear, doesn't re-fire on tab switch alone, result count/tab scoped correctly after switching tabs, 100-char truncation)
- `news-rail.test.tsx` updated for the `source` field + new test covering the onSuccess/onError mutual-exclusivity fix
- New `forum-digest.test.tsx` (previously zero coverage) — all 3 frequency branches × success/failure paths
- Full suite: 479 passing; lint, typecheck, and prettier clean on every touched file
- Manually verified both search and digest-subscribe flows in the browser (no console errors)

**Known pre-existing issue, not introduced by this PR:** one `news-rail.test.tsx` test ("hides digest cards for authenticated users without forum access") fails on this branch's base commit too — `NewsRail.tsx`'s `showDigest` variable is computed but never used to gate rendering. Confirmed via `git stash` this predates this PR's changes; left as-is since it's unrelated to the analytics work here.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)