### PR TITLE
feat(plaa): July Buyback Auction banner, KPI chart values, hero CTA copy

### DIFF
--- a/components/core/navbar/components/HighlightsBar/HighlightsBar.module.scss
+++ b/components/core/navbar/components/HighlightsBar/HighlightsBar.module.scss
@@ -27,7 +27,8 @@
     }
 
     .wrapper {
-      height: 80px;
+      // min-height so a taller banner grows rather than being clipped
+      min-height: 80px;
       padding: 0;
       gap: 0;
       overflow: hidden;

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
@@ -131,34 +131,17 @@
   color: #fff;
 }
 
-// Subtitle container - Figma: 12px
+// Subtitle container - matches .title size so all banner text reads at one size
 .subtitle {
   margin: 0;
   display: flex;
   align-items: center;
   gap: 8px;
   font-family: 'Inter', sans-serif;
-  font-size: 12px;
+  font-size: 16px;
   font-weight: 400; // Regular
   line-height: normal;
   color: #fff;
-}
-
-// Inline CTA link, sits between the title and the supporting copy
-.ctaLink {
-  align-self: flex-start;
-  font-family: 'Inter', sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: normal;
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition: opacity 0.15s ease;
-
-  &:hover {
-    opacity: 0.8;
-  }
 }
 
 // Bold lead-in within the supporting copy
@@ -198,11 +181,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 36px;
+  // min-height so the label is never clipped at the shared 16px text size
+  min-height: 36px;
   padding: 10px 16px;
   border-radius: 58px;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 500;
   line-height: 20px;
   text-decoration: none;
@@ -388,26 +372,14 @@
   gap: 8px;
 }
 
-// Mobile Subtitle
+// Mobile Subtitle - matches .mobileTitle size so all banner text reads at one size
 .mobileSubtitle {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  font-size: 10px;
+  font-size: 14px;
   font-weight: 400;
   line-height: normal;
   color: #fff;
-}
-
-// Mobile inline CTA link, sits between the title and the supporting copy
-.mobileCtaLink {
-  align-self: flex-start;
-  font-family: 'Inter', sans-serif;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: normal;
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 // Mobile Date
@@ -440,15 +412,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 32px;
+  // min-height so the label is never clipped at the shared 14px text size
+  min-height: 32px;
   padding: 10px 16px;
   border-radius: 58px;
   font-family: 'Inter', sans-serif;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 20px;
   text-decoration: none;
-  white-space: nowrap;
   transition: all 0.15s ease;
   box-shadow: 0px 1px 1px 0px rgba(15, 23, 42, 0.08);
 }

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
@@ -118,11 +118,11 @@
   min-width: 0;
 }
 
-// Title - Figma: Inter Medium, 16px, white
+// Title - Inter Medium, white. Shared size with .subtitle and the CTA button.
 .title {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500; // Medium
   line-height: normal;
   white-space: nowrap;
@@ -138,7 +138,7 @@
   align-items: center;
   gap: 8px;
   font-family: 'Inter', sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400; // Regular
   line-height: normal;
   color: #fff;
@@ -181,12 +181,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  // min-height so the label is never clipped at the shared 16px text size
+  // min-height so the label is never clipped at the shared text size
   min-height: 36px;
   padding: 10px 16px;
   border-radius: 58px;
   font-family: 'Inter', sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 20px;
   text-decoration: none;
@@ -286,7 +286,7 @@
   }
 
   .mobileTitle {
-    font-size: 14px;
+    font-size: 12px;
   }
 
   // Hide extra content in compact mode with smooth transition
@@ -354,11 +354,11 @@
   transition: opacity 0.3s ease, max-height 0.3s ease, margin-top 0.3s ease;
 }
 
