### PR TITLE
fix: random 'Something went wrong' toast on /home

### DIFF
--- a/__tests__/core/query-provider.test.ts
+++ b/__tests__/core/query-provider.test.ts
@@ -1,0 +1,38 @@
+import { onQueryError } from '@/providers/QueryProvider';
+import { toast } from '@/components/core/ToastContainer';
+import { TOAST_MESSAGES } from '@/utils/constants';
+
+jest.mock('@/components/core/ToastContainer', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe('QueryProvider onQueryError', () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not toast for queries without meta.errorToast (background failures degrade silently)', () => {
+    onQueryError(new Error('403 Forbidden'), { queryKey: ['GET_FORUM_DIGEST_SETTINGS', 'uid-1'] });
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('toasts the generic message when meta.errorToast is true', () => {
+    onQueryError(new Error('boom'), { queryKey: ['SOME_QUERY'], meta: { errorToast: true } });
+
+    expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+  });
+
+  it('toasts a custom message when meta.errorToast is a string', () => {
+    onQueryError(new Error('boom'), { queryKey: ['SOME_QUERY'], meta: { errorToast: 'Custom failure message' } });
+
+    expect(toast.error).toHaveBeenCalledWith('Custom failure message');
+  });
+});

--- a/__tests__/page/home/husky-discover.test.tsx
+++ b/__tests__/page/home/husky-discover.test.tsx
@@ -1,0 +1,109 @@
+import { render, waitFor } from '@testing-library/react';
+import HuskyDiscover from '@/components/page/home/husky-discover';
+import { getHuskyResponseBySlug } from '@/services/discovery.service';
+import { toast } from '@/components/core/ToastContainer';
+import { TOAST_MESSAGES } from '@/utils/constants';
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace, prefetch: jest.fn() }),
+  usePathname: () => '/home',
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock('@/components/core/ToastContainer', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@/services/discovery.service', () => ({
+  getHuskyResponseBySlug: jest.fn(),
+  incrementHuskyViewCount: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/analytics/husky.analytics', () => ({
+  useHuskyAnalytics: () => ({ trackSharedBlog: jest.fn() }),
+}));
+
+jest.mock('@/components/core/husky/husky-ai', () => ({
+  __esModule: true,
+  default: () => <div data-testid="husky-ai" />,
+}));
+
+jest.mock('@/components/core/page-loader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="page-loader" />,
+}));
+
+const mockGetHuskyResponseBySlug = getHuskyResponseBySlug as jest.Mock;
+
+describe('HuskyDiscover shared-link handling', () => {
+  const showModalMock = jest.fn();
+
+  beforeAll(() => {
+    // jsdom has no <dialog> implementation
+    HTMLDialogElement.prototype.showModal = showModalMock;
+    HTMLDialogElement.prototype.close = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it('opens the dialog without any toast for a valid shared link', async () => {
+    mockSearchParams = new URLSearchParams('showmodal=husky&discoverid=live-slug');
+    mockGetHuskyResponseBySlug.mockResolvedValue({ data: { question: 'Q', answer: 'A' } });
+
+    render(<HuskyDiscover isLoggedIn={false} />);
+
+    await waitFor(() => expect(showModalMock).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('shows the expired-link message and strips the params for a stale slug', async () => {
+    mockSearchParams = new URLSearchParams('showmodal=husky&discoverid=dead-slug');
+    mockGetHuskyResponseBySlug.mockResolvedValue({ isError: true, status: 404, message: null });
+
+    render(<HuskyDiscover isLoggedIn={false} />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.HUSKY_SHARED_LINK_EXPIRED, {
+        toastId: 'husky-discover',
+      }),
+    );
+    expect(mockReplace).toHaveBeenCalledWith('/home');
+    expect(showModalMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the retryable message on a network failure', async () => {
+    mockSearchParams = new URLSearchParams('showmodal=husky&discoverid=some-slug');
+    mockGetHuskyResponseBySlug.mockRejectedValue(new Error('network down'));
+
+    render(<HuskyDiscover isLoggedIn={false} />);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(TOAST_MESSAGES.HUSKY_SHARED_LINK_FAILED, {
+        toastId: 'husky-discover',
+      }),
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('silently cleans the URL when showmodal=husky has no discoverid', async () => {
+    mockSearchParams = new URLSearchParams('showmodal=husky');
+
+    render(<HuskyDiscover isLoggedIn={false} />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/home'));
+    expect(mockGetHuskyResponseBySlug).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/discovery/discovery.service.test.ts
+++ b/__tests__/services/discovery/discovery.service.test.ts
@@ -1,0 +1,104 @@
+import { getHuskyResponseBySlug } from '@/services/discovery.service';
+
+jest.mock('@/utils/home.utils', () => ({
+  formatNumber: (n: number) => n,
+}));
+
+describe('getHuskyResponseBySlug', () => {
+  const originalEnv = process.env.DIRECTORY_API_URL;
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    process.env.DIRECTORY_API_URL = 'https://api.example.com';
+    global.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    process.env.DIRECTORY_API_URL = originalEnv;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('returns isError with status for a 404 even when the body is not JSON', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => {
+        throw new Error('Unexpected token < in JSON');
+      },
+    });
+
+    const result = await getHuskyResponseBySlug('dead-slug');
+
+    expect(result).toEqual({ isError: true, status: 404, message: null });
+  });
+
+  it('does not increment the view count for a failed slug', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'not found' }),
+    });
+
+    await getHuskyResponseBySlug('dead-slug', true);
+
+    // only the GET — no follow-up PATCH for the view count
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'GET' });
+  });
+
+  it('increments the view count after a successful fetch when increaseView is set', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        content: 'What is IPFS?',
+        answer: 'A protocol',
+        answerSources: [],
+        relatedQuestions: [{ content: 'follow-up' }],
+        viewCount: 1,
+        shareCount: 0,
+      }),
+    });
+
+    const result = await getHuskyResponseBySlug('live-slug', true);
+
+    expect(result.data?.question).toBe('What is IPFS?');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'PATCH' });
+  });
+
+  it('returns isError when a 200 body is not valid JSON', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('bad body');
+      },
+    });
+
+    const result = await getHuskyResponseBySlug('weird-slug');
+
+    expect(result).toEqual({ isError: true, status: 200, message: null });
+  });
+
+  it('tolerates a response without relatedQuestions', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        content: 'Q',
+        answer: 'A',
+        answerSources: [],
+        viewCount: 0,
+        shareCount: 0,
+      }),
+    });
+
+    const result = await getHuskyResponseBySlug('sparse-slug');
+
+    expect(result.data?.followupQuestions).toEqual([]);
+  });
+});

