### PR TITLE
feat(home): mobile horizontal-scroll Quick Actions carousel

### DIFF
--- a/components/page/home/QuickActions/QuickActions.module.scss
+++ b/components/page/home/QuickActions/QuickActions.module.scss
@@ -31,20 +31,42 @@
   }
 
   // Below 640px the grid becomes a horizontally-scrolling, snap-scroll row of
-  // fixed-width cards (partial peek of the next card). It bleeds full-bleed to
-  // the screen edge (negative margin cancels .home__cn's 14px mobile padding);
-  // only the first/last card gets that 14px back, as margin rather than
-  // container padding, so it's honored at max-scroll in every browser.
+  // fixed-width cards (~2.5 visible at once, matching the prototype). It
+  // bleeds full-bleed to the screen edge (negative margin cancels .home__cn's
+  // 14px mobile padding); only the first/last card gets that 14px back, as
+  // margin rather than container padding, so it's honored at max-scroll in
+  // every browser. --fade-left/--fade-right (set from JS based on scroll
+  // position) drive an edge fade-out mask hinting more cards are scrollable.
   @include mobile-only {
     display: flex;
     grid-template-columns: none;
     overflow-x: scroll;
     scroll-snap-type: x mandatory;
     margin-inline: -14px;
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black var(--fade-left, 0px),
+      black calc(100% - var(--fade-right, 0px)),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      black var(--fade-left, 0px),
+      black calc(100% - var(--fade-right, 0px)),
+      transparent 100%
+    );
     @include mixins.hide-scrollbar;
 
+    // Fixed width (not a %) sized to comfortably fit the longest title ("Book
+    // Office Hours", ~152px at this weight/tracking in Inter) plus the card's
+    // 16px side padding, so it never ellipsizes. min-width: 0 overrides the
+    // flex-item default of min-width: auto, which would otherwise let a card
+    // grow past this to fit its unbreakable (white-space: nowrap) text anyway.
     > * {
-      flex: 0 0 80%;
+      flex: 0 0 200px;
+      min-width: 0;
       scroll-snap-align: start;
     }
 

--- a/components/page/home/QuickActions/QuickActions.module.scss
+++ b/components/page/home/QuickActions/QuickActions.module.scss
@@ -1,3 +1,4 @@
+@use 'styles/mixins';
 @import 'styles/media.scss';
 
 .section {
@@ -29,7 +30,30 @@
     grid-template-columns: repeat(2, 1fr);
   }
 
+  // Below 640px the grid becomes a horizontally-scrolling, snap-scroll row of
+  // fixed-width cards (partial peek of the next card). It bleeds full-bleed to
+  // the screen edge (negative margin cancels .home__cn's 14px mobile padding);
+  // only the first/last card gets that 14px back, as margin rather than
+  // container padding, so it's honored at max-scroll in every browser.
   @include mobile-only {
-    grid-template-columns: 1fr;
+    display: flex;
+    grid-template-columns: none;
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+    margin-inline: -14px;
+    @include mixins.hide-scrollbar;
+
+    > * {
+      flex: 0 0 80%;
+      scroll-snap-align: start;
+    }
+
+    > *:first-child {
+      margin-left: 14px;
+    }
+
+    > *:last-child {
+      margin-right: 14px;
+    }
   }
 }

--- a/components/page/home/QuickActions/QuickActions.tsx
+++ b/components/page/home/QuickActions/QuickActions.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+
 import { useOfficeHoursAccess } from '@/services/access-control/hooks/useOfficeHoursAccess';
 import { useFounderGuidesAccess } from '@/services/access-control/hooks/useFounderGuidesAccess';
 