-// Mobile Title
+// Mobile Title - shared size with .mobileSubtitle and the mobile CTA button
 .mobileTitle {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
   line-height: normal;
   color: #fff;
@@ -376,7 +376,7 @@
 .mobileSubtitle {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 400;
   line-height: normal;
   color: #fff;
@@ -412,12 +412,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  // min-height so the label is never clipped at the shared 14px text size
+  // min-height so the label is never clipped at the shared text size
   min-height: 32px;
   padding: 10px 16px;
   border-radius: 58px;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 20px;
   text-decoration: none;

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
@@ -118,12 +118,12 @@
   min-width: 0;
 }
 
-// Title - Inter Medium, white. Shared size with .subtitle and the CTA button.
+// Title - Inter Bold, white. Shared size with .subtitle and the CTA button.
 .title {
   margin: 0;
   font-family: 'Inter', sans-serif;
   font-size: 14px;
-  font-weight: 500; // Medium
+  font-weight: 700; // Bold
   line-height: normal;
   white-space: nowrap;
   overflow: hidden;
@@ -359,7 +359,7 @@
   margin: 0;
   font-family: 'Inter', sans-serif;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 700; // Bold
   line-height: normal;
   color: #fff;
   transition: font-size 0.3s ease;

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.module.scss
@@ -10,8 +10,10 @@
   display: none;
   align-items: center;
   width: 100%;
-  height: 80px;
-  padding: 0 40px;
+  // min-height rather than height: the banner grows if the copy wraps
+  // instead of being clipped by the bar's overflow: hidden.
+  min-height: 80px;
+  padding: 12px 40px;
   color: #fff;
   position: relative;
 
@@ -139,8 +141,29 @@
   font-size: 12px;
   font-weight: 400; // Regular
   line-height: normal;
-  white-space: nowrap;
   color: #fff;
+}
+
+// Inline CTA link, sits between the title and the supporting copy
+.ctaLink {
+  align-self: flex-start;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: normal;
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+// Bold lead-in within the supporting copy
+.subtitleStrong {
+  font-weight: 700;
 }
 
 // Yellow highlight - Figma: Inter Bold, #ef0
@@ -373,6 +396,18 @@
   font-weight: 400;
   line-height: normal;
   color: #fff;
+}
+
+// Mobile inline CTA link, sits between the title and the supporting copy
+.mobileCtaLink {
+  align-self: flex-start;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: normal;
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 // Mobile Date

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { usePathname } from 'next/navigation';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 
 import { HighlightsBar } from '@/components/core/navbar/components/HighlightsBar';
@@ -17,10 +17,20 @@ interface BannerButton {
   variant: 'primary' | 'secondary';
 }
 
+interface BannerCta {
+  label: string;
+  link: string;
+}
+
 interface BannerContent {
   id: string;
   type: BannerType;
   title: string;
+  // Inline CTA rendered between the title and the supporting copy.
+  // Use this instead of `buttons` when the CTA must precede the copy.
+  cta?: BannerCta;
+  // Bold lead-in rendered immediately before `subtitle`.
+  subtitleBold?: string;
   subtitle: string;
   highlightText?: string;
   date: string;
@@ -30,55 +40,30 @@ interface BannerContent {
 // Shared Confirm Referral link for all bonus-lead items
 const CONFIRM_REFERRAL_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSfuDNC7fGLc5TMhSh1g6IpTXzOkS8Ie-I1QbIxOdqefUKSt3g/viewform';
 
+// Scroll distance (px) after which the mobile banner collapses to title-only
+const COMPACT_SCROLL_OFFSET = 24;
+
 // Banner data
 export const BANNER_CONTENTS: BannerContent[] = [
   {
-    id: 'banner-1',
-    type: 'bonus',
-    title: 'New Activity: Contribute a High-Quality Response to the Forum',
-    subtitle: 'Contribute thoughtful forum responses and collect 100 points per qualifying post.',
+    id: 'buyback-auction-july',
+    type: 'event',
+    title: 'The July Buyback Auction Is Now Live',
+    cta: {
+      label: 'Place Your Bid Now on the Surus Platform',
+      link: 'https://auction-interface.fly.dev/',
+    },
+    subtitleBold: 'All bids must be in no later than July 21 at 12 PM ET',
+    subtitle: ' for the opportunity to redeem your PLAA in exchange for cash.',
     date: '',
-    buttons: [
-       { label: 'Join the conversation', link: 'https://directory.plnetwork.io/alignment-asset/activities#contribute-forum-response', variant: 'secondary' },
-    ],
-  },
-  {
-    id: 'banner-2',
-    type: 'bonus',
-    title: 'New Activity: Share a Reusable AI Resource or Tool',
-    subtitle: 'Share reusable AI tools or resources with the network and collect 150 points.',
-    date: '',
-    buttons: [
-       { label: 'View details', link: 'https://directory.plnetwork.io/alignment-asset/activities#share-ai-resource', variant: 'secondary' },
-    ],
-  },
-  {
-    id: 'banner-3',
-    type: 'bonus',
-    title: 'New Activity: Rank Among the Network\'s Most Supportive Members',
-    subtitle: 'Top contributors in each snapshot period can now collect bonus points.',
-    date: '',
-    buttons: [
-       { label: 'View bonus points', link: 'https://directory.plnetwork.io/alignment-asset/activities#rank-supportive-members', variant: 'secondary' },
-    ],
-  },
-  {
-    id: 'banner-4',
-    type: 'bonus',
-    title: 'New Feature: Activity Assistant Bot',
-    subtitle: 'Use the new Activity Assistant Bot for your next submission + provide feedback = collect 50 bonus points.',
-    date: '',
-    buttons: [
-       { label: 'Submit and give feedback', link: ' https://directory.plnetwork.io/alignment-asset/', variant: 'secondary' },
-    ],
+    buttons: [],
   },
 ];
 
 export function PlaaBanner() {
   const pathname = usePathname();
   const [isCompact, setIsCompact] = useState(false);
-  const mobileBannerWrapperRef = useRef<HTMLDivElement>(null);
-  
+
   const { onBannerCarouselPrevClicked, onBannerCarouselNextClicked, onBannerButtonClicked } = useAlignmentAssetsAnalytics();
   
   // Desktop carousel
@@ -94,34 +79,24 @@ export function PlaaBanner() {
     dragFree: false,
   });
 
-  // Intersection Observer to detect when banner becomes "stuck"
-  // We observe a sentinel placed BEFORE the mobile banner wrapper
+  // Collapse the banner to title-only once the page is scrolled.
+  // The banner sits inside a `position: sticky` header, so a sentinel placed next to
+  // it never leaves the viewport - read the scroll container directly instead.
+  // `body` is the vertical scroller here (globals.scss sets height: 100dvh +
+  // overflow-x: hidden, which forces overflow-y to auto), so window.scrollY stays 0.
   useEffect(() => {
-    const bannerWrapper = mobileBannerWrapperRef.current;
-    if (!bannerWrapper) return;
+    const getScrollOffset = () =>
+      Math.max(document.body?.scrollTop ?? 0, document.documentElement?.scrollTop ?? 0, window.scrollY || 0);
 
-    // Create sentinel and place it BEFORE the banner wrapper
-    const sentinel = document.createElement('div');
-    sentinel.id = 'plaa-scroll-sentinel';
-    sentinel.style.cssText = 'height: 1px; width: 100%; pointer-events: none;';
-    bannerWrapper.parentNode?.insertBefore(sentinel, bannerWrapper);
+    const onScroll = () => setIsCompact(getScrollOffset() > COMPACT_SCROLL_OFFSET);
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsCompact(!entry.isIntersecting);
-      },
-      {
-        root: null,
-        rootMargin: `-${getComputedStyle(document.documentElement).getPropertyValue('--app-header-height') || '64px'} 0px 0px 0px`,
-        threshold: 0,
-      }
-    );
+    onScroll();
 
-    observer.observe(sentinel);
+    const targets: Array<EventTarget> = [document.body, document, window];
+    targets.forEach((t) => t.addEventListener('scroll', onScroll, { passive: true }));
 
     return () => {
-      observer.disconnect();
-      sentinel.remove();
+      targets.forEach((t) => t.removeEventListener('scroll', onScroll));
     };
   }, [pathname]);
 
@@ -158,9 +133,9 @@ export function PlaaBanner() {
             <div className={styles.emblaViewport} ref={desktopCarousel.emblaRef}>
               <div className={styles.emblaContainer}>
                 {BANNER_CONTENTS.map((item) => {
-                  const hasSubtitle = !!(item.subtitle || item.date || item.highlightText);
+                  const hasSubtitle = !!(item.subtitle || item.subtitleBold || item.date || item.highlightText);
                   const hasButtons = item.buttons.length > 0;
-                  const titleOnly = !hasSubtitle && !hasButtons;
+                  const titleOnly = !hasSubtitle && !hasButtons && !item.cta;
                   return (
                   <div key={item.id} className={`${styles.emblaSlide} ${titleOnly ? styles.emblaSlideTitleOnly : ''}`}>
                     {/* Icon */}
@@ -176,6 +151,17 @@ export function PlaaBanner() {
                     {/* Text */}
                     <div className={styles.textArea}>
                       <p className={styles.title}>{item.title}</p>
+                      {item.cta && (
+                        <a
+                          href={item.cta.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.ctaLink}
+                          onClick={() => onBannerButtonClicked(item.cta!.label, item.cta!.link)}
+                        >
+                          {item.cta.label}
+                        </a>
+                      )}
                       {hasSubtitle && (
                         <div className={styles.subtitle}>
                           <span>
@@ -184,7 +170,10 @@ export function PlaaBanner() {
                                 Bonus Points Multiplier <span className={styles.highlight}>{item.highlightText}</span> on Key Talent Referrals
                               </>
                             ) : (
-                              item.subtitle
+                              <>
+                                {item.subtitleBold && <strong className={styles.subtitleStrong}>{item.subtitleBold}</strong>}
+                                {item.subtitle}
+                              </>
                             )}
                           </span>
                           {item.date && (
@@ -221,7 +210,9 @@ export function PlaaBanner() {
           </div>
 
           {/* Pagination */}
-          <span className={styles.pagination}>{desktopCarousel.activeIndex + 1}/{totalSlides}</span>
+          {totalSlides > 1 && (
+            <span className={styles.pagination}>{desktopCarousel.activeIndex + 1}/{totalSlides}</span>
+          )}
 
           {/* Right Arrow - far right */}
           {totalSlides > 1 && (
@@ -232,16 +223,18 @@ export function PlaaBanner() {
         </div>
       </HighlightsBar>
 
-      <div ref={mobileBannerWrapperRef} className={styles.mobileBannerWrapper}>
+      <div className={styles.mobileBannerWrapper}>
         <div className={`${styles.mobileBanner} ${isCompact ? styles.mobileBannerCompact : ''}`}>
       {/* Dots - always visible, positioned at top in compact mode */}
-      <div className={styles.dotsWrapper}>
-        <div className={styles.dots}>
-          {BANNER_CONTENTS.map((_, i) => (
-            <span key={i} className={`${styles.dot} ${i === mobileCarousel.activeIndex ? styles.dotActive : ''}`} />
-          ))}
+      {totalSlides > 1 && (
+        <div className={styles.dotsWrapper}>
+          <div className={styles.dots}>
+            {BANNER_CONTENTS.map((_, i) => (
+              <span key={i} className={`${styles.dot} ${i === mobileCarousel.activeIndex ? styles.dotActive : ''}`} />
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Single carousel - always mounted for consistent swipe */}
       <div className={styles.mobileEmblaViewport} ref={mobileCarousel.emblaRef}>
@@ -253,9 +246,21 @@ export function PlaaBanner() {
               
               {/* Content hidden in compact mode */}
               <div className={styles.mobileHideOnCompact}>
+                {item.cta && (
+                  <a
+                    href={item.cta.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.mobileCtaLink}
+                    onClick={() => onBannerButtonClicked(item.cta!.label, item.cta!.link)}
+                  >
+                    {item.cta.label}
+                  </a>
+                )}
                 <div className={styles.mobileTextGroup}>
                   {item.type === 'event' ? (
                     <p className={styles.mobileSubtitle}>
+                      {item.subtitleBold && <strong className={styles.subtitleStrong}>{item.subtitleBold}</strong>}
                       {item.subtitle}{item.date && ` - ${item.date}`}
                     </p>
                   ) : (
@@ -266,27 +271,32 @@ export function PlaaBanner() {
                             Bonus Points Multiplier <span className={styles.highlight}>{item.highlightText}</span> on Key Talent Referrals
                           </>
                         ) : (
-                          item.subtitle
+                          <>
+                            {item.subtitleBold && <strong className={styles.subtitleStrong}>{item.subtitleBold}</strong>}
+                            {item.subtitle}
+                          </>
                         )}
                       </p>
                       {item.date && <p className={styles.mobileDate}>{item.date}</p>}
                     </>
                   )}
                 </div>
-                <div className={styles.mobileButtons}>
-                  {item.buttons.map((btn, i) => (
-                    <a
-                      key={i}
-                      href={btn.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={btn.variant === 'primary' ? styles.mobileBtnPrimary : styles.mobileBtnSecondary}
-                      onClick={() => onBannerButtonClicked(btn.label, btn.link)}
-                    >
-                      {btn.label}
-                    </a>
-                  ))}
-                </div>
+                {item.buttons.length > 0 && (
+                  <div className={styles.mobileButtons}>
+                    {item.buttons.map((btn, i) => (
+                      <a
+                        key={i}
+                        href={btn.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={btn.variant === 'primary' ? styles.mobileBtnPrimary : styles.mobileBtnSecondary}
+                        onClick={() => onBannerButtonClicked(btn.label, btn.link)}
+                      >
+                        {btn.label}
+                      </a>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           ))}
@@ -294,14 +304,16 @@ export function PlaaBanner() {
       </div>
 
       {/* Pagination with dots - bottom right in full mode */}
-      <div className={styles.mobilePaginationFixed}>
-        <span className={styles.paginationText}>{mobileCarousel.activeIndex + 1}/{totalSlides}</span>
-        <div className={styles.dots}>
-          {BANNER_CONTENTS.map((_, i) => (
-            <span key={i} className={`${styles.dot} ${i === mobileCarousel.activeIndex ? styles.dotActive : ''}`} />
-          ))}
+      {totalSlides > 1 && (
+        <div className={styles.mobilePaginationFixed}>
+          <span className={styles.paginationText}>{mobileCarousel.activeIndex + 1}/{totalSlides}</span>
+          <div className={styles.dots}>
+            {BANNER_CONTENTS.map((_, i) => (
+              <span key={i} className={`${styles.dot} ${i === mobileCarousel.activeIndex ? styles.dotActive : ''}`} />
+            ))}
+          </div>
         </div>
-      </div>
+      )}
         </div>
       </div>
     </>

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
@@ -17,18 +17,10 @@ interface BannerButton {
   variant: 'primary' | 'secondary';
 }
 
-interface BannerCta {
-  label: string;
-  link: string;
-}
-
 interface BannerContent {
   id: string;
   type: BannerType;
   title: string;
-  // Inline CTA rendered between the title and the supporting copy.
-  // Use this instead of `buttons` when the CTA must precede the copy.
-  cta?: BannerCta;
   // Bold lead-in rendered immediately before `subtitle`.
   subtitleBold?: string;
   subtitle: string;
@@ -49,14 +41,12 @@ export const BANNER_CONTENTS: BannerContent[] = [
     id: 'buyback-auction-july',
     type: 'event',
     title: 'The July Buyback Auction Is Now Live',
-    cta: {
-      label: 'Place Your Bid Now on the Surus Platform',
-      link: 'https://auction-interface.fly.dev/',
-    },
     subtitleBold: 'All bids must be in no later than July 21 at 12 PM ET',
     subtitle: ' for the opportunity to redeem your PLAA in exchange for cash.',
     date: '',
-    buttons: [],
+    buttons: [
+      { label: 'Place Your Bid Now on the Surus Platform', link: 'https://auction-interface.fly.dev/', variant: 'secondary' },
+    ],
   },
 ];
 
@@ -135,7 +125,7 @@ export function PlaaBanner() {
                 {BANNER_CONTENTS.map((item) => {
                   const hasSubtitle = !!(item.subtitle || item.subtitleBold || item.date || item.highlightText);
                   const hasButtons = item.buttons.length > 0;
-                  const titleOnly = !hasSubtitle && !hasButtons && !item.cta;
+                  const titleOnly = !hasSubtitle && !hasButtons;
                   return (
                   <div key={item.id} className={`${styles.emblaSlide} ${titleOnly ? styles.emblaSlideTitleOnly : ''}`}>
                     {/* Icon */}
@@ -151,17 +141,6 @@ export function PlaaBanner() {
                     {/* Text */}
                     <div className={styles.textArea}>
                       <p className={styles.title}>{item.title}</p>
-                      {item.cta && (
-                        <a
-                          href={item.cta.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.ctaLink}
-                          onClick={() => onBannerButtonClicked(item.cta!.label, item.cta!.link)}
-                        >
-                          {item.cta.label}
-                        </a>
-                      )}
                       {hasSubtitle && (
                         <div className={styles.subtitle}>
                           <span>
@@ -246,17 +225,6 @@ export function PlaaBanner() {
               
               {/* Content hidden in compact mode */}
               <div className={styles.mobileHideOnCompact}>
-                {item.cta && (
-                  <a
-                    href={item.cta.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.mobileCtaLink}
-                    onClick={() => onBannerButtonClicked(item.cta!.label, item.cta!.link)}
-                  >
-                    {item.cta.label}
-                  </a>
-                )}
                 <div className={styles.mobileTextGroup}>
                   {item.type === 'event' ? (
                     <p className={styles.mobileSubtitle}>

--- a/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
+++ b/components/core/navbar/components/PlaaBanner/PlaaBanner.tsx
@@ -42,7 +42,7 @@ export const BANNER_CONTENTS: BannerContent[] = [
     type: 'event',
     title: 'The July Buyback Auction Is Now Live',
     subtitleBold: 'All bids must be in no later than July 21 at 12 PM ET',
-    subtitle: ' for the opportunity to redeem your PLAA in exchange for cash.',
+    subtitle: ' for the opportunity to redeem your PLAA in exchange for USD.',
     date: '',
     buttons: [
       { label: 'Place Your Bid Now on the Surus Platform', link: 'https://auction-interface.fly.dev/', variant: 'secondary' },

--- a/components/page/aligement-assets/rounds/data/current-round.data.ts
+++ b/components/page/aligement-assets/rounds/data/current-round.data.ts
@@ -129,7 +129,7 @@ export const currentRoundData: CurrentRoundData = {
       { name: 'Network Tooling', value: 200 },
       { name: 'People/Talent', value: 0 },
       { name: 'Programs', value: 0 },
-      { name: 'Projects', value: 0 }
+      { name: 'Projects', value: 500 }
     ]
   },
 

--- a/components/page/aligement-assets/rounds/data/current-round.data.ts
+++ b/components/page/aligement-assets/rounds/data/current-round.data.ts
@@ -122,11 +122,11 @@ export const currentRoundData: CurrentRoundData = {
   chart: {
     title: 'Total Points Collected Per KPI category In Current Snapshot Period (updated weekly)',
     subtitle: 'Please note: totals may not include the most recent submissions, as some activities rely on participant reporting.',
-    maxValue: 100,
+    maxValue: 500,
     chartData: [
       { name: 'Brand', value: 0 },
-      { name: 'Knowledge', value: 0 },
-      { name: 'Network Tooling', value: 0 },
+      { name: 'Knowledge', value: 450 },
+      { name: 'Network Tooling', value: 200 },
       { name: 'People/Talent', value: 0 },
       { name: 'Programs', value: 0 },
       { name: 'Projects', value: 0 }

--- a/components/page/aligement-assets/rounds/data/current-round.data.ts
+++ b/components/page/aligement-assets/rounds/data/current-round.data.ts
@@ -160,7 +160,8 @@ export const currentRoundData: CurrentRoundData = {
       'Share a Reusable AI Resource or Tool',
       'Rank Among the Network\'s Most Supportive Members'
     ],
-    totalPointsCollected: '0',
+    // Sum of chart.chartData values above (450 + 200 + 500)
+    totalPointsCollected: '1,150',
     totalTokensAvailable: '10,000',
     numberOfBuybacks: 0
   },

--- a/components/page/aligement-assets/rounds/data/current-round.data.ts
+++ b/components/page/aligement-assets/rounds/data/current-round.data.ts
@@ -35,7 +35,7 @@ export const currentRoundData: CurrentRoundData = {
         openInNewTab: false
       },
       {
-        label: 'Check Your PLAA Balance',
+        label: 'Manage your Surus Account',
         url: 'https://app.surus.io/',
         type: 'secondary',
         icon: '/icons/rounds/filecoin.svg',

--- a/components/page/aligement-assets/rounds/sections/chart-section.tsx
+++ b/components/page/aligement-assets/rounds/sections/chart-section.tsx
@@ -7,6 +7,18 @@ interface ChartSectionProps {
   data: ChartSectionData;
 }
 
+const Y_AXIS_TICK_COUNT = 10;
+
+/**
+ * Build evenly spaced Y-axis ticks from 0 to maxValue.
+ * Derived rather than hardcoded so the axis always matches the data's scale.
+ */
+function buildYAxisTicks(maxValue: number): number[] {
+  if (!maxValue || maxValue <= 0) return [0];
+  const step = maxValue / Y_AXIS_TICK_COUNT;
+  return Array.from({ length: Y_AXIS_TICK_COUNT + 1 }, (_, i) => Math.round(step * i));
+}
+
 /**
  * ChartSection - Displays bar chart of points collected per KPI pillar
  * @param data - Chart section data from master JSON
@@ -49,7 +61,7 @@ export default function ChartSection({ data }: ChartSectionProps) {
                   />
                   <YAxis 
                     domain={[0, data.maxValue]}
-                    ticks={[0, 300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000]}
+                    ticks={buildYAxisTicks(data.maxValue)}
                     axisLine={false}
                     tickLine={false}
                     tick={{ 


### PR DESCRIPTION
## What changed

**Banner** — replaces the four "New Activity" slides with the July Buyback Auction announcement:
- Heading: **The July Buyback Auction Is Now Live** (bold)
- Supporting copy: **All bids must be in no later than July 21 at 12 PM ET** for the opportunity to redeem your PLAA in exchange for USD.
- CTA: [Place Your Bid Now on the Surus Platform](https://auction-interface.fly.dev/), right-aligned on desktop
- All banner text is a single size per breakpoint (14px desktop / 12px mobile)

**KPI chart** — Knowledge 450, Network Tooling 200, Projects 500. Total Points Collected set to 1,150 to match.

**Hero CTA** — "Check Your PLAA Balance" → "Manage your Surus Account" (link unchanged).

Verified in-browser at 1440 / 960 / 390px.

---

## ⚠️ Go-live timing — requires a timed deploy

**The banner must go live at exactly 12:00 PM Eastern on July 15.**

There is no scheduling mechanism: `PlaaBanner` renders on any `/alignment-asset*` route as soon as the code is deployed. There is no date gate or feature flag. **The code will not enforce this window — the production deploy must be timed to land at 12:00 PM ET on July 15.** Deploying earlier makes the banner live early.

---

## Notes for review

**1. Fixes a pre-existing bug, not introduced here.** The mobile banner was permanently stuck in compact mode, so the CTA and supporting copy were invisible and unclickable. The `IntersectionObserver` watched a sentinel injected inside a `position: sticky` header — it never moved relative to the viewport, and the `-56px` rootMargin left it outside the root from first paint, so it could never toggle. Reproduces on `main`, where the old subtitle and "Join the conversation" button were equally hidden. Now reads the real scroll container (`body`, per `globals.scss` `height: 100dvh`). This also restores collapse-on-scroll, which had never worked. Without it the new CTA does not exist on mobile.

**2. Two changes reach beyond the July banner** — worth the closest look:
- `chart-section.tsx` now derives Y-axis ticks from `maxValue`. A hardcoded `[0, 300 … 3000]` array was silently overriding `domain`, making `maxValue` dead config; the new values would have rendered as small bars in a mostly empty chart. **Applies to the KPI chart for future rounds.**
- `HighlightsBar.module.scss` `plaa` variant: fixed `height: 80px` → `min-height`, so the banner grows instead of clipping. **This variant is shared.**

**3. Mobile CTA sits below the copy.** The brief said no CTA at the bottom; a stacked mobile layout has no right-hand side. It is the only CTA, not a second one.

**4. `release/plaa-v7.9` was cut from `origin/main`**, so it carries everything on `main` not already in `v7.8` (e.g. `fix RelationshipDetails card width`, `AppSecretsPanel` work). UAT for `v7.9` exercises that too, not just the banner.

**5. Minor.**
- `Projects` (500) sits exactly at `maxValue` (500) — any future value above 500 needs `maxValue` raised with it.
- `totalPointsCollected` ('1,150') is a hardcoded string with no link to `chart.chartData`; the two can drift if pillar values change.
- "Manage **your** Surus Account" uses lowercase "your", unlike its title-case sibling "Submit Activities".

---

## Follow-up: current round leaderboard

Should be updated to the following. **This is a backend / leaderboard-API change — not settable from this repo**, so it is not included here:

| Rank | Name | Points |
|---|---|---|
| 1 | Michael Stachiw | 500 |
| 2 | Marc Johnson | 200 |
| 3 | Bradley Holden | 150 |
| 4 | David Casey | 150 |
| 5 | Ian Brunner | 150 |

`app/alignment-asset/page.tsx` fetches this from `PLAA_API_URL/api/v1/leaderboard`; `data.leaderboard` is only a fallback when the API returns zero entries, and the section renders for logged-in users only. Ties at 150 need a tie-break order, and each row needs an `activities` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
