### PR TITLE
LAB-2124 [AI Apps] Show creator profile photo on AI Apps tiles

### DIFF
--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
@@ -47,7 +47,13 @@ export function AiAppCard(props: Props) {
   const footer = (
     <div className={s.footer}>
       <div className={s.author}>
-        <img className={s.avatar} src={getDefaultAvatar(app.member.name)} alt="" width={20} height={20} />
+        <img
+          className={s.avatar}
+          src={app.member.image || getDefaultAvatar(app.member.name)}
+          alt=""
+          width={20}
+          height={20}
+        />
         <div className={s.authorText}>
           <p className={s.authorLine}>
             <span className={s.creatorTitle}>by</span>{' '}

--- a/prototypes/entries/ai-apps/mocks.ts
+++ b/prototypes/entries/ai-apps/mocks.ts
@@ -86,7 +86,7 @@ export const mockAiApps: AiAppWithDoc[] = [
     providedEnvVars: ['OPENAI_API_KEY'],
     createdAt: '2026-06-18T10:00:00.000Z',
     updatedAt: '2026-06-18T10:00:00.000Z',
-    member: { uid: 'm-1', name: 'Polina Bublii' },
+    member: { uid: 'm-1', name: 'Polina Bublii', image: null },
     // Seeded 1-pager (preview only) so the "anyone can view" state is visible
     // out of the box. Uploaded files additionally get a real `fileUrl`.
     onePager: {
@@ -112,7 +112,7 @@ export const mockAiApps: AiAppWithDoc[] = [
     providedEnvVars: [],
     createdAt: '2026-06-12T14:30:00.000Z',
     updatedAt: '2026-06-12T14:30:00.000Z',
-    member: { uid: 'm-2', name: 'Daniel Singer' },
+    member: { uid: 'm-2', name: 'Daniel Singer', image: null },
     onePager: {
       fileName: 'Founder Digest - Overview.html',
       fileSize: 18_240,
@@ -136,7 +136,7 @@ export const mockAiApps: AiAppWithDoc[] = [
     providedEnvVars: [],
     createdAt: '2026-06-05T09:15:00.000Z',
     updatedAt: '2026-06-05T09:15:00.000Z',
-    member: { uid: 'm-3', name: 'Maria Lopez' },
+    member: { uid: 'm-3', name: 'Maria Lopez', image: null },
   },
 ];
 

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -26,6 +26,8 @@ export interface AiApp {
   member: {
     uid: string;
     name: string;
+    /** Profile photo URL; null when the member has no photo (UI falls back to a generated avatar). */
+    image: string | null;
   };
 }
 


### PR DESCRIPTION
## Screenshot
<img width="745" height="307" alt="Screenshot 2026-07-15 at 6 33 20 PM" src="https://github.com/user-attachments/assets/701e2d16-7cf4-41da-9729-4cf70dc66878" />


## Ticket

[LAB-2124](https://linear.app/plrs-labos/issue/LAB-2124/ai-apps-show-creator-profile-photo-on-ai-apps-tiles)