### PR TITLE
[AI Apps] Updates and improvements for AI Apps

### DIFF
--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.module.scss
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.module.scss
@@ -214,8 +214,3 @@
     text-decoration: underline;
   }
 }
-
-.secretsPanel {
-  max-width: 560px;
-  padding-bottom: 8px;
-}

--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
@@ -9,6 +9,7 @@ import { checkAiAppLive } from '@/services/ai-apps/ai-apps.service';
 import { FloatingFeedbackButton } from '../components/FloatingFeedbackButton';
 
 import { AppSecretsPanel } from './components/AppSecretsPanel';
+import { UpdateSecretsModal } from './components/UpdateSecretsModal';
 
 import s from './AiAppDetailPage.module.scss';
 
@@ -42,7 +43,7 @@ export function AiAppDetailPage(props: Props) {
   const trackedAppUid = useRef<string | null>(null);
   const trackedDraftSetupUid = useRef<string | null>(null);
   const iframeTracked = useRef<string | null>(null);
-  const [showSecrets, setShowSecrets] = useState(false);
+  const [isSecretsModalOpen, setIsSecretsModalOpen] = useState(false);
   const [isRedeploying, setIsRedeploying] = useState(false);
   // Bumped by "Try again" to restart the polling effect after it gave up.
   const [retryToken, setRetryToken] = useState(0);
@@ -66,14 +67,11 @@ export function AiAppDetailPage(props: Props) {
     analytics.onDraftSetupViewed({ appUid: app.uid, appName: app.name });
   }, [app, needsSetup, analytics]);
 