--- a/components/core/application-search/components/AiChatPanel/AiChatPanel.tsx
+++ b/components/core/application-search/components/AiChatPanel/AiChatPanel.tsx
@@ -287,7 +287,7 @@ export const AiChatPanel = ({
         analytics.trackAiResponse('success', type, false, question);
       } catch (error) {
         console.error(`Error in ${type} submission:`, error);
-        toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+        toast.error(TOAST_MESSAGES.AI_CHAT_FAILED);
         analytics.trackAiResponse('error', type, false, question);
       }
     },

--- a/components/core/office-hours-rating/happened.tsx
+++ b/components/core/office-hours-rating/happened.tsx
@@ -136,7 +136,6 @@ const Happened = (props: IHappened) => {
       const result = await createFeedBack(userInfo?.uid ?? '', currentFollowup?.uid ?? '', authToken ?? '', feedback);
       document.dispatchEvent(new CustomEvent(EVENTS.TRIGGER_REGISTER_LOADER, { detail: false }));
       if (result?.error) {
-        toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
         analytics.onOfficeHoursFeedbackFailed(
           getAnalyticsUserInfo(userInfo),
           getAnalyticsNotificationInfo(currentFollowup),
@@ -145,7 +144,7 @@ const Happened = (props: IHappened) => {
         if (result?.error?.data?.message?.includes('There is no follow-up')) {
           toast.success(TOAST_MESSAGES.FEEDBACK__ALREADY__RECORDED);
         } else {
-          toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+          toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
         }
         onClose(false);
         return;
@@ -161,7 +160,7 @@ const Happened = (props: IHappened) => {
     } catch (error) {
       console.error(error);
       onClose(false);
-      toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+      toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
       document.dispatchEvent(new CustomEvent(EVENTS.TRIGGER_REGISTER_LOADER, { detail: false }));
     }
   };

--- a/components/core/office-hours-rating/not-happened.tsx
+++ b/components/core/office-hours-rating/not-happened.tsx
@@ -88,14 +88,14 @@ const NotHappened = (props: INotHappened) => {
           getAnalyticsNotificationInfo(currentFollowup),
           feedback,
         );
-        toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+        toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
       }
       onClose(false);
     } catch (error) {
       console.error(error);
       document.dispatchEvent(new CustomEvent(EVENTS.TRIGGER_REGISTER_LOADER, { detail: false }));
       onClose(false);
-      toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+      toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
     }
   };
 

