### PR TITLE
LAB-2118 [AI Apps] Add deploy status check and retry when deployment fails

### DIFF
--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
@@ -60,6 +60,14 @@ export function AiAppDetailPage(props: Props) {
 
   const requiredEnvVars = app?.requiredEnvVars ?? [];
   const needsSetup = !!app && requiredEnvVars.length > 0 && app.status !== 'READY';
+  // A failed deploy (runner error, or a stuck deploy the backend settled to
+  // ERROR) is surfaced as a full status card — never a broken iframe — with the
+  // error notes and a retry path for the creator/admin.
+  const deployFailed = app?.status === 'ERROR';
+  // An in-flight deploy someone else started (agent redeploy, another admin).
+  // While OUR deploy runs (isRedeploying) the secrets panel owns the UI instead,
+  // so its result/error handling is never unmounted mid-flight.
+  const deployInProgress = app?.status === 'DEPLOYING' && !isRedeploying;
 
   useEffect(() => {
     if (!app || app.status !== 'DRAFT' || !needsSetup || trackedDraftSetupUid.current === app.uid) return;
@@ -153,11 +161,15 @@ export function AiAppDetailPage(props: Props) {
   // for a healthy, running app whose creator opted into updating its secrets
   // (showSecrets) — same centered card either way, so a voluntary redeploy
   // gets the identical experience to a first deploy or a failed one.
-  if (needsSetup || showSecrets) {
+  if (needsSetup || deployFailed || deployInProgress || showSecrets) {
+    // Back link only when the creator opened the card voluntarily over a
+    // healthy app — for a failed/undeployed/deploying app there is nothing
+    // usable behind it to go back to.
+    const cameFromHealthyApp = showSecrets && !needsSetup && !deployFailed && !deployInProgress;
     return (
       <div className={s.setupPage}>
         <div className={s.setupContent}>
-          {!needsSetup && (
+          {cameFromHealthyApp && (
             <button type="button" className={s.backLink} onClick={closeSecrets} disabled={isRedeploying}>
               <ArrowBackIcon width={16} height={16} />
               Back to app
@@ -172,12 +184,22 @@ export function AiAppDetailPage(props: Props) {
             </div>
             {app.description && <p className={s.setupDescription}>{app.description}</p>}
             {app.status === 'ERROR' && app.notes && <p className={s.setupError}>Last deploy failed: {app.notes}</p>}
-            {isCreator ? (
+            {deployInProgress ? (
+              <div className={s.progress}>
+                <div className={s.progressBar}>
+                  <div className={s.progressIndicator} />
+                </div>
+                <p className={s.progressText}>
+                  A deploy is in progress — this page updates automatically once it finishes.
+                </p>
+              </div>
+            ) : isCreator ? (
               <AppSecretsPanel app={app} onDeployingChange={setIsRedeploying} onDeploySucceeded={closeSecrets} />
             ) : (
               <p className={s.setupInfo}>
-                This app is not deployed yet. Only {app.member?.name ?? 'its creator'} can provide the required values
-                and deploy it.
+                {deployFailed
+                  ? `The last deploy of this app failed. Only ${app.member?.name ?? 'its creator'} or an admin can retry it.`
+                  : `This app is not deployed yet. Only ${app.member?.name ?? 'its creator'} can provide the required values and deploy it.`}
               </p>
             )}
           </div>

--- a/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
@@ -45,6 +45,9 @@ export function AppSecretsPanel(props: Props) {
 
   const provided = new Set(app.providedEnvVars);
   const isDraft = app.status === 'DRAFT';
+  // No env vars to collect — the panel is a plain retry of the stored bundle
+  // (shown after a failed/stuck deploy of a non-secrets app).
+  const isRetry = app.requiredEnvVars.length === 0;
 
   const onChange = (name: string, value: string) => {
     setValues((prev) => ({ ...prev, [name]: value }));
@@ -119,82 +122,100 @@ export function AppSecretsPanel(props: Props) {
   return (
     <div className={s.root}>
       <p className={s.intro}>
-        {isDraft
-          ? 'This app needs the following values before it can be deployed. They are stored securely on the sandbox and never shown again.'
-          : 'Update one or more values and re-deploy. Stored values are kept unless you edit them.'}
+        {isRetry
+          ? 'Retry deploying the stored app bundle to the sandbox. If the sandbox runner had an outage, retrying once it recovers usually fixes it — but if the app itself fails to build, ask your AI agent to fix it and deploy again.'
+          : isDraft
+            ? 'This app needs the following values before it can be deployed. They are stored securely on the sandbox and never shown again.'
+            : 'Update one or more values and re-deploy. Stored values are kept unless you edit them.'}
       </p>
 
-      <div className={s.fields}>
-        {app.requiredEnvVars.map((name) => {
-          const stored = provided.has(name);
-          const isEditing = !!editing[name];
-          const inputId = `secret-${name}`;
+      {!isRetry && (
+        <div className={s.fields}>
+          {app.requiredEnvVars.map((name) => {
+            const stored = provided.has(name);
+            const isEditing = !!editing[name];
+            const inputId = `secret-${name}`;
 
-          return (
-            <div key={name} className={s.field}>
-              <span className={s.fieldLabelRow}>
-                <label htmlFor={inputId} className={s.fieldName}>
-                  {name}
-                </label>
-                {stored && isEditing && (
-                  <button
-                    type="button"
-                    className={s.inlineLink}
-                    onClick={() => cancelEdit(name)}
+            return (
+              <div key={name} className={s.field}>
+                <span className={s.fieldLabelRow}>
+                  <label htmlFor={inputId} className={s.fieldName}>
+                    {name}
+                  </label>
+                  {stored && isEditing && (
+                    <button
+                      type="button"
+                      className={s.inlineLink}
+                      onClick={() => cancelEdit(name)}
+                      disabled={isDeploying}
+                    >
+                      Cancel — keep stored value
+                    </button>
+                  )}
+                </span>
+
+                {stored && !isEditing ? (
+                  <div className={`${s.input} ${s.lockedInput}`}>
+                    <span className={s.maskedValue} aria-hidden>
+                      ••••••••••••••••
+                    </span>
+                    <button
+                      type="button"
+                      ref={(el) => {
+                        if (el && pendingFocusName.current === name) {
+                          el.focus();
+                          pendingFocusName.current = null;
+                        }
+                      }}
+                      className={s.inlineLink}
+                      onClick={() => startEdit(name)}
+                      disabled={isDeploying}
+                    >
+                      Edit
+                    </button>
+                  </div>
+                ) : (
+                  <input
+                    id={inputId}
+                    className={s.input}
+                    type="password"
+                    autoComplete="off"
+                    autoFocus={isEditing}
+                    value={values[name] ?? ''}
+                    placeholder={stored ? 'Enter new value' : 'Required'}
+                    onChange={(e) => onChange(name, e.target.value)}
                     disabled={isDeploying}
-                  >
-                    Cancel — keep stored value
-                  </button>
+                  />
                 )}
-              </span>
-
-              {stored && !isEditing ? (
-                <div className={`${s.input} ${s.lockedInput}`}>
-                  <span className={s.maskedValue} aria-hidden>
-                    ••••••••••••••••
-                  </span>
-                  <button
-                    type="button"
-                    ref={(el) => {
-                      if (el && pendingFocusName.current === name) {
-                        el.focus();
-                        pendingFocusName.current = null;
-                      }
-                    }}
-                    className={s.inlineLink}
-                    onClick={() => startEdit(name)}
-                    disabled={isDeploying}
-                  >
-                    Edit
-                  </button>
-                </div>
-              ) : (
-                <input
-                  id={inputId}
-                  className={s.input}
-                  type="password"
-                  autoComplete="off"
-                  autoFocus={isEditing}
-                  value={values[name] ?? ''}
-                  placeholder={stored ? 'Enter new value' : 'Required'}
-                  onChange={(e) => onChange(name, e.target.value)}
-                  disabled={isDeploying}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {error && <p className={s.error}>{error}</p>}
 
       <div className={s.actions}>
         <Button variant="primary" size="m" onClick={onDeploy} disabled={isDeploying}>
-          {isDeploying ? (isDraft ? 'Deploying…' : 'Re-deploying…') : isDraft ? 'Deploy' : 'Re-deploy'}
+          {isDeploying
+            ? isRetry
+              ? 'Retrying…'
+              : isDraft
+                ? 'Deploying…'
+                : 'Re-deploying…'
+            : isRetry
+              ? 'Retry deploy'
+              : isDraft
+                ? 'Deploy'
+                : 'Re-deploy'}
         </Button>
         {isDeploying && (
           <span className={s.deployNote}>
-            {isDraft ? 'The first deploy can take a couple of minutes.' : 'Restarting the app with the updated values.'}
+            {isRetry
+              ? 'Redeploying the stored bundle — this can take a couple of minutes.'
+              : isDraft
+                ? 'The first deploy can take a couple of minutes.'
+                : 'Restarting the app with the updated values.'}
           </span>
         )}
       </div>

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
@@ -61,6 +61,18 @@
   color: #92400e;
 }
 
+.errorBadge {
+  @extend .draftBadge;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.deployingBadge {
+  @extend .draftBadge;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
 .description {
   margin: 0;
   color: #475569;

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
@@ -28,12 +28,16 @@ export function AiAppCard(props: Props) {
   };
 
   const isDraft = app.status === 'DRAFT';
+  const hasDeployFailed = app.status === 'ERROR';
+  const isDeploying = app.status === 'DEPLOYING';
 
   const body = (
     <>
       <div className={s.nameRow}>
         <h3 className={s.name}>{app.name}</h3>
         {isDraft && <span className={s.draftBadge}>Draft</span>}
+        {hasDeployFailed && <span className={s.errorBadge}>Deploy failed</span>}
+        {isDeploying && <span className={s.deployingBadge}>Deploying</span>}
       </div>
       <p className={s.description}>{app.description}</p>
     </>

--- a/services/ai-apps/hooks/useAiApp.ts
+++ b/services/ai-apps/hooks/useAiApp.ts
@@ -10,6 +10,10 @@ export function useAiApp(uid: string) {
     queryFn: () => fetchAiApp(uid),
     staleTime: 5 * 60 * 1000,
     retry: 2,
+    // While a deploy is in flight (e.g. agent-triggered), keep polling so the
+    // page picks up the settled READY/ERROR state — including the backend
+    // marking a stuck deploy as failed — without a manual reload.
+    refetchInterval: (query) => (query.state.data?.status === 'DEPLOYING' ? 5000 : false),
   });
 
   return {


### PR DESCRIPTION
## Ticket

[LAB-2118](https://linear.app/plrs-labos/issue/LAB-2118/ai-apps-add-deploy-status-check-and-retry-when-deployment-fails)

## Summary

Failed or stuck AI App deploys are now clearly reflected on the AI App page and the dashboard, and the owner/admin can manually retry from the page. Pairs with the backend PR memser-spaceport/pln-directory-portal#3243 (stuck-deploy detection, retry gating).

## Changes

- **Detail page** (`AiAppDetailPage`) — apps in `ERROR` or `DEPLOYING` show a full status card instead of a broken iframe:
  - `ERROR`: "Deploy failed" badge + the failure reason from `notes` + a **Retry deploy** button for the creator/admin (non-owners see who can retry). Secrets apps keep the existing secrets panel as their re-deploy path.
  - `DEPLOYING`: progress card; the page polls the app every 5s (`useAiApp` `refetchInterval`) and switches automatically once the deploy settles — including the backend marking a stuck deploy as failed.
  - The "Back to app" link only shows when the card was opened voluntarily over a healthy app.
- **Secrets panel** (`AppSecretsPanel`) — retry mode when the app has no required env vars: retry-specific copy, "Retry deploy" button, no empty fields block. A failed retry surfaces the API error inline.
- **Dashboard cards** (`AiAppCard`) — "Deploy failed" / "Deploying" status badges next to the app name.

## Screenshots

**Dashboard — status badges:**

![Dashboard badges](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/01-dashboard-status-badges.png)

**Failed deploy — error reason + retry (owner/admin):**

![Deploy failed with retry](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/02-detail-deploy-failed-retry.png)

**Stuck deploy — settled to ERROR by the backend with a timeout explanation:**

![Stuck deploy timed out](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/03-detail-stuck-deploy-timed-out.png)

**Deploy in progress — auto-updating card:**

![Deploy in progress](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/04-detail-deploy-in-progress.png)

**Failed secrets app — error + secrets panel re-deploy:**

![Secrets app failed](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/05-detail-secrets-app-failed.png)

**Retry in flight:**

![Retry in flight](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/06-retry-in-flight.png)

**Retry failed — API error surfaced on the card:**

![Retry failed](https://raw.githubusercontent.com/memser-spaceport/pln-directory-portal-v2/assets/lab-2118-screenshots/07-retry-failed-error-surfaced.png)

> Screenshots are served from the `assets/lab-2118-screenshots` branch (not meant to be merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
