### PR TITLE
feat(team-profile): enable news upvotes and match prototype card design

### DIFF
--- a/__tests__/page/home/news-card.test.tsx
+++ b/__tests__/page/home/news-card.test.tsx
@@ -1,0 +1,122 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { NewsCard } from '@/components/page/home/TeamNews/components/NewsCard/NewsCard';
+import type { ITeamNewsDiscussion, ITeamNewsItem, TeamNewsEventType } from '@/types/team-news.types';
+
+const mockPush = jest.fn();
+const mockUseCurrentUserStore = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/services/auth/store', () => ({
+  useCurrentUserStore: () => mockUseCurrentUserStore(),
+}));
+
+jest.mock('@/components/page/home/TeamNews/components/NewsCard/components/StartConversationButton', () => ({
+  StartConversationButton: () => <button type="button">Discuss</button>,
+}));
+
+jest.mock('@/utils/formatTimeAgo', () => ({
+  formatTimeAgo: () => '4d ago',
+}));
+
+const item: ITeamNewsItem = {
+  uid: 'news-1',
+  teamUid: 'team-1',
+  teamName: 'Protocol Labs',
+  teamLogoUrl: null,
+  eventType: 'ANNOUNCEMENT' as TeamNewsEventType,
+  eventDate: '2026-06-01T00:00:00.000Z',
+  title: 'Headline news-1',
+  summary: null,
+  sourceUrl: 'https://example.com/news-1',
+  sourceDomain: 'example.com',
+  tags: [],
+  focusAreas: [],
+  subFocusAreas: [],
+  createdAt: '2026-06-02T00:00:00.000Z',
+  discussion: { count: 0, latestTopicUrl: null } satisfies ITeamNewsDiscussion,
+  upvoteCount: 2,
+  viewerHasUpvoted: false,
+};
+
+describe('NewsCard upvotes', () => {
+  let windowOpen: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'm-1' }, isHydrated: true });
+    windowOpen = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    windowOpen.mockRestore();
+  });
+
+  it('renders no upvote button when onUpvoteToggle is not provided', () => {
+    render(<NewsCard item={item} upvoteCount={2} viewerHasUpvoted={false} />);
+
+    expect(screen.queryByRole('button', { name: /Upvote/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Discuss' })).toBeInTheDocument();
+  });
+
+  it('renders the upvote button and forwards the toggle for a signed-in viewer', () => {
+    const onUpvoteToggle = jest.fn();
+    render(<NewsCard item={item} upvoteCount={2} viewerHasUpvoted={false} onUpvoteToggle={onUpvoteToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upvote (2)' }));
+
+    expect(onUpvoteToggle).toHaveBeenCalledWith(item);
+    expect(mockPush).not.toHaveBeenCalled();
+    // The card is itself a link — the upvote click must not open the article.
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it('redirects guests to login instead of toggling', () => {
+    mockUseCurrentUserStore.mockReturnValue({ currentUser: null, isHydrated: true });
+    const onUpvoteToggle = jest.fn();
+    render(<NewsCard item={item} upvoteCount={2} viewerHasUpvoted={false} onUpvoteToggle={onUpvoteToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upvote (2)' }));
+
+    expect(onUpvoteToggle).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+  });
+
+  it('withholds the upvote button until the auth store hydrates', () => {
+    mockUseCurrentUserStore.mockReturnValue({ currentUser: null, isHydrated: false });
+    render(<NewsCard item={item} upvoteCount={2} viewerHasUpvoted={false} onUpvoteToggle={jest.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /Upvote/i })).not.toBeInTheDocument();
+  });
+
+  it('does not open the article when Enter is pressed on an inner button', () => {
+    const onUpvoteToggle = jest.fn();
+    render(<NewsCard item={item} hideTeam upvoteCount={2} viewerHasUpvoted={false} onUpvoteToggle={onUpvoteToggle} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Upvote (2)' }), { key: 'Enter' });
+    expect(windowOpen).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole('link'), { key: 'Enter' });
+    expect(windowOpen).toHaveBeenCalledWith('https://example.com/news-1', '_blank', 'noopener,noreferrer');
+  });
+
+  it('shows the voted state with the count', () => {
+    render(<NewsCard item={item} upvoteCount={3} viewerHasUpvoted onUpvoteToggle={jest.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Remove upvote (3)' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveTextContent('Upvoted');
+    expect(button).toHaveTextContent('3');
+  });
+
+  it('hides the count at zero', () => {
+    render(<NewsCard item={item} upvoteCount={0} viewerHasUpvoted={false} onUpvoteToggle={jest.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Upvote (0)' });
+    expect(button).toHaveTextContent(/^Upvote$/);
+  });
+});

--- a/__tests__/page/teams/team-news-rail.test.tsx
+++ b/__tests__/page/teams/team-news-rail.test.tsx
@@ -7,12 +7,25 @@ import type { ITeamNewsDiscussion, ITeamNewsItem, TeamNewsEventType } from '@/ty
 
 const mockOnCardClicked = jest.fn();
 const mockOnViewAllClicked = jest.fn();
+const mockOnUpvoteToggled = jest.fn();
+const mockUpvoteMutate = jest.fn();
+const mockUseCurrentUserStore = jest.fn(() => ({ currentUser: { uid: 'm-1' }, isHydrated: true }));
+let lastModalProps: Record<string, unknown> | null = null;
 
 jest.mock('@/analytics/team-news.analytics', () => ({
   useTeamNewsAnalytics: () => ({
     onTeamNewsCardClicked: (...a: unknown[]) => mockOnCardClicked(...a),
     onTeamNewsViewAllClicked: (...a: unknown[]) => mockOnViewAllClicked(...a),
+    onTeamNewsUpvoteToggled: (...a: unknown[]) => mockOnUpvoteToggled(...a),
   }),
+}));
+
+jest.mock('@/services/team-news/hooks/useTeamNewsUpvoteToggle', () => ({
+  useTeamNewsUpvoteToggle: () => ({ mutate: mockUpvoteMutate }),
+}));
+
+jest.mock('@/services/auth/store', () => ({
+  useCurrentUserStore: () => mockUseCurrentUserStore(),
 }));
 
 jest.mock('@/components/page/home/TeamNews/components/NewsCard/components/StartConversationButton', () => ({
@@ -28,12 +41,14 @@ jest.mock('@/hooks/useIsMobile', () => ({
 }));
 
 jest.mock('@/components/page/team-details/TeamNews/TeamNewsModal', () => ({
-  TeamNewsModal: ({ isOpen, fullscreen }: { isOpen: boolean; fullscreen?: boolean }) =>
-    isOpen ? (
-      <div data-testid={fullscreen ? 'team-news-fullpage' : 'team-news-modal'}>
-        {fullscreen ? 'Full page open' : 'Modal open'}
+  TeamNewsModal: (props: { isOpen: boolean; fullscreen?: boolean }) => {
+    lastModalProps = props;
+    return props.isOpen ? (
+      <div data-testid={props.fullscreen ? 'team-news-fullpage' : 'team-news-modal'}>
+        {props.fullscreen ? 'Full page open' : 'Modal open'}
       </div>
-    ) : null,
+    ) : null;
+  },
 }));
 
 const makeItem = (uid: string): ITeamNewsItem => ({
@@ -142,5 +157,58 @@ describe('TeamNewsRail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'View all news (4)' }));
     expect(mockOnViewAllClicked).toHaveBeenCalledWith('team-1', 'Protocol Labs', 4);
     expect(screen.getByTestId('team-news-fullpage')).toBeInTheDocument();
+  });
+
+  const renderRailWithOneItem = () =>
+    render(
+      <TeamNewsRail
+        teamUid="team-1"
+        teamName="Protocol Labs"
+        initialData={{
+          teamUid: 'team-1',
+          teamName: 'Protocol Labs',
+          page: 1,
+          limit: 3,
+          total: 1,
+          items: [{ ...makeItem('news-1'), upvoteCount: 0, viewerHasUpvoted: false }],
+        }}
+      />,
+    );
+
+  it('optimistically upvotes, reconciles on success, and shares the overlay with the modal', () => {
+    mockUpvoteMutate.mockImplementation((_action, { onSuccess }) =>
+      onSuccess({ upvoteCount: 5, viewerHasUpvoted: true }),
+    );
+
+    renderRailWithOneItem();
+    fireEvent.click(screen.getByRole('button', { name: 'Upvote (0)' }));
+
+    expect(mockUpvoteMutate).toHaveBeenCalledWith({ uid: 'news-1', isUpvoted: true }, expect.any(Object));
+    // Reconciled with the server's authoritative count.
+    const voted = screen.getByRole('button', { name: 'Remove upvote (5)' });
+    expect(voted).toHaveTextContent('Upvoted');
+    expect(mockOnUpvoteToggled).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'news-1' }),
+      0,
+      true,
+      'team-profile-rail',
+    );
+    // The same overlay is handed to the modal so both views stay in sync.
+    expect((lastModalProps?.upvoteOverlay as Map<string, unknown>).get('news-1')).toEqual({
+      viewerHasUpvoted: true,
+      upvoteCount: 5,
+    });
+    expect(lastModalProps?.onUpvoteToggle).toEqual(expect.any(Function));
+  });
+
+  it('reverts the optimistic vote when the mutation fails', () => {
+    mockUpvoteMutate.mockImplementation((_action, { onError }) => onError(new Error('nope')));
+
+    renderRailWithOneItem();
+    fireEvent.click(screen.getByRole('button', { name: 'Upvote (0)' }));
+
+    const button = screen.getByRole('button', { name: 'Upvote (0)' });
+    expect(button).toHaveTextContent(/^Upvote$/);
+    expect(mockOnUpvoteToggled).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/team-news/team-news.service.test.ts
+++ b/__tests__/services/team-news/team-news.service.test.ts
@@ -13,9 +13,7 @@ describe('buildTeamNewsByTeamUrl', () => {
 
   it('builds the team news URL with pagination and search params', () => {
     const url = buildTeamNewsByTeamUrl('team-1', { page: 2, limit: 20, q: 'funding' });
-    expect(url).toBe(
-      'https://api.example.com/v1/teams/team-1/team-news?page=2&limit=20&q=funding',
-    );
+    expect(url).toBe('https://api.example.com/v1/teams/team-1/team-news?page=2&limit=20&q=funding');
   });
 
   it('omits empty search query', () => {
@@ -60,6 +58,23 @@ describe('fetchTeamNewsByTeam', () => {
       'https://api.example.com/v1/teams/team-1/team-news?page=1&limit=3',
       expect.objectContaining({ cache: 'no-store' }),
     );
+  });
+
+  it('sends no Authorization header without a token', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [] }) });
+    await fetchTeamNewsByTeam('team-1', { page: 1, limit: 3 });
+
+    const headers = fetchMock.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBeNull();
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('sends the viewer token as a Bearer Authorization header', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [] }) });
+    await fetchTeamNewsByTeam('team-1', { page: 1, limit: 3 }, 'token-123');
+
+    const headers = fetchMock.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer token-123');
   });
 
   it('returns null on non-OK response', async () => {

--- a/app/teams/[id]/page.tsx
+++ b/app/teams/[id]/page.tsx
@@ -206,7 +206,7 @@ async function getPageData(teamId: string) {
           isLoggedIn,
         ),
         getFocusAreas('Team', {}),
-        fetchTeamNewsByTeam(teamId, { page: 1, limit: TEAM_NEWS_PREVIEW_LIMIT }),
+        fetchTeamNewsByTeam(teamId, { page: 1, limit: TEAM_NEWS_PREVIEW_LIMIT }, authToken),
         isLoggedIn ? getTeamFollowers(teamId, { authToken }) : Promise.resolve(null),
       ]);
     teamNews = teamNewsResponse;

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
@@ -118,21 +118,27 @@
 }
 
 .headlineCompact {
-  font-size: 15px;
-  line-height: 20px;
+  font-size: 16px;
+  line-height: 22px;
   letter-spacing: -0.3px;
-  -webkit-line-clamp: 3;
 }
 
+// `compact` is the team-profile treatment (rail + news modal); the homepage
+// never passes it. Values match the team-profile prototype: tighter inner
+// rhythm, 2-line teaser, and room for the wrapped Upvote/Discuss row.
 .compact {
-  gap: 10px;
+  gap: 8px;
 
   &.card {
     padding: 16px;
   }
 
   &.cardFlat {
-    padding: 12px 0;
+    padding: 16px 0 12px;
+  }
+
+  .metaLine {
+    row-gap: 12px;
   }
 }
 
@@ -239,9 +245,10 @@
   -webkit-box-orient: vertical;
 }
 
+// Two-line teaser at the base 14px size, per the team-profile prototype.
 .summaryCompact {
-  font-size: 13px;
-  line-height: 18px;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 
 .actions {

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
@@ -12,6 +12,7 @@ import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
 import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
 
 import { StartConversationButton } from './components/StartConversationButton';
+import { UpvoteButton } from './components/UpvoteButton/UpvoteButton';
 
 import s from './NewsCard.module.scss';
 
@@ -27,6 +28,9 @@ interface NewsCardProps {
   analyticsSource?: TeamNewsAnalyticsSource;
   isFollowing?: boolean;
   onFollowToggle?: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
+  upvoteCount?: number;
+  viewerHasUpvoted?: boolean;
+  onUpvoteToggle?: (item: ITeamNewsItem) => void;
 }
 
 export const NewsCard = ({
@@ -41,6 +45,9 @@ export const NewsCard = ({
   analyticsSource = 'home',
   isFollowing = false,
   onFollowToggle,
+  upvoteCount = 0,
+  viewerHasUpvoted = false,
+  onUpvoteToggle,
 }: NewsCardProps) => {
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
@@ -54,12 +61,23 @@ export const NewsCard = ({
     onFollowToggle?.(item.teamUid, item.teamName, isFollowing);
   };
 
+  const handleUpvoteToggle = () => {
+    if (!currentUser) {
+      router.push(`${window.location.pathname}${window.location.search}#login`);
+      return;
+    }
+    onUpvoteToggle?.(item);
+  };
+
   const handleClick = () => {
     onClick?.(item);
     window.open(item.sourceUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Only act on keys pressed on the card itself — Enter on an inner button
+    // (Upvote/Discuss) must not also open the article.
+    if (e.target !== e.currentTarget) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleClick();
@@ -124,7 +142,14 @@ export const NewsCard = ({
           <span className={s.sep} aria-hidden="true" />
           <span className={s.time}>{formatTimeAgo(item.eventDate)}</span>
         </div>
-        <StartConversationButton item={item} position={position} analyticsSource={analyticsSource} />
+        <span className={s.actions}>
+          {/* Gated on hydration (like FollowButton) so a pre-hydration click
+              can't misread a signed-in viewer as a guest. */}
+          {isHydrated && onUpvoteToggle && (
+            <UpvoteButton count={upvoteCount} voted={viewerHasUpvoted} onToggle={handleUpvoteToggle} />
+          )}
+          <StartConversationButton item={item} position={position} analyticsSource={analyticsSource} />
+        </span>
       </div>
     </div>
   );

--- a/components/page/team-details/TeamNews/TeamNewsCard.tsx
+++ b/components/page/team-details/TeamNews/TeamNewsCard.tsx
@@ -10,9 +10,17 @@ interface TeamNewsCardProps {
   variant?: 'flat' | 'outline';
   onClick?: (item: ITeamNewsItem) => void;
   analyticsSource: TeamNewsAnalyticsSource;
+  onUpvoteToggle?: (item: ITeamNewsItem) => void;
 }
 
-export function TeamNewsCard({ item, position = 0, variant = 'outline', onClick, analyticsSource }: TeamNewsCardProps) {
+export function TeamNewsCard({
+  item,
+  position = 0,
+  variant = 'outline',
+  onClick,
+  analyticsSource,
+  onUpvoteToggle,
+}: TeamNewsCardProps) {
   return (
     <NewsCard
       item={item}
@@ -22,6 +30,9 @@ export function TeamNewsCard({ item, position = 0, variant = 'outline', onClick,
       variant={variant}
       onClick={onClick}
       analyticsSource={analyticsSource}
+      upvoteCount={item.upvoteCount ?? 0}
+      viewerHasUpvoted={Boolean(item.viewerHasUpvoted)}
+      onUpvoteToggle={onUpvoteToggle}
     />
   );
 }

--- a/components/page/team-details/TeamNews/TeamNewsModal.tsx
+++ b/components/page/team-details/TeamNews/TeamNewsModal.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Modal } from '@/components/common/Modal/Modal';
 import { SearchInput } from '@/components/common/filters/SearchInput/SearchInput';
 import { CloseIcon } from '@/components/core/UpdatesPanel/icons';
 import { useDebounce } from '@/hooks/useDebounce';
-import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { useTeamNewsByTeamInfinite } from '@/services/team-news/hooks/useTeamNewsByTeam';
 import type { ITeamNewsItem } from '@/types/team-news.types';
 
 import { TeamNewsCard } from './TeamNewsCard';
+import { mergeUpvoteOverlay, type TeamNewsUpvoteOverlay } from './TeamNewsRail';
 import s from './TeamNewsRail.module.scss';
 
 interface TeamNewsModalProps {
@@ -20,20 +21,43 @@ interface TeamNewsModalProps {
   teamName: string;
   total: number;
   fullscreen?: boolean;
+  /** Owned by TeamNewsRail so votes stay in sync between the rail and this view. */
+  upvoteOverlay?: TeamNewsUpvoteOverlay;
+  onUpvoteToggle?: (item: ITeamNewsItem, position: number, source: TeamNewsAnalyticsSource) => void;
 }
 
-export function TeamNewsModal({ isOpen, onClose, teamUid, teamName, total, fullscreen = false }: TeamNewsModalProps) {
+export function TeamNewsModal({
+  isOpen,
+  onClose,
+  teamUid,
+  teamName,
+  total,
+  fullscreen = false,
+  upvoteOverlay,
+  onUpvoteToggle,
+}: TeamNewsModalProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebounce(searchQuery, 300);
   const effectiveQuery = searchQuery === '' ? '' : debouncedQuery;
   const sentinelRef = useRef<HTMLDivElement>(null);
   const { onTeamNewsCardClicked, onTeamNewsLoadMoreClicked } = useTeamNewsAnalytics();
 
-  const { items, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useTeamNewsByTeamInfinite({
+  const {
+    items: fetchedItems,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useTeamNewsByTeamInfinite({
     teamUid,
     q: effectiveQuery,
     enabled: isOpen,
   });
+
+  const items = useMemo(
+    () => (upvoteOverlay ? mergeUpvoteOverlay(fetchedItems, upvoteOverlay) : fetchedItems),
+    [fetchedItems, upvoteOverlay],
+  );
 
   const handleClose = useCallback(() => {
     onClose();
@@ -107,6 +131,9 @@ export function TeamNewsModal({ isOpen, onClose, teamUid, teamName, total, fulls
             variant="outline"
             analyticsSource="team-profile-modal"
             onClick={(clicked) => handleCardClick(clicked, index)}
+            onUpvoteToggle={
+              onUpvoteToggle ? (toggled) => onUpvoteToggle(toggled, index, 'team-profile-modal') : undefined
+            }
           />
         ))}
       </div>

--- a/components/page/team-details/TeamNews/TeamNewsRail.module.scss
+++ b/components/page/team-details/TeamNews/TeamNewsRail.module.scss
@@ -8,7 +8,7 @@
     width: 340px;
     flex-shrink: 0;
     position: sticky;
-    top: 16px;
+    top: 32px;
   }
 }
 

--- a/components/page/team-details/TeamNews/TeamNewsRail.tsx
+++ b/components/page/team-details/TeamNews/TeamNewsRail.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { DetailsSectionHeader } from '@/components/common/profile/DetailsSection';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { TEAM_NEWS_PREVIEW_LIMIT } from '@/services/team-news/constants';
+import { useTeamNewsUpvoteToggle } from '@/services/team-news/hooks/useTeamNewsUpvoteToggle';
 import type { ITeamNewsByTeamResponse, ITeamNewsItem } from '@/types/team-news.types';
 
 import { TeamNewsCard } from './TeamNewsCard';
@@ -18,13 +19,72 @@ interface TeamNewsRailProps {
   initialData: ITeamNewsByTeamResponse;
 }
 
+export type TeamNewsUpvoteOverlay = Map<string, { viewerHasUpvoted: boolean; upvoteCount: number }>;
+
+export function mergeUpvoteOverlay(items: ITeamNewsItem[], overlay: TeamNewsUpvoteOverlay): ITeamNewsItem[] {
+  if (overlay.size === 0) return items;
+  return items.map((item) => (overlay.has(item.uid) ? { ...item, ...overlay.get(item.uid) } : item));
+}
+
 export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const isMobile = useIsMobile();
-  const { onTeamNewsCardClicked, onTeamNewsViewAllClicked } = useTeamNewsAnalytics();
+  const { onTeamNewsCardClicked, onTeamNewsViewAllClicked, onTeamNewsUpvoteToggled } = useTeamNewsAnalytics();
+  const { mutate: upvoteMutate } = useTeamNewsUpvoteToggle();
+
+  // The rail reads server-provided `initialData` and the modal has its own
+  // infinite query — two data sources for the same stories. Like the homepage
+  // feed (TeamNews.tsx), a single local overlay merged over both keeps the
+  // viewer's vote consistent everywhere it renders. Auth check + login
+  // redirect happens inside NewsCard; this handler assumes a signed-in caller.
+  const [upvoteOverlay, setUpvoteOverlay] = useState<TeamNewsUpvoteOverlay>(() => new Map());
+
+  const handleUpvoteToggle = useCallback(
+    (item: ITeamNewsItem, position: number, source: TeamNewsAnalyticsSource) => {
+      const wasUpvoted = Boolean(item.viewerHasUpvoted);
+      const nextUpvoted = !wasUpvoted;
+      const prevCount = item.upvoteCount ?? 0;
+      const nextCount = wasUpvoted ? Math.max(0, prevCount - 1) : prevCount + 1;
+
+      setUpvoteOverlay((prev) => {
+        const next = new Map(prev);
+        next.set(item.uid, { viewerHasUpvoted: nextUpvoted, upvoteCount: nextCount });
+        return next;
+      });
+
+      upvoteMutate(
+        { uid: item.uid, isUpvoted: nextUpvoted },
+        {
+          onError: () => {
+            setUpvoteOverlay((prev) => {
+              const next = new Map(prev);
+              next.set(item.uid, { viewerHasUpvoted: wasUpvoted, upvoteCount: prevCount });
+              return next;
+            });
+          },
+          onSuccess: (status) => {
+            // Reconcile with the server's authoritative count/state (e.g.
+            // concurrent votes from others), when available.
+            if (status) {
+              setUpvoteOverlay((prev) => {
+                const next = new Map(prev);
+                next.set(item.uid, { viewerHasUpvoted: status.viewerHasUpvoted, upvoteCount: status.upvoteCount });
+                return next;
+              });
+            }
+            onTeamNewsUpvoteToggled(item, position, nextUpvoted, source);
+          },
+        },
+      );
+    },
+    [onTeamNewsUpvoteToggled, upvoteMutate],
+  );
 
   const total = initialData.total;
-  const previewItems = initialData.items.slice(0, TEAM_NEWS_PREVIEW_LIMIT);
+  const previewItems = useMemo(
+    () => mergeUpvoteOverlay(initialData.items.slice(0, TEAM_NEWS_PREVIEW_LIMIT), upvoteOverlay),
+    [initialData.items, upvoteOverlay],
+  );
   const hasMore = total > TEAM_NEWS_PREVIEW_LIMIT;
 
   const handleCardClick = useCallback(
@@ -49,6 +109,7 @@ export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailPro
                 variant="flat"
                 analyticsSource="team-profile-rail"
                 onClick={(clicked) => handleCardClick(clicked, index)}
+                onUpvoteToggle={(toggled) => handleUpvoteToggle(toggled, index, 'team-profile-rail')}
               />
             ))}
           </div>
@@ -74,6 +135,8 @@ export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailPro
         teamName={teamName}
         total={total}
         fullscreen={isMobile}
+        upvoteOverlay={upvoteOverlay}
+        onUpvoteToggle={handleUpvoteToggle}
       />
     </>
   );

--- a/components/page/team-details/TeamNews/TeamNewsRail.tsx
+++ b/components/page/team-details/TeamNews/TeamNewsRail.tsx
@@ -109,7 +109,7 @@ export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailPro
                 variant="flat"
                 analyticsSource="team-profile-rail"
                 onClick={(clicked) => handleCardClick(clicked, index)}
-                onUpvoteToggle={(toggled) => handleUpvoteToggle(toggled, index, 'team-profile-rail')}
+                onUpvoteToggle={(toggled: ITeamNewsItem) => handleUpvoteToggle(toggled, index, 'team-profile-rail')}
               />
             ))}
           </div>

--- a/services/team-news/hooks/useTeamNewsByTeam.ts
+++ b/services/team-news/hooks/useTeamNewsByTeam.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 
 import type { ITeamNewsByTeamResponse, ITeamNewsItem } from '@/types/team-news.types';
+import { getCookiesFromClient } from '@/utils/third-party.helper';
 
 import { fetchTeamNewsByTeam } from '../team-news.service';
 import { TeamNewsQueryKeys, TEAM_NEWS_MODAL_PAGE_SIZE } from '../constants';
@@ -28,11 +29,17 @@ export function useTeamNewsByTeamInfinite({
     queryKey: [TeamNewsQueryKeys.BY_TEAM, teamUid, search, limit],
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>
-      fetchTeamNewsByTeam(teamUid, {
-        page: pageParam as number,
-        limit,
-        q: search || undefined,
-      }).then((data) => {
+      // Pass the viewer's token so `viewerHasUpvoted` reflects them, not the
+      // anonymous view (the server rail fetch does the same via page.tsx).
+      fetchTeamNewsByTeam(
+        teamUid,
+        {
+          page: pageParam as number,
+          limit,
+          q: search || undefined,
+        },
+        getCookiesFromClient().authToken,
+      ).then((data) => {
         if (!data) {
           throw new Error('Failed to fetch team news');
         }
@@ -45,10 +52,7 @@ export function useTeamNewsByTeamInfinite({
     enabled: enabled && !!teamUid,
   });
 
-  const items: ITeamNewsItem[] = useMemo(
-    () => query.data?.pages.flatMap((page) => page.items) ?? [],
-    [query.data],
-  );
+  const items: ITeamNewsItem[] = useMemo(() => query.data?.pages.flatMap((page) => page.items) ?? [], [query.data]);
 
   const total = query.data?.pages[0]?.total ?? 0;
 

--- a/services/team-news/team-news.service.ts
+++ b/services/team-news/team-news.service.ts
@@ -31,13 +31,16 @@ export function buildTeamNewsByTeamUrl(teamUid: string, options: FetchTeamNewsBy
 export async function fetchTeamNewsByTeam(
   teamUid: string,
   options: FetchTeamNewsByTeamOptions = {},
+  authToken?: string,
 ): Promise<ITeamNewsByTeamResponse | null> {
   const url = buildTeamNewsByTeamUrl(teamUid, options);
 
   try {
+    // Auth is optional, but without it `viewerHasUpvoted` comes back as the
+    // anonymous view — same convention as the grouped/popular fetchers below.
     const response = await fetch(url, {
       cache: 'no-store',
-      headers: { 'Content-Type': 'application/json' },
+      headers: getHeader(authToken),
     });
     if (!response.ok) {
       return null;


### PR DESCRIPTION
## Summary
- Adds upvoting to Team News on the Team Profile page — in the sidebar rail, the desktop "View all news" modal, and the mobile full-page view — reusing the homepage newsfeed's `UpvoteButton`, `useTeamNewsUpvoteToggle` mutation, and optimistic-overlay pattern (hidden-zero count, revert on error, reconcile with the server on success). No toasts.
- The shared overlay lives in `TeamNewsRail`, which renders both the rail and `TeamNewsModal`, so a vote in either view is immediately reflected in the other — matching the prototype's lifted-state design (`prototypes/entries/team-profile/`).
- The shared `NewsCard` gains optional `upvoteCount`/`viewerHasUpvoted`/`onUpvoteToggle` props (rendered next to Discuss, gated on store hydration); homepage usage is unchanged since it doesn't pass them. Guests who click Upvote are redirected to the sign-in flow (`#login`), same as Follow.
- **Data fix:** `fetchTeamNewsByTeam` sent no auth header, so `viewerHasUpvoted` was always the anonymous view. It now accepts an optional `authToken` (like the grouped/popular fetchers), passed from the team page's server fetch and the modal's client query.
- **Bug fix:** `NewsCard`'s Enter-key handler fired regardless of event target, so Enter on an inner button would also open the article — now guarded.
- Prototype card design ported to the team-profile `compact` variant: 16px/22px headline, 2-line summary clamp at base size, tighter row rhythm, row-gap for the wrapped actions line.

## Testing
- New `__tests__/page/home/news-card.test.tsx` (7 cases): button absent without props, signed-in toggle, guest redirect, hydration gating, Enter-key guard, voted state, hidden-zero.
- Extended `__tests__/page/teams/team-news-rail.test.tsx`: optimistic upvote + server reconcile + analytics source + overlay shared with the modal; optimistic revert on mutation failure.
- Extended `__tests__/services/team-news/team-news.service.test.ts`: Bearer-token header assertions for `fetchTeamNewsByTeam`.
- Full suite passes (627 tests); lint/types/prettier clean on touched files (one pre-existing `react-hooks/set-state-in-effect` error in `TeamNewsModal.tsx` exists on `main` and is untouched).

## Notes for review
- **Backend assumption:** `/v1/teams/{uid}/team-news` should return `viewerHasUpvoted`/`upvoteCount` when called with a Bearer token (the fields are already on `ITeamNewsItem` and the upvote endpoint shipped with homepage v1). If the endpoint omits them, voting still works but the initial voted state renders unvoted — please verify against dev.
- Not yet visually verified against the live prototype in a browser — worth a pass on the preview deploy (design reference: https://directoryv2.dev.plnetwork.io/prototypes/team-profile).

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)