--- a/components/core/office-hours-rating/user-confirmation.tsx
+++ b/components/core/office-hours-rating/user-confirmation.tsx
@@ -53,7 +53,7 @@ const UserConfirmation = (props: IUserConfirmation) => {
         if (result?.error?.data?.message?.includes('There is no follow-up')) {
           toast.success(TOAST_MESSAGES.FEEDBACK__ALREADY__RECORDED);
         } else {
-          toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+          toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
         }
       }
 
@@ -71,7 +71,7 @@ const UserConfirmation = (props: IUserConfirmation) => {
       console.error(error);
       document.dispatchEvent(new CustomEvent(EVENTS.TRIGGER_REGISTER_LOADER, { detail: false }));
       onClose(false);
-      toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+      toast.error(TOAST_MESSAGES.OH_FEEDBACK_FAILED);
     }
   };
 

--- a/components/page/home/husky-discover.tsx
+++ b/components/page/home/husky-discover.tsx
@@ -9,6 +9,7 @@ import cookies from 'js-cookie';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from '@/components/core/ToastContainer';
 import { getHuskyResponseBySlug, incrementHuskyViewCount } from '@/services/discovery.service';
+import { TOAST_MESSAGES } from '@/utils/constants';
 
 let huskyRecorded = false;
 
@@ -28,7 +29,8 @@ function HuskyDiscover(props: any) {
     dialogRef.current?.close();
     setInitialChats([]);
     if (modalCode === 'husky') {
-      router.push('/');
+      // replace (not push) so Back doesn't return to the modal URL and replay the flow
+      router.replace('/home');
     }
   };
   const increaseViewAndShow = (data: any) => {
@@ -68,24 +70,34 @@ function HuskyDiscover(props: any) {
   }, []);
 
   useEffect(() => {
+    if (modalCode === 'husky' && !huskyShareId) {
+      // malformed share URL — nothing to open, just clean it up
+      router.replace('/home');
+      return;
+    }
     if (modalCode === 'husky' && huskyShareId && huskyShareId === slugId) {
       setLoadingStatus(true);
       getHuskyResponseBySlug(huskyShareId, true)
         .then((result) => {
-          if (result.data && dialogRef.current) {
+          if (result.data) {
             setInitialChats([result.data]);
             if (!huskyRecorded) {
               trackSharedBlog(huskyShareId, 'shareurl', result.data?.question);
             }
             huskyRecorded = true;
-            dialogRef.current.showModal();
+            dialogRef.current?.showModal();
+          } else if (result.status === 404) {
+            toast.error(TOAST_MESSAGES.HUSKY_SHARED_LINK_EXPIRED, { toastId: 'husky-discover' });
+            // strip the dead params so refresh/Back doesn't replay the error
+            router.replace('/home');
           } else {
-            toast.error('Something went wrong');
+            console.error(`Failed to load shared husky post ${huskyShareId} (status ${result.status})`);
+            toast.error(TOAST_MESSAGES.HUSKY_SHARED_LINK_FAILED, { toastId: 'husky-discover' });
           }
         })
         .catch((e) => {
           console.error(e);
-          toast.error('Something went wrong');
+          toast.error(TOAST_MESSAGES.HUSKY_SHARED_LINK_FAILED, { toastId: 'husky-discover' });
         })
         .finally(() => setLoadingStatus(false));
     }

--- a/components/page/member-info/register-form.tsx
+++ b/components/page/member-info/register-form.tsx
@@ -97,13 +97,18 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onCloseForm }) => {
           setCurrentStep('success');
           analytics.recordMemberJoinNetworkSave('save-success', bodyData);
         } else {
-          toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+          if (formResult.status === 409) {
+            toast.error('A join request for this email already exists');
+          } else {
+            toast.error(TOAST_MESSAGES.REGISTER_SUBMIT_FAILED);
+          }
           analytics.recordMemberJoinNetworkSave('save-error', bodyData);
         }
       }
     } catch (err) {
+      console.error(err);
       document.dispatchEvent(new CustomEvent(EVENTS.TRIGGER_REGISTER_LOADER, { detail: false }));
-      toast.error(TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+      toast.error(TOAST_MESSAGES.REGISTER_SUBMIT_FAILED);
       analytics.recordMemberJoinNetworkSave('save-error');
     }
   };