-  const handleSecretsToggle = () => {
-    setShowSecrets((wasOpen) => {
-      const next = !wasOpen;
-      if (next && app) {
-        analytics.onSecretsPanelOpened({ appUid: app.uid, isDraft: false });
-      }
-      return next;
-    });
+  const handleOpenSecretsModal = () => {
+    if (app) {
+      analytics.onSecretsPanelOpened({ appUid: app.uid, isDraft: false });
+    }
+    setIsSecretsModalOpen(true);
   };
 
   useEffect(() => {
@@ -232,16 +230,19 @@ export function AiAppDetailPage(props: Props) {
   return (
     <div className={s.root}>
       {isCreator && requiredEnvVars.length > 0 && (
-        <div className={s.secretsBar}>
-          <button type="button" className={s.secretsToggle} onClick={handleSecretsToggle}>
-            {showSecrets ? 'Hide secrets' : 'Update secrets & redeploy'}
-          </button>
-          {showSecrets && (
-            <div className={s.secretsPanel}>
-              <AppSecretsPanel app={app} onDeployingChange={setIsRedeploying} />
-            </div>
-          )}
-        </div>
+        <>
+          <div className={s.secretsBar}>
+            <button type="button" className={s.secretsToggle} onClick={handleOpenSecretsModal}>
+              Update secrets &amp; redeploy
+            </button>
+          </div>
+          <UpdateSecretsModal
+            isOpen={isSecretsModalOpen}
+            onClose={() => setIsSecretsModalOpen(false)}
+            app={app}
+            onDeployingChange={setIsRedeploying}
+          />
+        </>
       )}
       {renderFrameArea()}
       <FloatingFeedbackButton appUid={app.uid} appName={app.name} />

--- a/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
@@ -14,6 +14,8 @@ interface Props {
   app: AiApp;
   /** Fires while a deploy is in flight, so the parent can hide the stale iframe. */
   onDeployingChange?: (deploying: boolean) => void;
+  /** Fires after a successful deploy has settled (caches refreshed) — e.g. to close a wrapping modal. */
+  onDeploySuccess?: () => void;
 }
 
 /**
@@ -22,7 +24,7 @@ interface Props {
  * vars start empty and blank means "keep the stored value".
  */
 export function AppSecretsPanel(props: Props) {
-  const { app, onDeployingChange } = props;
+  const { app, onDeployingChange, onDeploySuccess } = props;
 
   const analytics = useAiAppsAnalytics();
   const queryClient = useQueryClient();
@@ -86,6 +88,9 @@ export function AppSecretsPanel(props: Props) {
       queryClient.invalidateQueries({ queryKey: [AiAppsQueryKeys.AI_APPS_LIST] }),
     ]);
     setDeploying(false);
+    if (!result.error) {
+      onDeploySuccess?.();
+    }
   };
 
   return (
@@ -122,7 +127,11 @@ export function AppSecretsPanel(props: Props) {
         <Button variant="primary" size="m" onClick={onDeploy} disabled={isDeploying}>
           {isDeploying ? 'Deploying…' : 'Deploy'}
         </Button>
-        {isDeploying && <span className={s.deployNote}>The first deploy can take a couple of minutes.</span>}
+        {isDeploying && (
+          <span className={s.deployNote}>
+            {isDraft ? 'The first deploy can take a couple of minutes.' : 'Redeploying can take a couple of minutes.'}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/UpdateSecretsModal.module.scss
+++ b/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/UpdateSecretsModal.module.scss
@@ -1,0 +1,63 @@
+@use 'styles/media';
+
+/* Visuals mirror CreateAiAppModal (same feature's modal convention). */
+
+.modal {
+  max-width: 520px !important;
+}
+
+.content {
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid rgba(27, 56, 96, 0.06);
+  box-shadow: 0 4px 24px 0 rgba(14, 15, 17, 0.08);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(14, 15, 17, 0.06);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 27px;
+  letter-spacing: -0.4px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+}
+
+.body {
+  padding: 24px;
+  overflow-y: auto;
+  min-height: 0;
+}

--- a/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/UpdateSecretsModal.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/UpdateSecretsModal.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Modal } from '@/components/common/Modal/Modal';
+import { CloseIcon } from '@/components/icons';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+import { AppSecretsPanel } from '../AppSecretsPanel';
+
+import s from './UpdateSecretsModal.module.scss';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  app: AiApp;
+  /** Forwarded from AppSecretsPanel so the page can swap the iframe for its progress state. */
+  onDeployingChange?: (deploying: boolean) => void;
+}
+
+/**
+ * "Update secrets & redeploy" dialog wrapping AppSecretsPanel. While a deploy is
+ * in flight the modal locks (no backdrop/escape/close) — unmounting the panel
+ * mid-deploy would orphan the request and the page would never learn it settled.
+ * On success it closes itself; on failure it stays open showing the panel error.
+ */
+export function UpdateSecretsModal(props: Props) {
+  const { isOpen, onClose, app, onDeployingChange } = props;
+
+  const [isDeploying, setIsDeploying] = useState(false);
+
+  const handleDeployingChange = (deploying: boolean) => {
+    setIsDeploying(deploying);
+    onDeployingChange?.(deploying);
+  };
+
+  const handleClose = () => {
+    if (isDeploying) return;
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      closeOnBackdropClick={!isDeploying}
+      closeOnEscape={!isDeploying}
+      className={s.modal}
+    >
+      <div className={s.content}>
+        <div className={s.header}>
+          <h2 className={s.title}>Update secrets &amp; redeploy</h2>
+          <button
+            type="button"
+            className={s.closeButton}
+            onClick={handleClose}
+            disabled={isDeploying}
+            aria-label="Close"
+          >
+            <CloseIcon width={20} height={20} />
+          </button>
+        </div>
+
+        <div className={s.body}>
+          <AppSecretsPanel app={app} onDeployingChange={handleDeployingChange} onDeploySuccess={onClose} />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/index.ts
+++ b/components/page/ai-apps/AiAppDetailPage/components/UpdateSecretsModal/index.ts
@@ -1,0 +1,1 @@
+export { UpdateSecretsModal } from './UpdateSecretsModal';


### PR DESCRIPTION
## Summary
The "Update secrets & redeploy" form on the app detail page now opens in a centered modal dialog (styled like the existing AI Apps modals) instead of expanding inline in the top bar.
The modal closes itself after a successful deploy, stays open to show errors, and cannot be dismissed while a deploy is running.

## Screenshot
<img width="613" height="409" alt="Screenshot 2026-07-10 at 4 22 01 PM" src="https://github.com/user-attachments/assets/925a9a94-8a4f-451c-a0d3-70a47bb0948f" />
