### PR TITLE
LAB-2107 [Team News] Digest content toggles

### DIFF
--- a/__tests__/page/email-preferences/forum-digest.test.tsx
+++ b/__tests__/page/email-preferences/forum-digest.test.tsx
@@ -45,11 +45,14 @@ jest.mock('@/services/forum/hooks/useGetForumDigestSettings', () => ({
 
 const mockOnForumDigestOptionSelect = jest.fn();
 const mockOnForumDigestSaveFailed = jest.fn();
+const mockOnForumDigestNetworkNewsToggleClicked = jest.fn();
+const mockOnForumDigestForumActivityToggleClicked = jest.fn();
 jest.mock('@/analytics/settings.analytics', () => ({
   useSettingsAnalytics: () => ({
     onForumDigestOptionSelect: (...a: unknown[]) => mockOnForumDigestOptionSelect(...a),
     onForumDigestSaveFailed: (...a: unknown[]) => mockOnForumDigestSaveFailed(...a),
-    onForumDigestNetworkNewsToggleClicked: jest.fn(),
+    onForumDigestNetworkNewsToggleClicked: (...a: unknown[]) => mockOnForumDigestNetworkNewsToggleClicked(...a),
+    onForumDigestForumActivityToggleClicked: (...a: unknown[]) => mockOnForumDigestForumActivityToggleClicked(...a),
   }),
 }));
 
@@ -58,10 +61,17 @@ const userInfo: IUserInfo = { uid: 'user-1' };
 const baseData: ForumDigestSettings = {
   forumDigestEnabled: false,
   forumDigestFrequency: 7,
+  forumDigestForumEnabled: true,
   forumDigestNewsEnabled: false,
   forumDigestLastSentAt: null,
   memberExternalId: null,
   memberUid: 'user-1',
+};
+
+const enabledData: ForumDigestSettings = {
+  ...baseData,
+  forumDigestEnabled: true,
+  forumDigestNewsEnabled: true,
 };
 
 describe('ForumDigest', () => {
@@ -76,13 +86,13 @@ describe('ForumDigest', () => {
     ['Weekly Digest', 'weekly'],
   ])('%s branch', (optionLabel, attemptedFrequency) => {
     it('calls mutate with the expected payload', () => {
-      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} hasForumAccess />);
       fireEvent.click(screen.getByRole('button', { name: optionLabel }));
       expect(mockMutate).toHaveBeenCalledTimes(1);
     });
 
     it('fires onForumDigestOptionSelect(source: settings) on success, and not onForumDigestSaveFailed', () => {
-      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} hasForumAccess />);
       fireEvent.click(screen.getByRole('button', { name: optionLabel }));
 
       const options = mockMutate.mock.calls[0][1];
@@ -93,7 +103,7 @@ describe('ForumDigest', () => {
     });
 
     it('fires onForumDigestSaveFailed(source: settings) on failure, and not onForumDigestOptionSelect', () => {
-      render(<ForumDigest userInfo={userInfo} initialData={baseData} />);
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} hasForumAccess />);
       fireEvent.click(screen.getByRole('button', { name: optionLabel }));
 
       const options = mockMutate.mock.calls[0][1];
@@ -101,6 +111,67 @@ describe('ForumDigest', () => {
 
       expect(mockOnForumDigestSaveFailed).toHaveBeenCalledWith({ attemptedFrequency, source: 'settings' });
       expect(mockOnForumDigestOptionSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content-type toggles', () => {
+    it('hides both toggles while the digest is off', () => {
+      render(<ForumDigest userInfo={userInfo} initialData={baseData} hasForumAccess />);
+      expect(screen.queryByText('Forum activity')).not.toBeInTheDocument();
+      expect(screen.queryByText('Network news')).not.toBeInTheDocument();
+    });
+
+    it('shows both toggles when the digest is enabled', () => {
+      mockGetForumDigestSettings.mockReturnValue({ data: enabledData });
+      render(<ForumDigest userInfo={userInfo} initialData={enabledData} hasForumAccess />);
+      expect(screen.getByText('Forum activity')).toBeInTheDocument();
+      expect(screen.getByText('Network news')).toBeInTheDocument();
+    });
+
+    it('mutates forumDigestForumEnabled and fires analytics when the forum-activity toggle is clicked', () => {
+      mockGetForumDigestSettings.mockReturnValue({ data: enabledData });
+      render(<ForumDigest userInfo={userInfo} initialData={enabledData} hasForumAccess />);
+
+      fireEvent.click(screen.getByRole('switch', { name: /forum activity/i }));
+
+      expect(mockMutate).toHaveBeenCalledWith({
+        uid: 'user-1',
+        payload: { ...enabledData, forumDigestForumEnabled: false },
+      });
+      expect(mockOnForumDigestForumActivityToggleClicked).toHaveBeenCalledWith({ forumDigestForumEnabled: false });
+    });
+
+    it('mutates forumDigestNewsEnabled and fires analytics when the network-news toggle is clicked', () => {
+      mockGetForumDigestSettings.mockReturnValue({ data: enabledData });
+      render(<ForumDigest userInfo={userInfo} initialData={enabledData} hasForumAccess />);
+
+      fireEvent.click(screen.getByRole('switch', { name: /network news/i }));
+
+      expect(mockMutate).toHaveBeenCalledWith({
+        uid: 'user-1',
+        payload: { ...enabledData, forumDigestNewsEnabled: false },
+      });
+      expect(mockOnForumDigestNetworkNewsToggleClicked).toHaveBeenCalledWith({ forumDigestNewsEnabled: false });
+    });
+
+    it('renders the forum-activity toggle disabled and off for users without forum access, and never mutates it', () => {
+      mockGetForumDigestSettings.mockReturnValue({ data: enabledData });
+      render(<ForumDigest userInfo={userInfo} initialData={enabledData} hasForumAccess={false} />);
+
+      const forumSwitch = screen.getByRole('switch', { name: /forum activity/i });
+      expect(forumSwitch).toBeDisabled();
+      expect(forumSwitch).not.toBeChecked();
+
+      fireEvent.click(forumSwitch);
+      expect(mockMutate).not.toHaveBeenCalled();
+      expect(mockOnForumDigestForumActivityToggleClicked).not.toHaveBeenCalled();
+
+      // Network news still works without forum access.
+      fireEvent.click(screen.getByRole('switch', { name: /network news/i }));
+      expect(mockMutate).toHaveBeenCalledWith({
+        uid: 'user-1',
+        payload: { ...enabledData, forumDigestNewsEnabled: false },
+      });
     });
   });
 });

--- a/__tests__/page/home/news-rail.test.tsx
+++ b/__tests__/page/home/news-rail.test.tsx
@@ -32,11 +32,6 @@ jest.mock('@/analytics/settings.analytics', () => ({
   }),
 }));
 
-const mockUseForumAccess = jest.fn();
-jest.mock('@/services/access-control/hooks/useForumAccess', () => ({
-  useForumAccess: () => mockUseForumAccess(),
-}));
-
 const mockOnPopularItemClick = jest.fn();
 
 describe('NewsRail', () => {
@@ -44,7 +39,6 @@ describe('NewsRail', () => {
     jest.clearAllMocks();
     mockUseCurrentUserStore.mockReturnValue({ currentUser: null, isHydrated: false });
     mockGetForumDigestSettings.mockReturnValue({ data: { forumDigestEnabled: false } });
-    mockUseForumAccess.mockReturnValue({ hasAccess: false, isLoading: false });
   });
 
   it('does not render the why-follow explainer', () => {
@@ -74,7 +68,6 @@ describe('NewsRail', () => {
 
   it('calls the forum-digest mutation with weekly frequency when an authenticated user subscribes, and fires onForumDigestOptionSelect(source: home-feed) once it succeeds', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
-    mockUseForumAccess.mockReturnValue({ hasAccess: true, isLoading: false });
     mockGetForumDigestSettings.mockReturnValue({
       data: { forumDigestEnabled: false, forumDigestFrequency: 7, memberUid: 'user-1' },
     });
@@ -102,7 +95,6 @@ describe('NewsRail', () => {
 
   it('fires onForumDigestSaveFailed(source: home-feed) on mutation failure, and does not also fire onForumDigestOptionSelect', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
-    mockUseForumAccess.mockReturnValue({ hasAccess: true, isLoading: false });
     mockGetForumDigestSettings.mockReturnValue({
       data: { forumDigestEnabled: false, forumDigestFrequency: 7, memberUid: 'user-1' },
     });
@@ -118,7 +110,6 @@ describe('NewsRail', () => {
 
   it('shows the subscribed card with a link to Settings once forumDigestEnabled is true, instead of the promo card', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
-    mockUseForumAccess.mockReturnValue({ hasAccess: true, isLoading: false });
     mockGetForumDigestSettings.mockReturnValue({ data: { forumDigestEnabled: true } });
     render(<NewsRail onPopularItemClick={mockOnPopularItemClick} />);
 
@@ -130,13 +121,12 @@ describe('NewsRail', () => {
     expect(screen.queryByRole('button', { name: 'Subscribe' })).not.toBeInTheDocument();
   });
 
-  it('hides digest cards for authenticated users without forum access', () => {
+  it('shows the digest promo to authenticated users without forum access (news-only digest)', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
-    mockUseForumAccess.mockReturnValue({ hasAccess: false, isLoading: false });
     render(<NewsRail onPopularItemClick={mockOnPopularItemClick} />);
 
-    expect(screen.queryByText('Get network news Digest')).not.toBeInTheDocument();
-    expect(screen.queryByText("You're subscribed to the Digest")).not.toBeInTheDocument();
+    expect(screen.getByText('Get network news Digest')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Subscribe' })).toBeInTheDocument();
   });
 
   it('keeps a followed suggestion visible with Following for 2s, then removes it', () => {

--- a/analytics/settings.analytics.ts
+++ b/analytics/settings.analytics.ts
@@ -209,6 +209,10 @@ export const useSettingsAnalytics = () => {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_NETWORK_NEWS_TOGGLE_CLICKED, params);
   }
 
+  function onForumDigestForumActivityToggleClicked(params: Record<any, boolean>) {
+    captureEvent(SETTINGS_ANALYTICS_EVENTS.FORUM_DIGEST_FORUM_ACTIVITY_TOGGLE_CLICKED, params);
+  }
+
   function onSubscribeToPlNewsletterChange(params: Record<any, boolean>) {
     captureEvent(SETTINGS_ANALYTICS_EVENTS.SETTINGS_SUBSCRIBE_TO_NEWSLETTER_CHANGE, params);
   }
@@ -248,6 +252,7 @@ export const useSettingsAnalytics = () => {
     onForumDigestOptionSelect,
     onForumDigestSaveFailed,
     onForumDigestNetworkNewsToggleClicked,
+    onForumDigestForumActivityToggleClicked,
     onSubscribeToPlNewsletterChange,
     onSubscribeToDemoDayUpdatesChange,
     onDemoDayUpdatesNotificationToggleClicked,

--- a/components/page/email-preferences/components/EmailPreferencesForm/EmailPreferencesForm.tsx
+++ b/components/page/email-preferences/components/EmailPreferencesForm/EmailPreferencesForm.tsx
@@ -34,7 +34,9 @@ export const EmailPreferencesForm = ({ uid, userInfo, initialData }: Props) => {
   const router = useRouter();
   const { isInvestor: v2IsInvestor } = useInvestorAccess();
   const { currentUser } = useCurrentUserStore();
-  const hasDigestAccess = currentUser?.rbac?.effectivePermissions.some((p) => p.code === 'forum.read');
+  // The digest itself is available to everyone; forum access only controls
+  // whether the "Forum activity" content type can be enabled inside it.
+  const hasForumAccess = Boolean(currentUser?.rbac?.effectivePermissions.some((p) => p.code === 'forum.read'));
 
   useEffect(() => {
     triggerLoader(false);
@@ -57,7 +59,7 @@ export const EmailPreferencesForm = ({ uid, userInfo, initialData }: Props) => {
   return (
     <div className={s.root}>
       <h5 className={s.title}>Email Preferences</h5>
-      {hasDigestAccess && <ForumDigest userInfo={userInfo} initialData={initialData.settings} />}
+      <ForumDigest userInfo={userInfo} initialData={initialData.settings} hasForumAccess={hasForumAccess} />
       {!v2IsInvestor && <Newsletter userInfo={userInfo} initialData={initialData.memberInfo} />}
       <DemoDayUpdates userInfo={userInfo} initialData={initialData.demoDaySubscription} />
       <InvestorCommunications

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.module.scss
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.module.scss
@@ -75,3 +75,8 @@
   line-height: 22px; /* 157.143% */
   letter-spacing: -0.2px;
 }
+
+.Switch[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
+++ b/components/page/email-preferences/components/ForumDigest/ForumDigest.tsx
@@ -26,21 +26,29 @@ const options = [
   {
     label: 'No Digest',
     value: 'no_digest',
-    description: 'Don’t receive forum digests by email.',
+    description: 'Don’t receive digest emails.',
   },
   {
     label: 'Daily Digest',
     value: 'daily_digest',
-    description: 'New and trending posts every day.',
+    description: 'A summary of what’s new every day.',
   },
   {
     label: 'Weekly Digest',
     value: 'weekly_digest',
-    description: 'Top discussions and replies every week.',
+    description: 'A summary of what’s new every week.',
   },
 ];
 
-export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; initialData: ForumDigestSettings }) => {
+export const ForumDigest = ({
+  userInfo,
+  initialData,
+  hasForumAccess,
+}: {
+  userInfo: IUserInfo;
+  initialData: ForumDigestSettings;
+  hasForumAccess: boolean;
+}) => {
   const { mutate } = useUpdateForumDigestSettings();
   const { data } = useGetForumDigestSettings(userInfo.uid, initialData);
   const analytics = useSettingsAnalytics();
@@ -161,12 +169,28 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
     analytics.onForumDigestNetworkNewsToggleClicked({ forumDigestNewsEnabled: checked });
   };
 
+  const handleForumChange = (checked: boolean) => {
+    if (!userInfo.uid || !data || !hasForumAccess) {
+      return;
+    }
+
+    mutate({
+      uid: userInfo.uid,
+      payload: {
+        ...data,
+        forumDigestForumEnabled: checked,
+      },
+    });
+
+    analytics.onForumDigestForumActivityToggleClicked({ forumDigestForumEnabled: checked });
+  };
+
   return (
     <div className={s.root}>
-      <div className={s.header}>Forum Digest</div>
+      <div className={s.header}>Digest</div>
       <div className={s.content}>
         <Field.Root className={s.field}>
-          <Field.Label className={clsx(s.label)}>Email me about forum activity:</Field.Label>
+          <Field.Label className={clsx(s.label)}>Email me a digest:</Field.Label>
           <Select
             menuPlacement="auto"
             placeholder="Select frequency"
@@ -267,23 +291,44 @@ export const ForumDigest = ({ userInfo, initialData }: { userInfo: IUserInfo; in
           />
         </Field.Root>
         {data?.forumDigestEnabled && (
-          <div className={s.toggleSection}>
-            <label className={clsx(s.Label, s.toggle)}>
-              Include Network News
-              <Switch.Root
-                className={s.Switch}
-                checked={data?.forumDigestNewsEnabled ?? true}
-                onCheckedChange={handleNewsChange}
-              >
-                <Switch.Thumb className={s.Thumb}>
-                  <div className={s.dot} />
-                </Switch.Thumb>
-              </Switch.Root>
-            </label>
-            <div className={s.desc}>
-              Get the latest news from teams across the network included in your digest email.
+          <>
+            {/* Forum activity is hard-gated on forum access: without it the
+                toggle is rendered disabled and always off, and the backend
+                never includes forum posts in the digest either way. */}
+            <div className={s.toggleSection}>
+              <label className={clsx(s.Label, s.toggle)}>
+                Forum activity
+                <Switch.Root
+                  className={s.Switch}
+                  checked={hasForumAccess && (data?.forumDigestForumEnabled ?? true)}
+                  disabled={!hasForumAccess}
+                  onCheckedChange={handleForumChange}
+                >
+                  <Switch.Thumb className={s.Thumb}>
+                    <div className={s.dot} />
+                  </Switch.Thumb>
+                </Switch.Root>
+              </label>
+              <div className={s.desc}>Discussions, replies, and trending posts from the forum.</div>
             </div>
-          </div>
+            <div className={s.toggleSection}>
+              <label className={clsx(s.Label, s.toggle)}>
+                Network news
+                <Switch.Root
+                  className={s.Switch}
+                  checked={data?.forumDigestNewsEnabled ?? true}
+                  onCheckedChange={handleNewsChange}
+                >
+                  <Switch.Thumb className={s.Thumb}>
+                    <div className={s.dot} />
+                  </Switch.Thumb>
+                </Switch.Root>
+              </label>
+              <div className={s.desc}>
+                Funding, launches, partnerships, and milestones from teams across the network.
+              </div>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { AnimatePresence, motion } from 'framer-motion';
 
-import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useGetForumDigestSettings, type ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
@@ -39,6 +38,7 @@ const MailIcon = () => (
 const buildDefaultDigestSettings = (uid: string): ForumDigestSettings => ({
   forumDigestEnabled: false,
   forumDigestFrequency: 7,
+  forumDigestForumEnabled: true,
   forumDigestNewsEnabled: false,
   forumDigestLastSentAt: null,
   memberExternalId: null,
@@ -168,9 +168,7 @@ export function NewsRail({
 }: NewsRailProps) {
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
-  const { hasAccess, isLoading: forumAccessLoading } = useForumAccess();
   const analytics = useSettingsAnalytics();
-  const showDigest = !currentUser || (!forumAccessLoading && hasAccess);
   const { mutate } = useUpdateForumDigestSettings();
   const visibleSuggestions = useDelayedHideFollowedSuggestions(suggestedTeams, followedTeamUids);
 
@@ -223,42 +221,39 @@ export function NewsRail({
           <PopularThisWeekCard key="popular-this-week" items={popularItems} onPopularItemClick={onPopularItemClick} />
         )}
 
-        {showDigest &&
-          (isSubscribed ? (
-            <motion.section
-              key="digest-subscribed"
-              layout
-              className={s.subscribedCard}
-              aria-label="You're subscribed to the news digest"
-            >
-              <span className={s.iconBadge} aria-hidden="true">
-                <MailIcon />
-              </span>
-              <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
-              <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
-              <Link href="/settings/email" className={s.manageLink}>
-                <span>Manage in Settings</span>
-                <ArrowRight />
-              </Link>
-            </motion.section>
-          ) : (
-            <motion.section
-              key="digest-promo"
-              layout
-              className={s.digestCard}
-              aria-label="Subscribe to the news digest"
-            >
-              <p className={s.digestTitle}>Get network news Digest</p>
-              <p className={s.digestBody}>
-                A news digest covering raises, launches, and milestones across the network, straight to your inbox.
-              </p>
-              {isHydrated && (
-                <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
-                  <span>Subscribe</span>
-                </button>
-              )}
-            </motion.section>
-          ))}
+        {/* The digest CTA is open to everyone — members without forum access
+            get a network-news-only digest (forum posts are suppressed
+            server-side at send time). */}
+        {isSubscribed ? (
+          <motion.section
+            key="digest-subscribed"
+            layout
+            className={s.subscribedCard}
+            aria-label="You're subscribed to the news digest"
+          >
+            <span className={s.iconBadge} aria-hidden="true">
+              <MailIcon />
+            </span>
+            <p className={s.whyTitle}>You&apos;re subscribed to the Digest</p>
+            <p className={s.whyBody}>Change frequency or unsubscribe anytime in Settings.</p>
+            <Link href="/settings/email" className={s.manageLink}>
+              <span>Manage in Settings</span>
+              <ArrowRight />
+            </Link>
+          </motion.section>
+        ) : (
+          <motion.section key="digest-promo" layout className={s.digestCard} aria-label="Subscribe to the news digest">
+            <p className={s.digestTitle}>Get network news Digest</p>
+            <p className={s.digestBody}>
+              A news digest covering raises, launches, and milestones across the network, straight to your inbox.
+            </p>
+            {isHydrated && (
+              <button type="button" className={s.digestBtn} onClick={handleSubscribeClick}>
+                <span>Subscribe</span>
+              </button>
+            )}
+          </motion.section>
+        )}
       </AnimatePresence>
     </aside>
   );

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -39,7 +39,11 @@ const buildDefaultDigestSettings = (uid: string): ForumDigestSettings => ({
   forumDigestEnabled: false,
   forumDigestFrequency: 7,
   forumDigestForumEnabled: true,
-  forumDigestNewsEnabled: false,
+  // Both content types default to on: this fallback is used as the subscribe
+  // payload when the real settings haven't loaded yet, and a member without
+  // forum access who subscribed with news off would get an empty (never-sent)
+  // digest.
+  forumDigestNewsEnabled: true,
   forumDigestLastSentAt: null,
   memberExternalId: null,
   memberUid: uid,

--- a/services/forum/hooks/useGetForumDigestSettings.ts
+++ b/services/forum/hooks/useGetForumDigestSettings.ts
@@ -5,6 +5,7 @@ import { ForumQueryKeys } from '@/services/forum/constants';
 export type ForumDigestSettings = {
   forumDigestEnabled: boolean;
   forumDigestFrequency: 1 | 7;
+  forumDigestForumEnabled: boolean;
   forumDigestNewsEnabled: boolean;
   forumDigestLastSentAt: null;
   memberExternalId: null;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -218,6 +218,7 @@ export const SETTINGS_ANALYTICS_EVENTS = {
   FORUM_DIGEST_OPTION_SELECTED: 'settings-forum-digest-option-selected',
   FORUM_DIGEST_SAVE_FAILED: 'settings-forum-digest-save-failed',
   FORUM_DIGEST_NETWORK_NEWS_TOGGLE_CLICKED: 'settings-forum-digest-network-news-toggle-clicked',
+  FORUM_DIGEST_FORUM_ACTIVITY_TOGGLE_CLICKED: 'settings-forum-digest-forum-activity-toggle-clicked',
   SETTINGS_SUBSCRIBE_TO_DEMO_DAY_UPDATES_CHANGE: 'settings-subscribe-to-demo-day-updates-change',
   SETTINGS_DEMO_DAY_UPDATES_NOTIFICATION_TOGGLE_CLICKED: 'settings-demo-day-updates-notification-toggle-clicked',
 };


### PR DESCRIPTION
### Ticket
[LAB-2107](https://linear.app/plrs-labos/issue/LAB-2107/team-news-digest-content-toggles-digest-for-users-without-forum-access)

### Summary
- The digest is now available to all members — previously the Email Preferences section and the home-feed subscribe card were hidden for users without forum access.
- The "Forum Digest" section in Settings > Email Preferences is renamed to "Digest", with copy updated to reflect that it covers more than forum content.
- When the digest is enabled, two content-type toggles appear: **Forum activity** and **Network news**, each controlling whether that section is included in the digest email.
- For members without forum access, the Forum activity toggle is shown disabled and off — they can subscribe to a news-only digest.
- Subscribing from the home feed now defaults both content types to on, so new subscribers always receive a digest.
- Adds an analytics event for the Forum activity toggle and test coverage for the new behavior.

### Screenshot
<img width="1123" height="1109" alt="Screenshot 2026-07-10 at 6 31 14 PM" src="https://github.com/user-attachments/assets/d1ca02e0-5f46-4f49-b64e-e3343fafc339" />

### Related PRs
- Backend: memser-spaceport/pln-directory-portal#3240
- Notification service: memser-spaceport/pl-notification-service#117