--- a/providers/QueryProvider.tsx
+++ b/providers/QueryProvider.tsx
@@ -8,10 +8,15 @@ import { TOAST_MESSAGES } from '@/utils/constants';
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
-      if (query.state.data !== undefined) {
-        console.error(error.message);
+      console.error(`Query failed [${JSON.stringify(query.queryKey)}]:`, error.message);
 
-        toast.error(`${TOAST_MESSAGES.SOMETHING_WENT_WRONG}`);
+      // Toasting is opt-in: background refetch failures of non-critical data
+      // (digest settings, profile status, ...) must degrade silently — the UI
+      // keeps rendering last-known data. Queries that want a user-facing error
+      // set meta.errorToast to true (generic message) or a custom string.
+      const errorToast = query.meta?.errorToast;
+      if (errorToast) {
+        toast.error(typeof errorToast === 'string' ? errorToast : TOAST_MESSAGES.SOMETHING_WENT_WRONG);
       }
     },
   }),

--- a/providers/QueryProvider.tsx
+++ b/providers/QueryProvider.tsx
@@ -5,20 +5,22 @@ import { ReactNode } from 'react';
 import { toast } from '@/components/core/ToastContainer';
 import { TOAST_MESSAGES } from '@/utils/constants';
 
+// Toasting is opt-in: background refetch failures of non-critical data
+// (digest settings, profile status, ...) must degrade silently — the UI
+// keeps rendering last-known data. Queries that want a user-facing error
+// set meta.errorToast to true (generic message) or a custom string.
+export const onQueryError = (error: Error, query: { queryKey: unknown; meta?: Record<string, unknown> }) => {
+  console.error(`Query failed [${JSON.stringify(query.queryKey)}]:`, error.message);
+
+  const errorToast = query.meta?.errorToast;
+  if (errorToast) {
+    toast.error(typeof errorToast === 'string' ? errorToast : TOAST_MESSAGES.SOMETHING_WENT_WRONG);
+  }
+};
+
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error, query) => {
-      console.error(`Query failed [${JSON.stringify(query.queryKey)}]:`, error.message);
-
-      // Toasting is opt-in: background refetch failures of non-critical data
-      // (digest settings, profile status, ...) must degrade silently — the UI
-      // keeps rendering last-known data. Queries that want a user-facing error
-      // set meta.errorToast to true (generic message) or a custom string.
-      const errorToast = query.meta?.errorToast;
-      if (errorToast) {
-        toast.error(typeof errorToast === 'string' ? errorToast : TOAST_MESSAGES.SOMETHING_WENT_WRONG);
-      }
-    },
+    onError: onQueryError,
   }),
 });
 

