### PR TITLE
fix(ai-apps): feedback page tab overflow, cell clamping, optimistic badge count

### DIFF
--- a/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.module.scss
+++ b/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.module.scss
@@ -100,12 +100,21 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .tab {
   position: relative;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 8px;
   padding: 10px 4px 14px;
   margin-right: 20px;
@@ -114,6 +123,7 @@
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
+  white-space: nowrap;
   color: var(--foreground-neutral-primary, #0a0c11);
 
   &:hover {
@@ -216,8 +226,14 @@
   white-space: nowrap;
 }
 
-.messageCell {
+// -webkit-box is unreliable directly on a td, so the clamp lives on an inner div.
+.messageText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .dateCell {

--- a/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.tsx
+++ b/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.tsx
@@ -141,14 +141,20 @@ export function AiAppFeedbackPage() {
                       const submitterName = row.member?.name ?? 'Unknown member';
                       return (
                         <tr key={row.uid}>
-                          <td className={s.appNameCell}>{row.appName}</td>
-                          <td className={s.messageCell}>{row.text}</td>
+                          <td className={s.appNameCell} title={row.appName}>
+                            {row.appName}
+                          </td>
+                          <td title={row.text}>
+                            <div className={s.messageText}>{row.text}</div>
+                          </td>
                           <td>
                             <div className={s.submitter}>
                               <span className={s.avatar} style={{ background: getAvatarColor(submitterName) }}>
                                 {submitterName.charAt(0).toUpperCase()}
                               </span>
-                              <span className={s.submitterName}>{submitterName}</span>
+                              <span className={s.submitterName} title={submitterName}>
+                                {submitterName}
+                              </span>
                             </div>
                           </td>
                           <td className={s.dateCell}>

--- a/services/ai-app-feedback/hooks/useSubmitAiAppFeedback.ts
+++ b/services/ai-app-feedback/hooks/useSubmitAiAppFeedback.ts
@@ -1,7 +1,9 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
-import { submitAiAppFeedback } from '@/services/ai-app-feedback/ai-app-feedback.service';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AiAppFeedback, submitAiAppFeedback } from '@/services/ai-app-feedback/ai-app-feedback.service';
+import { AiAppFeedbackQueryKeys } from '@/services/ai-app-feedback/constants';
+import { useCurrentUserStore } from '@/services/auth/store';
 
 export interface SubmitAiAppFeedbackData {
   appUid: string;
@@ -9,10 +11,43 @@ export interface SubmitAiAppFeedbackData {
 }
 
 export function useSubmitAiAppFeedback() {
+  const queryClient = useQueryClient();
+  const { currentUser } = useCurrentUserStore();
+
   return useMutation({
     mutationFn: ({ appUid, text }: SubmitAiAppFeedbackData) => submitAiAppFeedback(appUid, text),
-    onError: (error) => {
+    // Optimistically prepend the new row to the per-app feedback cache so the
+    // "View feedback" badge and review table update without a reload. Only an
+    // already-cached list is touched - if the viewer can't review this app,
+    // there's no cache entry to update and nothing should appear anyway.
+    onMutate: async ({ appUid, text }: SubmitAiAppFeedbackData) => {
+      const queryKey = [AiAppFeedbackQueryKeys.AI_APP_FEEDBACK_LIST, appUid];
+      await queryClient.cancelQueries({ queryKey });
+
+      const previous = queryClient.getQueryData<AiAppFeedback[]>(queryKey);
+      if (previous) {
+        const optimisticRow: AiAppFeedback = {
+          uid: `optimistic-${Date.now()}`,
+          appUid,
+          text,
+          createdAt: new Date().toISOString(),
+          member: currentUser?.uid ? { uid: currentUser.uid, name: currentUser.name ?? 'You' } : null,
+        };
+        queryClient.setQueryData<AiAppFeedback[]>(queryKey, [optimisticRow, ...previous]);
+      }
+
+      return { previous, queryKey };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(context.queryKey, context.previous);
+      }
       console.error('Failed to submit AI App feedback:', error);
+    },
+    // Refetch regardless of outcome so the optimistic row (with its fake uid)
+    // is replaced by the server's canonical list.
+    onSettled: (_data, _error, { appUid }) => {
+      queryClient.invalidateQueries({ queryKey: [AiAppFeedbackQueryKeys.AI_APP_FEEDBACK_LIST, appUid] });
     },
   });
 }


### PR DESCRIPTION
## Summary
- Feedback page tabs render on a single line and scroll horizontally instead of wrapping onto multiple lines
- Feedback table cells clamp to 3 lines with ellipsis (`title` attribute shows the full text on hover); long unbroken strings wrap within the column instead of overflowing into From/Date
- Submitting feedback optimistically prepends the row to the per-app feedback query cache, so the "View feedback" badge count on /pl-infra/ai-apps updates immediately instead of only after a page reload (rolls back on error, invalidates on settle)

## Test plan
- [x] `npx jest --testPathPattern "ai-app"` — 11 suites, 60 tests pass
- [x] Verify tabs scroll horizontally on /pl-infra/ai-apps/feedback with many apps
- [x] Submit feedback with a long unbroken string and confirm it clamps instead of overflowing
- [ ] Submit feedback as an app creator/admin and confirm the badge count bumps without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)