### PR TITLE
fix: office-hours rating popup listener leak

### DIFF
--- a/__tests__/core/office-hours-rating/rating-container.test.tsx
+++ b/__tests__/core/office-hours-rating/rating-container.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import RatingContainer from '@/components/core/office-hours-rating/rating-container';
+import { EVENTS } from '@/utils/constants';
+
+jest.mock('@/services/office-hours.service', () => ({
+  getFollowUps: jest.fn(),
+  patchFollowup: jest.fn(),
+}));
+
+describe('RatingContainer TRIGGER_RATING_POPUP listener', () => {
+  it('removes the same listener reference on unmount (no listener leak)', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+    const { unmount } = render(<RatingContainer isLoggedIn={false} authToken="" userInfo={{} as any} />);
+
+    const added = addSpy.mock.calls.filter(([type]) => type === EVENTS.TRIGGER_RATING_POPUP);
+    expect(added).toHaveLength(1);
+
+    unmount();
+
+    const removed = removeSpy.mock.calls.filter(([type]) => type === EVENTS.TRIGGER_RATING_POPUP);
+    expect(removed).toHaveLength(1);
+    // the leak: a fresh inline function was passed to removeEventListener,
+    // so the original listener was never actually removed
+    expect(removed[0][1]).toBe(added[0][1]);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/components/core/office-hours-rating/rating-container.tsx
+++ b/components/core/office-hours-rating/rating-container.tsx
@@ -117,7 +117,7 @@ const RatingContainer = (props: IRatingContainer) => {
   };
 
   useEffect(() => {
-    async function updateNotification(notification: IFollowUp) {
+    function updateNotification(notification: IFollowUp) {
       setCurrentStep(notification.type);
       setCurrentFollowup(notification);
       if (ratingContainerRef?.current) {
@@ -125,16 +125,14 @@ const RatingContainer = (props: IRatingContainer) => {
       }
     }
 
-    document.addEventListener(EVENTS.TRIGGER_RATING_POPUP, (e: any) => {
-      console.log(e);
-      console.log(e.detail);
+    const onTriggerRatingPopup = (e: any) => {
       updateNotification(e?.detail?.notification);
-    });
+    };
+
+    document.addEventListener(EVENTS.TRIGGER_RATING_POPUP, onTriggerRatingPopup);
 
     return () => {
-      document.removeEventListener(EVENTS.TRIGGER_RATING_POPUP, (e: any) => {
-        updateNotification(e?.detail?.notification);
-      });
+      document.removeEventListener(EVENTS.TRIGGER_RATING_POPUP, onTriggerRatingPopup);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Follow-up to #2639. `RatingContainer` (mounted in the root layout) registered its `TRIGGER_RATING_POPUP` document listener with an inline function and passed a *different* freshly-created inline function to `removeEventListener` in the effect cleanup — so the original listener was never removed. Every remount stacked another live handler, which could open duplicate rating popups (and fire duplicate follow-up state updates) from a single event.

- The handler is now a stable function reference, added and removed symmetrically.
- Dropped two stray `console.log`s from the handler.

## Testing

- New `__tests__/core/office-hours-rating/rating-container.test.tsx`: asserts exactly one listener is added for the event and that unmount removes the **same reference** (fails on the old code, where the removed reference differed).
- Full suite: 601 passed, 0 failed. No new lint issues (the one warning on the file is a pre-existing `exhaustive-deps` on an unrelated effect).

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)