### PR TITLE
feat(team-news): clickable Teams to Follow names with short-description subtitle

### DIFF
--- a/__tests__/page/home/teams-to-follow-card.test.tsx
+++ b/__tests__/page/home/teams-to-follow-card.test.tsx
@@ -82,6 +82,57 @@ describe('TeamsToFollowCard', () => {
     expect(screen.queryByText(/followers/i)).not.toBeInTheDocument();
   });
 
+  it('links the team name to its profile, opening in a new tab', () => {
+    render(
+      <TeamsToFollowCard
+        suggestions={[team({ uid: 't1', name: 'Banyan Storage' })]}
+        isLoading={false}
+        followedTeamUids={emptyFollowed}
+        onFollowToggle={mockOnFollowToggle}
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'Banyan Storage' });
+    expect(link).toHaveAttribute('href', '/teams/t1');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('prefers the short description as the subtitle when available', () => {
+    render(
+      <TeamsToFollowCard
+        suggestions={[
+          team({
+            uid: 't1',
+            name: 'Banyan Storage',
+            reason: 'Storage · 1.2k followers',
+            shortDescription: 'Decentralized hot storage for large datasets.',
+          }),
+        ]}
+        isLoading={false}
+        followedTeamUids={emptyFollowed}
+        onFollowToggle={mockOnFollowToggle}
+      />,
+    );
+    expect(screen.getByText('Decentralized hot storage for large datasets.')).toBeInTheDocument();
+    expect(screen.queryByText('Storage')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the focus-area reason when the short description is missing or blank', () => {
+    render(
+      <TeamsToFollowCard
+        suggestions={[
+          team({ uid: 't1', name: 'Banyan Storage', shortDescription: '   ' }),
+          team({ uid: 't2', name: 'Other Team', reason: 'Infrastructure · 890 followers' }),
+        ]}
+        isLoading={false}
+        followedTeamUids={emptyFollowed}
+        onFollowToggle={mockOnFollowToggle}
+      />,
+    );
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+  });
+
   it('redirects to login on follow click when anonymous, without calling onFollowToggle', () => {
     render(
       <TeamsToFollowCard

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.module.scss
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.module.scss
@@ -196,6 +196,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-decoration: none;
+
+  &:hover {
+    color: #1b4dff;
+    text-decoration: underline;
+  }
 }
 
 .railReason {
@@ -204,6 +210,12 @@
   line-height: 16px;
   letter-spacing: -0.2px;
   color: #455468;
+  /* Short descriptions can run longer than the old focus-area label — keep
+     rows tidy at two lines. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .railStory {

--- a/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
@@ -90,7 +90,9 @@ export function TeamsToFollowCard({
       <h3 className={s.railTitle}>Teams to follow</h3>
       {suggestions.map((team, position) => {
         const isFollowing = followedTeamUids.has(team.uid);
-        const reason = stripFollowerCountFromReason(team.reason);
+        // Prefer the team's own one-liner (same field the teams grid shows);
+        // the recommendation reason (focus area) is only the fallback.
+        const subtitle = team.shortDescription?.trim() || stripFollowerCountFromReason(team.reason);
         return (
           <div key={team.uid} className={s.railRow}>
             {team.logo ? (
@@ -100,7 +102,15 @@ export function TeamsToFollowCard({
             )}
             <span className={s.railInfo}>
               <span className={s.railNameRow}>
-                <span className={s.railName}>{team.name}</span>
+                <a
+                  href={`/teams/${team.uid}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={s.railName}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {team.name}
+                </a>
                 <FollowButton
                   following={isFollowing}
                   onClick={handleFollowClick(team, position)}
@@ -109,7 +119,7 @@ export function TeamsToFollowCard({
                   disabled={isFollowing}
                 />
               </span>
-              {reason ? <span className={s.railReason}>{reason}</span> : null}
+              {subtitle ? <span className={s.railReason}>{subtitle}</span> : null}
             </span>
           </div>
         );

--- a/types/team-news.types.ts
+++ b/types/team-news.types.ts
@@ -41,6 +41,9 @@ export interface ISuggestedTeam {
   name: string;
   logo: string | null;
   reason: string;
+  /** One-line team blurb (same field the teams grid shows). Optional until the
+      follow-suggestions endpoint ships it; the UI falls back to `reason`. */
+  shortDescription?: string | null;
 }
 
 export interface ITeamNewsFollowSuggestionsResponse {


### PR DESCRIPTION
## Summary
- Team names in the newsfeed's "Teams to Follow" card are now links that open the team profile in a new tab (`/teams/{uid}`, `target="_blank"` + `rel="noopener noreferrer"` — same pattern as `NewsCard`'s team-name anchor), with hover underline/brand color.
- The row subtitle now prefers the team's one-line `shortDescription` (the same field the teams grid tiles display), falling back to the existing stripped focus-area `reason` when the description is missing or blank. Subtitle clamps at two lines so longer descriptions keep rows tidy.
- Follow button behavior is completely unchanged (guest → `#login` redirect, `onFollowToggle` args, Following/disabled state).

## Data note (backend follow-up)
`GET /v1/team-news/follow-suggestions` does not return `shortDescription` today — `ISuggestedTeam` types it as optional and the UI degrades gracefully to the current focus-area subtitle. Descriptions will light up automatically (no frontend change needed) once the endpoint adds the field. Recommend a small backend ticket for that.

## Testing
- Extended `__tests__/page/home/teams-to-follow-card.test.tsx` (11 total): name renders as a link with correct href/target/rel; short description preferred as subtitle; fallback to focus-area reason when missing or whitespace-only; all pre-existing follow-behavior tests unchanged and passing.
- Full suite green (620 tests); lint, types, and prettier clean on touched files.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)