--- a/services/discovery.service.ts
+++ b/services/discovery.service.ts
@@ -70,16 +70,23 @@ export const getHuskyResponseBySlug = async (slug: string, increaseView = false)
       'Content-Type': 'application/json',
     },
   });
-  const output: any = await result.json();
-  if (increaseView) {
-    await incrementHuskyViewCount(slug);
-  }
+  // A 404/5xx body may be HTML or empty — parse only after the ok check, and
+  // never let a malformed body mask the real status.
   if (!result.ok) {
     return {
       isError: true,
       status: result.status,
-      message: output,
+      message: await result.json().catch(() => null),
     };
+  }
+  let output: any;
+  try {
+    output = await result.json();
+  } catch (e) {
+    return { isError: true, status: result.status, message: null };
+  }
+  if (increaseView) {
+    await incrementHuskyViewCount(slug);
   }
 
   return {
@@ -88,7 +95,7 @@ export const getHuskyResponseBySlug = async (slug: string, increaseView = false)
       answer: output.answer,
       answerSourceLinks: output.answerSources,
       answerSourcedFrom: 'none',
-      followupQuestions: output.relatedQuestions.map((v: any) => v.content),
+      followupQuestions: (output.relatedQuestions ?? []).map((v: any) => v.content),
       viewCount: output.viewCount,
       shareCount: output.shareCount,
     },

--- a/services/forum/hooks/useGetForumDigestSettings.ts
+++ b/services/forum/hooks/useGetForumDigestSettings.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { customFetch } from '@/utils/fetch-wrapper';
 import { ForumQueryKeys } from '@/services/forum/constants';
+import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
 
 export type ForumDigestSettings = {
   forumDigestEnabled: boolean;
@@ -23,17 +24,24 @@ async function fetcher(uid: string | undefined) {
   );
 
   if (!response?.ok) {
-    throw new Error('Failed to fetch forum digest settings');
+    // Non-critical background data: a 403/5xx here must not surface an error
+    // (the query is seeded with initialData, so throwing would trip the global
+    // query error handler on every failure, including the first fetch).
+    console.error(`Failed to fetch forum digest settings (status ${response?.status ?? 'unknown'})`);
+    return null;
   }
 
   return (await response.json()) as ForumDigestSettings;
 }
 
 export function useGetForumDigestSettings(uid: string | undefined, initialData: ForumDigestSettings) {
+  const { hasAccess, isLoading: isAccessLoading } = useForumAccess();
+
   return useQuery({
     queryKey: [ForumQueryKeys.GET_FORUM_DIGEST_SETTINGS, uid],
     queryFn: () => fetcher(uid),
-    enabled: Boolean(uid),
+    // Users without forum.read get a guaranteed 403 from this endpoint — don't ask.
+    enabled: Boolean(uid) && !isAccessLoading && hasAccess,
     initialData,
   });
 }