@@ -24,6 +26,35 @@ export function QuickActions() {
 
   const hasDealsAccess = !!currentUser?.rbac?.effectivePermissions.some((p) => p.code === 'deals.read');
 
+  // Drives the mobile scroll container's left/right edge fade — only fades
+  // the side that still has more cards to reveal. Hooks run unconditionally,
+  // ahead of the loading-guard early-returns below.
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [scrollEdges, setScrollEdges] = useState({ canScrollLeft: false, canScrollRight: false });
+
+  const updateScrollEdges = useCallback(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    const canScrollLeft = el.scrollLeft > 1;
+    const canScrollRight = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
+    setScrollEdges((prev) =>
+      prev.canScrollLeft === canScrollLeft && prev.canScrollRight === canScrollRight
+        ? prev
+        : { canScrollLeft, canScrollRight },
+    );
+  }, []);
+
+  // No dependency array: re-checks after every render, so it also catches the
+  // ref attaching once the loading-guard below lets real content mount.
+  useEffect(() => {
+    updateScrollEdges();
+  });
+
+  useEffect(() => {
+    window.addEventListener('resize', updateScrollEdges);
+    return () => window.removeEventListener('resize', updateScrollEdges);
+  }, [updateScrollEdges]);
+
   // For 'others' we defer until OH access resolves, and for 'founder' until
   // Founder Guides access resolves, to prevent a card swap — on the mobile
   // scroll-snap carousel a late-arriving card ahead of ones already swiped
@@ -41,7 +72,19 @@ export function QuickActions() {
     <section className={s.section}>
       <h2 className={s.title}>Quick Actions</h2>
       <p className={s.subtitle}>Quick actions to get the most from your network.</p>
-      <div className={s.grid} role="region" aria-label="Quick actions">
+      <div
+        ref={gridRef}
+        className={s.grid}
+        role="region"
+        aria-label="Quick actions"
+        onScroll={updateScrollEdges}
+        style={
+          {
+            '--fade-left': scrollEdges.canScrollLeft ? '20px' : '0px',
+            '--fade-right': scrollEdges.canScrollRight ? '20px' : '0px',
+          } as CSSProperties
+        }
+      >
         {group === 'pl-infra' && (
           <>
             <ActionCard

--- a/components/page/home/QuickActions/QuickActions.tsx
+++ b/components/page/home/QuickActions/QuickActions.tsx
@@ -20,51 +20,45 @@ export function QuickActions() {
   const { currentUser } = useCurrentUserStore();
   const group = detectUserGroup(currentUser?.rbac?.policies);
   const { canViewSupply, canSupply, canViewDemand, canRequestDemand, isLoading: ohLoading } = useOfficeHoursAccess();
-  const { hasAccess: hasFounderGuidesAccess } = useFounderGuidesAccess();
+  const { hasAccess: hasFounderGuidesAccess, isLoading: founderGuidesLoading } = useFounderGuidesAccess();
 
   const hasDealsAccess = !!currentUser?.rbac?.effectivePermissions.some((p) => p.code === 'deals.read');
 
-  // For 'others' we defer until OH access resolves to prevent a card swap flicker
+  // For 'others' we defer until OH access resolves, and for 'founder' until
+  // Founder Guides access resolves, to prevent a card swap — on the mobile
+  // scroll-snap carousel a late-arriving card ahead of ones already swiped
+  // past would visibly shift scroll position under the user.
   if (group === 'others' && ohLoading) return null;
+  if (group === 'founder' && founderGuidesLoading) return null;
 
   const hasOhAccess = canViewSupply || canSupply || canViewDemand || canRequestDemand;
 
   const ohCard = (
-    <ActionCard
-      icon={<CalendarBlankIcon />}
-      title="Book Office Hours"
-      description="Connect with experts across the network"
-      href={OH_HREF}
-    />
+    <ActionCard icon={<CalendarBlankIcon />} title="Book Office Hours" description="Meet experts" href={OH_HREF} />
   );
 
   return (
     <section className={s.section}>
       <h2 className={s.title}>Quick Actions</h2>
       <p className={s.subtitle}>Quick actions to get the most from your network.</p>
-      <div className={s.grid}>
+      <div className={s.grid} role="region" aria-label="Quick actions">
         {group === 'pl-infra' && (
           <>
             <ActionCard
               icon={<TeamsIcon />}
               title="Teams"
-              description="Explore organizations across the network"
+              description="Explore organizations"
               href="/teams?priorities=P1%7CP2%7CP3"
             />
             {ohCard}
-            <ActionCard
-              icon={<DealsIcon />}
-              title="Network Deals"
-              description="Exclusive offers for network members"
-              href="/deals"
-            />
+            <ActionCard icon={<DealsIcon />} title="Network Deals" description="Member perks" href="/deals" />
             <ActionCard
               icon={<FoundersGuidesIcon />}
               title="Founder Guides"
-              description="Resources curated for network founders"
+              description="For founders"
               href="/founder-guides"
             />
-            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Open roles" href="/jobs" />
           </>
         )}
 
@@ -75,19 +69,14 @@ export function QuickActions() {
               <ActionCard
                 icon={<FoundersGuidesIcon />}
                 title="Founder Guides"
-                description="Resources curated for network founders"
+                description="For founders"
                 href="/founder-guides"
               />
             )}
             {hasDealsAccess && (
-              <ActionCard
-                icon={<DealsIcon />}
-                title="Network Deals"
-                description="Exclusive offers for network members"
-                href="/deals"
-              />
+              <ActionCard icon={<DealsIcon />} title="Network Deals" description="Member perks" href="/deals" />
             )}
-            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Open roles" href="/jobs" />
           </>
         )}
 
@@ -103,7 +92,7 @@ export function QuickActions() {
                 href="/members"
               />
             )}
-            <ActionCard icon={<JobsIcon />} title="Job Board" description="Find your next role" href="/jobs" />
+            <ActionCard icon={<JobsIcon />} title="Job Board" description="Open roles" href="/jobs" />
           </>
         )}
       </div>

