### PR TITLE
fix(team-news): freeze followed-first sort until page reload

### DIFF
--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -712,6 +712,68 @@ describe('TeamNews', () => {
     });
   });
 
+  describe('follow — session-stable ordering (frozen until reload)', () => {
+    const zeta = {
+      ...makeItem('fz-1', 'FUNDING', ['AI & Robotics']),
+      teamUid: 'team-zeta',
+      teamName: 'Zeta',
+      isFollowed: true,
+    };
+    const alpha = { ...makeItem('fa-1', 'LAUNCH', ['AI & Robotics']), teamUid: 'team-alpha', teamName: 'Alpha' };
+    const beta = { ...makeItem('fb-1', 'MILESTONE', ['AI & Robotics']), teamUid: 'team-beta', teamName: 'Beta' };
+    // Insertion order alpha, beta, zeta — followed-first sorting must pin Zeta on mount.
+    const frozenGroups: ITeamNewsGroup[] = [{ focusArea: FA_AI, total: 3, items: [alpha, beta, zeta] }];
+
+    const getTeamOrder = () =>
+      screen.getAllByRole('link', { name: /^(Zeta|Alpha|Beta)/ }).map((l) => l.textContent);
+
+    // FollowButton only renders hydrated + signed-in (same setup as the upvotes block).
+    beforeEach(() => {
+      useCurrentUserStore.setState({ currentUser: { uid: 'user-1' }, isHydrated: true });
+    });
+    afterEach(() => {
+      useCurrentUserStore.setState({ currentUser: null, isHydrated: false });
+    });
+
+    it('clicking Follow flips the button immediately but does not move the cluster', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+      expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Follow Beta' }));
+
+      expect(screen.getByRole('button', { name: 'Following Beta' })).toBeInTheDocument();
+      expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']); // order frozen until reload
+    });
+
+    it('clicking Unfollow on a pinned cluster keeps its position (symmetric freeze)', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Following Zeta' }));
+
+      expect(screen.getByRole('button', { name: 'Follow Zeta' })).toBeInTheDocument();
+      expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']); // still pinned this session
+    });
+
+    it('a fresh mount applies the new follow order (simulates page reload)', () => {
+      const { unmount } = renderTeamNews(<TeamNews groups={frozenGroups} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Follow Beta' }));
+      expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']);
+      // rerender() would NOT reset the snapshot (state persists) — a reload is a fresh mount
+      // with fresh SSR flags, so unmount and render anew with the server's new truth.
+      unmount();
+
+      const reloadedGroups: ITeamNewsGroup[] = [
+        {
+          focusArea: FA_AI,
+          total: 3,
+          items: [alpha, { ...beta, isFollowed: true }, { ...zeta, isFollowed: false }],
+        },
+      ];
+      renderTeamNews(<TeamNews groups={reloadedGroups} />);
+      expect(getTeamOrder()).toEqual(['Beta', 'Alpha', 'Zeta']);
+    });
+  });
+
   describe('popular this week — scroll to story', () => {
     const popularItem = (
       partial: Partial<ITeamNewsPopularItem> & Pick<ITeamNewsPopularItem, 'uid'>,

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -64,6 +64,13 @@ jest.mock('@/services/team-news/hooks/useTeamNewsUpvoteToggle', () => ({
   useTeamNewsUpvoteToggle: () => ({ mutate: (...a: unknown[]) => mockUpvoteMutate(...a) }),
 }));
 
+// Same reason as above: the follow tests need to simulate the mutation outcome
+// (in particular the null-on-HTTP-failure contract of followTeam/unfollowTeam).
+const mockFollowMutate = jest.fn();
+jest.mock('@/services/follow/hooks/useFollowTeam', () => ({
+  useFollowTeam: () => ({ mutate: (...a: unknown[]) => mockFollowMutate(...a) }),
+}));
+
 const FA_AI = { uid: 'fa-ai', title: 'AI & Robotics' };
 const FA_DHR = { uid: 'fa-dhr', title: 'Digital Human Rights' };
 
@@ -752,6 +759,20 @@ describe('TeamNews', () => {
 
       expect(screen.getByRole('button', { name: 'Follow Zeta' })).toBeInTheDocument();
       expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']); // still pinned this session
+    });
+
+    it('reverts the button (but not the order) when the server rejects with a null response', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Follow Beta' }));
+      expect(screen.getByRole('button', { name: 'Following Beta' })).toBeInTheDocument();
+
+      // followTeam/unfollowTeam resolve to null on non-OK responses instead of
+      // throwing — simulate that outcome manually (mockFollowMutate is a bare jest.fn()).
+      const options = mockFollowMutate.mock.calls[0][1];
+      act(() => options.onSuccess(null));
+
+      expect(screen.getByRole('button', { name: 'Follow Beta' })).toBeInTheDocument();
+      expect(getTeamOrder()).toEqual(['Zeta', 'Alpha', 'Beta']); // frozen order untouched by the revert
     });
 
     it('a fresh mount applies the new follow order (simulates page reload)', () => {

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -118,6 +118,14 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
     () => new Set(allItems.filter((i) => i.isFollowed).map((i) => i.teamUid)),
   );
 
+  // Mount-time snapshot of the followed set, used only by sortedClusters below:
+  // follow/unfollow flips buttons immediately (via the live set above) but must
+  // not reorder the feed mid-session — the new order applies on the next page
+  // load, when this reseeds from fresh SSR data. Setter-less useState so the
+  // snapshot is captured during render (first paint is already sorted) and its
+  // identity never changes; the copy severs aliasing with the live set.
+  const [initialFollowedTeamUids] = useState<ReadonlySet<string>>(() => new Set(followedTeamUids));
+
   const itemsForActiveTab = useMemo(() => {
     if (activeTab === ALL_TAB) return allItems;
     const group = groups.find((g) => g.focusArea.title === activeTab);
@@ -159,10 +167,10 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   const clusters = useMemo(() => clusterByTeam(searchedItems), [searchedItems]);
 
   const sortedClusters = useMemo(() => {
-    const followed = clusters.filter((c) => followedTeamUids.has(c.teamUid));
-    const unfollowed = clusters.filter((c) => !followedTeamUids.has(c.teamUid));
+    const followed = clusters.filter((c) => initialFollowedTeamUids.has(c.teamUid));
+    const unfollowed = clusters.filter((c) => !initialFollowedTeamUids.has(c.teamUid));
     return [...followed, ...unfollowed];
-  }, [clusters, followedTeamUids]);
+  }, [clusters, initialFollowedTeamUids]);
 
   const visibleClusters = expanded ? sortedClusters : sortedClusters.slice(0, pageSize);
   const newCount = allItems.length;

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -41,7 +41,6 @@ import { TeamNewsTabs } from './components/TeamNewsTabs';
 import s from './TeamNews.module.scss';
 
 import { sortAllTabItemsByEventDate } from './utils/sortAllTabItemsByEventDate';
-import { toast } from '@/components/core/ToastContainer';
 
 // DebouncedInput (inside SearchInput) doesn't expose its <input> via props or
 // a forwarded ref, so this is the only way to read its live (undebounced)
@@ -186,7 +185,6 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
     setActiveTab(id);
     setActiveCategory(ALL_CAT);
     setExpanded(false);
-    toast.success('Your details have been updated!', { autoClose: false });
   };
 
   const handleCategory = (id: TeamNewsCategoryId) => {

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -279,15 +279,18 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
       isCurrentlyFollowing ? next.delete(teamUid) : next.add(teamUid);
       return next;
     });
+    const revert = () => {
+      setFollowedTeamUids((prev) => {
+        const next = new Set(prev);
+        isCurrentlyFollowing ? next.add(teamUid) : next.delete(teamUid);
+        return next;
+      });
+    };
     followMutate(
       { teamUid, action },
       {
         onError: () => {
-          setFollowedTeamUids((prev) => {
-            const next = new Set(prev);
-            isCurrentlyFollowing ? next.add(teamUid) : next.delete(teamUid);
-            return next;
-          });
+          revert();
           followAnalytics.onTeamFollowFailed({
             teamUid,
             teamName,
@@ -295,7 +298,14 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
             action,
           });
         },
-        onSuccess: () => {
+        onSuccess: (data) => {
+          // followTeam/unfollowTeam return null on non-OK responses instead of
+          // throwing, so onError only covers network failures — revert on null,
+          // matching useTeamFollowToggle and useToggleTeamFollowInList.
+          if (!data) {
+            revert();
+            return;
+          }
           if (action === 'follow') {
             followAnalytics.onTeamFollowed({ teamUid, teamName, source, ...meta });
           } else {

--- a/services/follow/hooks/useFollowTeam.ts
+++ b/services/follow/hooks/useFollowTeam.ts
@@ -4,6 +4,11 @@ import type { ITeamFollowState } from '@/types/follow.types';
 
 export type FollowAction = { teamUid: string; action: 'follow' | 'unfollow' };
 
+// Intentionally a bare mutation: call sites own their optimistic/consistency
+// policy (local Set overlays in TeamNews and useTeamFollowToggle; cache patching
+// + invalidation in useToggleTeamFollowInList for the /teams grid). Do not add
+// invalidateQueries here — it would refetch the suggestions query and drop
+// NewsRail rows mid-confirm-animation.
 export function useFollowTeam() {
   return useMutation({
     mutationFn: ({ teamUid, action }: FollowAction): Promise<ITeamFollowState | null> =>


### PR DESCRIPTION
## Summary

On `/home`, clicking **Follow** on a team in the news section immediately moved that team's cluster to the top of the list, shifting content under the user's cursor. The followed-first ordering is now computed **once per mount**: Follow/Unfollow flips the button instantly, but nothing moves until the next page load. Unfollow is symmetric — a pinned team keeps its position until reload.

**How:** sorting in `TeamNews.tsx` now reads a mount-time snapshot of the followed set (setter-less `useState<ReadonlySet<string>>`) instead of the live `followedTeamUids` state. The live set keeps driving Follow buttons, rail checkmarks, and analytics — only `sortedClusters` is frozen. The snapshot's identity never changes, so it sits honestly in the memo deps (no eslint suppressions) and a follow toggle can never invalidate the sort.

**Why `useState` and not `useRef`:** this repo runs `react-hooks/refs` at error level, which forbids `ref.current` reads inside `useMemo` (render). The setter-less `useState` idiom is lint-clean, react.dev-aligned, and already used in the alignment-assets round components. Effect-based capture was rejected because it would paint the first frame unsorted, then flicker.

Also included:
- **Silent HTTP-failure rollback**: `followTeam`/`unfollowTeam` resolve to `null` on non-OK responses instead of throwing, so `onError` only covers network failures — the button stayed flipped on a 4xx/5xx. `handleFollowToggle` now reverts on a null result, matching `useTeamFollowToggle` and `useToggleTeamFollowInList`.
- Guard comment in `useFollowTeam` documenting why it must remain a bare mutation (call sites own optimistic state; adding `invalidateQueries` would refetch the suggestions query and drop NewsRail rows mid-confirm-animation).
- Removed a leftover debug toast in `handleTab` that fired a non-dismissing "Your details have been updated!" on every tab click (plus its now-unused import).

## Testing

- New Jest tests in `__tests__/page/home/team-news.test.tsx`:
  - Follow flips the button but the cluster does not move
  - Unfollow on a pinned cluster keeps its position (symmetric freeze)
  - Server rejection (null response) reverts the button without touching the frozen order
  - A fresh mount with updated `isFollowed` flags applies the new order (simulates reload)
- All 23 `/home` suites pass (193 tests). ESLint and `tsc` clean on the changed files.
- No screenshots: the change is temporal ordering behavior — a static before/after would look identical. The behavior is asserted at the DOM level by the tests above.

## Notes for reviewers

- A follow toggle still re-renders the cards (buttons read live state) — this PR eliminates *reordering/remounting*, not render count.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)