--- a/services/members/hooks/useMemberProfileStatus.ts
+++ b/services/members/hooks/useMemberProfileStatus.ts
@@ -19,7 +19,11 @@ async function fetcher(uid: string | undefined) {
   );
 
   if (!response?.ok) {
-    throw new Error('Failed to fetch profile status');
+    // Non-critical background data (navbar treats missing status as "nothing to
+    // show") — returning null instead of throwing keeps a 403/5xx on a background
+    // refetch from tripping the global query error handler.
+    console.error(`Failed to fetch profile status (status ${response?.status ?? 'unknown'})`);
+    return null;
   }
 
   const data: MemberProfileStatus = await response.json();

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -306,6 +306,11 @@ export const TOAST_MESSAGES = {
   SELF_INTERACTION_FORBIDDEN: 'Scheduling office hours with yourself is not allowed',
   FAILED_TO_LINK_LINKEDIN: 'Failed to link LinkedIn account',
   EVENT_DELETED_SUCCESSFULLY: 'Event deleted successfully',
+  HUSKY_SHARED_LINK_EXPIRED: 'This shared Husky link is no longer available',
+  HUSKY_SHARED_LINK_FAILED: "Couldn't load the shared Husky post. Please try again",
+  OH_FEEDBACK_FAILED: "Couldn't submit your office hours feedback. Please try again",
+  AI_CHAT_FAILED: "Couldn't get an AI response. Please try again",
+  REGISTER_SUBMIT_FAILED: "Couldn't submit your join request. Please try again",
 };
 
 export const AUTH_ANALYTICS = {


### PR DESCRIPTION
## Summary

Users intermittently saw a generic "Something went wrong" toast on `/home`. Root cause: the **global React Query `QueryCache.onError`** in `providers/QueryProvider.tsx` toasted for any failed query that had data. Two queries mounted on /home fed it 403s:

- `useGetForumDigestSettings` (`/v1/notification/settings/<uid>/forum`) threw on any non-ok and — because it's seeded with server-side `initialData` — **every** failure toasted, including the first client fetch. It also ran for logged-in users without `forum.read`, a guaranteed 403.
- `useMemberProfileStatus` (`/v1/profile/<uid>/status`, navbar) threw on non-ok, so background window-refocus refetch failures toasted "randomly".
- `customFetch` only refreshes tokens on 401 — 403s pass straight through.

### Changes

**Primary fix**
- Global query error toast is now **opt-in** via `meta.errorToast` (true = generic, string = custom); all failures log to console with the query key.
- Digest-settings hook returns `null` on non-ok and only runs for users with forum access; profile-status hook returns `null` on non-ok (both UIs already handle null).

**Secondary fixes (the other emitters of the same string reachable on /home)**
- `HuskyDiscover` (`?showmodal=husky&discoverid=…` shared links): stale/deleted slug → specific "link no longer available" toast + `router.replace('/home')` so refresh/Back doesn't replay; other failures → distinct retryable message with stable `toastId` (dedupes React 18 strict-mode double effects); success can no longer fall into the error branch; missing `discoverid` cleans the URL silently.
- `getHuskyResponseBySlug`: `result.ok` checked **before** `json()` (a 404 HTML body no longer masks the status), view count no longer incremented for dead slugs, sparse responses guarded.
- Office-hours rating: removed a duplicate error toast in `happened.tsx` (it fired unconditionally *and* in the else branch — a failed submit could show an error and a success toast together); all rating error toasts now use a specific message.
- AI search panel + member register form: source-specific messages; registration surfaces 409 duplicate requests distinctly.

### Deviations from plan
- `AiChatPanel`'s `submitChat` is AI SDK `useObject().submit` (not a promise) — send failures already render an in-message error state via `chatError`, so no `.catch`/`await` changes were needed.

### Out of scope (noted for follow-up)
- `rating-container.tsx` never removes its `TRIGGER_RATING_POPUP` listener (removeEventListener gets a different function reference) → can stack duplicate popups after remounts.

## Testing
- New: `__tests__/core/query-provider.test.ts` (opt-in gating), `__tests__/services/discovery/discovery.service.test.ts` (404 HTML body, malformed 200, view-count gating, sparse response), `__tests__/page/home/husky-discover.test.tsx` (success/404/network/missing-id flows).
- Full suite: 612 passed, 0 failed. Lint: identical error/warning counts vs develop on touched files (pre-existing repo lint debt).
- No screenshots: changes are error-path handling and toast copy only (reproducing requires forced backend failures).

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)