--- a/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
+++ b/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
@@ -54,6 +54,8 @@
   line-height: 24px;
   letter-spacing: -0.4px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .description {

--- a/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
+++ b/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
@@ -1,3 +1,5 @@
+@import 'styles/media.scss';
+
 .link {
   text-decoration: none;
   display: block;
@@ -23,6 +25,15 @@
   &:hover {
     box-shadow: 0 2px 8px rgba(14, 15, 17, 0.12);
   }
+
+  // Mobile carousel cards use the prototype's vertical layout (icon on top,
+  // no arrow) instead of the desktop/tablet horizontal row.
+  @include mobile-only {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+  }
 }
 
 .icon {
@@ -44,6 +55,11 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+
+  @include mobile-only {
+    flex: none;
+    width: 100%;
+  }
 }
 
 .title {
@@ -72,4 +88,9 @@
 
 .arrow {
   flex-shrink: 0;
+
+  // Prototype's mobile cards have no trailing arrow.
+  @include mobile-only {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- On mobile (<640px), `QuickActions` cards become a horizontally-scrolling, snap-scroll carousel with a partial next-card peek instead of a vertical stack — matching the `newsfeed-v0` prototype's treatment. Desktop/tablet-portrait grids are unchanged.
- Reuses the codebase's existing scroll-snap + `hide-scrollbar` pattern (from the Gantry Roadmap mobile view) rather than a new dependency — no carousel library added.
- Full-bleed to the screen edge on mobile, with the first card still aligned to the page's normal 14px inset (same technique already used by `ApplicationSearch`/`AllMembers`/`MembersFilter`).
- Five card descriptions shortened for the narrower cards: Teams → "Explore organizations", Book Office Hours → "Meet experts", Network Deals → "Member perks", Founder Guides → "For founders", Job Board → "Open roles". `Network Directory` copy is unchanged.
- Added a loading guard to the `founder` group (mirroring the existing `others` guard) so a card arriving after an async access check resolves can't shift scroll position out from under a user who has already swiped.
- Added `role="region"`/`aria-label` to the scroll container and defensive title-ellipsis CSS (titles previously had no truncation, unlike descriptions).

## Testing
- `npx eslint`, `npx tsc --noEmit`, and the existing Jest suite (`--testPathPattern home`, 192 tests) all pass.
- `/home` requires an authenticated session, which wasn't available in this environment, so the layout was verified with an isolated HTML/CSS reproduction of the exact compiled rules in a real mobile-width browser viewport: confirmed first-card alignment, next-card peek, full-bleed to the edge, a clean (non-clipped) trailing gutter after the last card, hidden scrollbar (`scrollbar-width: none`), and keyboard Tab-focus scrolling into off-screen cards without visibly fighting scroll-snap.
- Worth a quick manual spot-check on a real device (especially Safari iOS) post-merge, since the reproduction was Chromium-based.

## Docs
- Brainstorm: `docs/brainstorms/2026-07-17-quick-actions-mobile-scroll-brainstorm.md`
- Plan: `docs/plans/2026-07-17-feat-quick-actions-mobile-scroll-plan.md`
(both gitignored, local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)