### PR TITLE
AI App PRD viewer + detail page top bar

### DIFF
--- a/__tests__/core/navbar/site-header.test.tsx
+++ b/__tests__/core/navbar/site-header.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { SiteHeader } from '@/components/core/navbar/components/SiteHeader';
+
+const mockUsePathname = jest.fn();
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+jest.mock('@/components/core/navbar/nav-bar', () => ({
+  __esModule: true,
+  default: () => <div data-testid="navbar" />,
+}));
+
+jest.mock('@/components/core/navbar/components/PlaaBanner', () => ({
+  PlaaBanner: () => <div data-testid="plaa-banner" />,
+}));
+
+jest.mock('@/components/core/navbar/components/CompleteYourProfile', () => ({
+  CompleteYourProfile: () => <div data-testid="complete-your-profile" />,
+}));
+
+const props = { userInfo: {} as never, isLoggedIn: false, authToken: '' };
+
+describe('SiteHeader', () => {
+  it('renders the site chrome on a normal route', () => {
+    mockUsePathname.mockReturnValue('/members');
+    render(<SiteHeader {...props} />);
+
+    expect(screen.getByTestId('navbar')).toBeInTheDocument();
+    expect(screen.getByTestId('plaa-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('complete-your-profile')).toBeInTheDocument();
+  });
+
+  it('renders nothing on the bare AI App PRD viewer route', () => {
+    mockUsePathname.mockReturnValue('/pl-infra/ai-apps/app-1/prd');
+    const { container } = render(<SiteHeader {...props} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/page/ai-apps/ai-app-detail-page.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-detail-page.test.tsx
@@ -167,15 +167,15 @@ describe('AiAppDetailPage', () => {
 
     expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('AppSecretsPanel')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /back to ai apps/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /back to all/i })).not.toBeInTheDocument();
   });
 
   describe('healthy app top bar', () => {
-    it('renders "Back to AI Apps" pointing at the list route', () => {
+    it('renders "back to all" pointing at the list route', () => {
       mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
       render(<AiAppDetailPage uid="app-1" />);
 
-      expect(screen.getByRole('link', { name: /back to ai apps/i })).toHaveAttribute('href', '/pl-infra/ai-apps');
+      expect(screen.getByRole('link', { name: /back to all/i })).toHaveAttribute('href', '/pl-infra/ai-apps');
     });
 
     it('shows "App Details" only when the app has a one-pager, and opens the details modal', () => {

--- a/__tests__/page/ai-apps/ai-app-detail-page.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-detail-page.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { AiAppDetailPage } from '@/components/page/ai-apps/AiAppDetailPage';
 import { AiApp } from '@/services/ai-apps/ai-apps.service';
@@ -9,7 +9,6 @@ const mockAnalytics = {
   onDraftSetupViewed: jest.fn(),
   onIframeLoadFailed: jest.fn(),
   onIframeLoaded: jest.fn(),
-  onSecretsPanelOpened: jest.fn(),
 };
 
 let mockUseAiAppReturn: { app: AiApp | null; isLoading: boolean; isError: boolean };
@@ -35,32 +34,96 @@ jest.mock('@/components/page/ai-apps/components/FloatingFeedbackButton', () => (
   FloatingFeedbackButton: () => null,
 }));
 
-// AppSecretsPanel's own behavior (locking, deploy flow) is covered by its own
-// test file — here we only need to trigger its callback props to verify how
-// AiAppDetailPage reacts to them.
+// AppSecretsPanel's own behavior is covered by the mandatory-setup-card path
+// only, which this feature doesn't change — a bare stub is enough here.
 jest.mock('@/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel', () => ({
-  AppSecretsPanel: ({
-    onDeployingChange,
-    onDeploySucceeded,
+  AppSecretsPanel: () => <div>AppSecretsPanel</div>,
+}));
+
+const mockCanLikelyManage = jest.fn();
+jest.mock('@/services/ai-apps/hooks/useAiAppManageAccess', () => ({
+  useAiAppManageAccess: () => ({ canLikelyManage: mockCanLikelyManage, isDirectoryAdmin: false }),
+}));
+
+jest.mock('@/components/page/ai-apps/AiAppsPage/components/AppActionsMenu', () => ({
+  AppActionsMenu: ({
+    onEdit,
+    onDeployment,
+    onDelete,
   }: {
-    onDeployingChange?: (deploying: boolean) => void;
-    onDeploySucceeded?: () => void;
+    onEdit: () => void;
+    onDeployment: () => void;
+    onDelete: () => void;
   }) => (
     <div>
-      <span>AppSecretsPanel</span>
-      <button type="button" onClick={() => onDeployingChange?.(true)}>
-        Simulate deploy start
-      </button>
+      <span>AppActionsMenu</span>
+      <button onClick={onEdit}>Edit details</button>
+      <button onClick={onDeployment}>Deployment settings</button>
+      <button onClick={onDelete}>Delete app</button>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/page/ai-apps/dynamicActionModals', () => ({
+  EditAiAppModal: ({ onClose }: { onClose: () => void }) => (
+    <div>
+      <span>EditAiAppModal</span>
+      <button onClick={onClose}>Close edit</button>
+    </div>
+  ),
+  DeploymentSettingsModal: ({
+    onClose,
+    onDeployingChange,
+  }: {
+    onClose: () => void;
+    onDeployingChange?: (deploying: boolean) => void;
+  }) => (
+    <div>
+      <span>DeploymentSettingsModal</span>
+      <button onClick={() => onDeployingChange?.(true)}>Start redeploy</button>
+      <button onClick={() => onDeployingChange?.(false)}>Finish redeploy</button>
+      <button onClick={onClose}>Close deployment</button>
+    </div>
+  ),
+  DeleteAiAppDialog: ({
+    onClose,
+    onDeleteSucceeded,
+  }: {
+    onClose: () => void;
+    onDeleteSucceeded?: () => void;
+  }) => (
+    <div>
+      <span>DeleteAiAppDialog</span>
       <button
-        type="button"
         onClick={() => {
-          onDeploySucceeded?.();
-          onDeployingChange?.(false);
+          onDeleteSucceeded?.();
+          onClose();
         }}
       >
-        Simulate deploy success
+        Confirm delete
       </button>
+      <button onClick={onClose}>Cancel delete</button>
     </div>
+  ),
+  AiAppDetailsModal: ({ onClose }: { onClose: () => void }) => (
+    <div>
+      <span>AiAppDetailsModal</span>
+      <button onClick={onClose}>Close details</button>
+    </div>
+  ),
+}));
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
 }));
 
@@ -83,89 +146,111 @@ function buildApp(overrides: Partial<AiApp> = {}): AiApp {
     canManage: true,
     createdAt: '2026-07-01T00:00:00.000Z',
     updatedAt: '2026-07-01T00:00:00.000Z',
-    member: { uid: 'member-1', name: 'Ada' },
+    member: { uid: 'member-1', name: 'Ada', image: null },
     ...overrides,
   };
 }
 
 describe('AiAppDetailPage', () => {
+  beforeEach(() => {
+    mockCanLikelyManage.mockReturnValue(true);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders the centered setup card (not a collapsible bar) for a DRAFT app', () => {
+  it('renders the centered setup card for a DRAFT app, with no top bar', () => {
     mockUseAiAppReturn = { app: buildApp({ status: 'DRAFT', providedEnvVars: [] }), isLoading: false, isError: false };
 
     render(<AiAppDetailPage uid="app-1" />);
 
     expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('AppSecretsPanel')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Back to app' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /back to ai apps/i })).not.toBeInTheDocument();
   });
 
-  it('shows the "Update secrets & redeploy" entry point for a READY app, and swaps to the full centered card on click', () => {
-    mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+  describe('healthy app top bar', () => {
+    it('renders "Back to AI Apps" pointing at the list route', () => {
+      mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      render(<AiAppDetailPage uid="app-1" />);
 
-    render(<AiAppDetailPage uid="app-1" />);
+      expect(screen.getByRole('link', { name: /back to ai apps/i })).toHaveAttribute('href', '/pl-infra/ai-apps');
+    });
 
-    expect(screen.queryByText('AppSecretsPanel')).not.toBeInTheDocument();
-    const trigger = screen.getByRole('button', { name: 'Update secrets & redeploy' });
+    it('shows "App Details" only when the app has a one-pager, and opens the details modal', () => {
+      mockUseAiAppReturn = { app: buildApp({ prd: 'https://bucket.s3.amazonaws.com/ai-app-prds/app-1.md' }), isLoading: false, isError: false };
+      render(<AiAppDetailPage uid="app-1" />);
 
-    fireEvent.click(trigger);
+      const detailsButton = screen.getByRole('button', { name: /app details for news summarizer/i });
+      fireEvent.click(detailsButton);
+      expect(screen.getByText('AiAppDetailsModal')).toBeInTheDocument();
 
-    expect(screen.getByText('AppSecretsPanel')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back to app' })).toBeInTheDocument();
-    expect(mockAnalytics.onSecretsPanelOpened).toHaveBeenCalledWith({ appUid: 'app-1', isDraft: false });
-  });
+      fireEvent.click(screen.getByText('Close details'));
+      expect(screen.queryByText('AiAppDetailsModal')).not.toBeInTheDocument();
+    });
 
-  it('"Back to app" returns to the running-app view', async () => {
-    mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+    it('hides "App Details" when the app has no one-pager', () => {
+      mockUseAiAppReturn = { app: buildApp({ prd: null }), isLoading: false, isError: false };
+      render(<AiAppDetailPage uid="app-1" />);
 
-    render(<AiAppDetailPage uid="app-1" />);
+      expect(screen.queryByRole('button', { name: /app details/i })).not.toBeInTheDocument();
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Update secrets & redeploy' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Back to app' }));
+    it('shows the manage menu only when canLikelyManage is true', () => {
+      mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      mockCanLikelyManage.mockReturnValue(false);
+      render(<AiAppDetailPage uid="app-1" />);
 
-    expect(screen.queryByText('AppSecretsPanel')).not.toBeInTheDocument();
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Update secrets & redeploy' })).toBeInTheDocument());
-  });
+      expect(screen.queryByText('AppActionsMenu')).not.toBeInTheDocument();
+    });
 
-  it('disables "Back to app" while a deploy from the panel is in flight, and it does nothing if clicked', () => {
-    mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+    it('opens EditAiAppModal / DeploymentSettingsModal / DeleteAiAppDialog from the manage menu', () => {
+      mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      render(<AiAppDetailPage uid="app-1" />);
 
-    render(<AiAppDetailPage uid="app-1" />);
+      fireEvent.click(screen.getByText('Edit details'));
+      expect(screen.getByText('EditAiAppModal')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Close edit'));
+      expect(screen.queryByText('EditAiAppModal')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Update secrets & redeploy' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Simulate deploy start' }));
+      fireEvent.click(screen.getByText('Deployment settings'));
+      expect(screen.getByText('DeploymentSettingsModal')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('Close deployment'));
+      expect(screen.queryByText('DeploymentSettingsModal')).not.toBeInTheDocument();
 
-    const backButton = screen.getByRole('button', { name: 'Back to app' });
-    expect(backButton).toBeDisabled();
+      fireEvent.click(screen.getByText('Delete app'));
+      expect(screen.getByText('DeleteAiAppDialog')).toBeInTheDocument();
+    });
 
-    fireEvent.click(backButton);
-    expect(screen.getByText('AppSecretsPanel')).toBeInTheDocument();
-  });
+    it('navigates to the AI Apps list once delete succeeds, not on cancel', () => {
+      mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      render(<AiAppDetailPage uid="app-1" />);
 
-  it('returns to the running-app view once the panel reports a successful deploy', () => {
-    mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      fireEvent.click(screen.getByText('Delete app'));
+      fireEvent.click(screen.getByText('Cancel delete'));
+      expect(mockPush).not.toHaveBeenCalled();
 
-    render(<AiAppDetailPage uid="app-1" />);
+      fireEvent.click(screen.getByText('Delete app'));
+      fireEvent.click(screen.getByText('Confirm delete'));
+      expect(mockPush).toHaveBeenCalledWith('/pl-infra/ai-apps');
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Update secrets & redeploy' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Simulate deploy success' }));
+    it('starting a redeploy from the menu does not swap the page into the mandatory "Deploying" card', () => {
+      mockUseAiAppReturn = { app: buildApp(), isLoading: false, isError: false };
+      const { rerender } = render(<AiAppDetailPage uid="app-1" />);
 
-    expect(screen.queryByText('AppSecretsPanel')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Update secrets & redeploy' })).toBeInTheDocument();
-  });
+      fireEvent.click(screen.getByText('Deployment settings'));
+      fireEvent.click(screen.getByText('Start redeploy'));
 
-  it('does not show the secrets entry point for a non-creator viewer', () => {
-    mockUseAiAppReturn = {
-      app: buildApp({ canManage: false, member: { uid: 'someone-else', name: 'Bea' } }),
-      isLoading: false,
-      isError: false,
-    };
+      // Simulate the page's own poll observing the backend flip to DEPLOYING —
+      // without the onDeployingChange fix, this would unmount the modal below.
+      mockUseAiAppReturn = { app: buildApp({ status: 'DEPLOYING' }), isLoading: false, isError: false };
+      rerender(<AiAppDetailPage uid="app-1" />);
 
-    render(<AiAppDetailPage uid="app-1" />);
-
-    expect(screen.queryByRole('button', { name: 'Update secrets & redeploy' })).not.toBeInTheDocument();
+      expect(screen.getByText('DeploymentSettingsModal')).toBeInTheDocument();
+      expect(screen.queryByText('Deploying')).not.toBeInTheDocument();
+      expect(screen.getByText('Redeploying the app')).toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/page/ai-apps/ai-app-details-modal.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-details-modal.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { AiAppDetailsModal } from '@/components/page/ai-apps/components/AiAppDetailsModal';
+
+const mockPrefetchQuery = jest.fn();
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({ prefetchQuery: mockPrefetchQuery }),
+}));
+
+const mockUseAiAppPrdContent = jest.fn();
+jest.mock('@/services/ai-apps/hooks/useAiAppPrdContent', () => ({
+  useAiAppPrdContent: (...args: unknown[]) => mockUseAiAppPrdContent(...args),
+}));
+
+const mockAnalytics = { onPrdOpenInNewTabClicked: jest.fn() };
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => mockAnalytics,
+}));
+
+jest.mock('@/components/page/ai-apps/components/PrdViewerBody', () => ({
+  PrdViewerBody: ({ isLoading, error, content }: { isLoading: boolean; error: string | null; content: string | null }) => (
+    <div data-testid="prd-viewer-body">{isLoading ? 'loading' : error ?? content}</div>
+  ),
+}));
+
+describe('AiAppDetailsModal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAiAppPrdContent.mockReturnValue({ content: '# One-pager', error: null, isLoading: false });
+  });
+
+  it('renders an "Open in new tab" link pointing at the app\'s prd route, opening in a new tab', () => {
+    render(<AiAppDetailsModal isOpen uid="app-1" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    const link = screen.getByRole('link', { name: /open in new tab/i });
+    expect(link).toHaveAttribute('href', '/pl-infra/ai-apps/app-1/prd');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('encodes the uid when building the link', () => {
+    render(<AiAppDetailsModal isOpen uid="app 1/x" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    const link = screen.getByRole('link', { name: /open in new tab/i });
+    expect(link).toHaveAttribute('href', `/pl-infra/ai-apps/${encodeURIComponent('app 1/x')}/prd`);
+  });
+
+  it('fires analytics on click without blocking navigation, even if the analytics client throws', () => {
+    mockAnalytics.onPrdOpenInNewTabClicked.mockImplementation(() => {
+      throw new Error('posthog unavailable');
+    });
+    render(<AiAppDetailsModal isOpen uid="app-1" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    const link = screen.getByRole('link', { name: /open in new tab/i });
+    expect(() => fireEvent.click(link)).not.toThrow();
+    expect(mockAnalytics.onPrdOpenInNewTabClicked).toHaveBeenCalledWith('app-1', 'News Summarizer');
+  });
+
+  it('primes the prd content cache on hover', () => {
+    render(<AiAppDetailsModal isOpen uid="app-1" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: /open in new tab/i }));
+
+    expect(mockPrefetchQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['ai-app-prd-content', 'https://s3.example/prd.md']) }),
+    );
+  });
+
+  it('renders PrdViewerBody driven by useAiAppPrdContent', () => {
+    mockUseAiAppPrdContent.mockReturnValue({ content: '# Hello', error: null, isLoading: false });
+    render(<AiAppDetailsModal isOpen uid="app-1" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('# Hello');
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    render(<AiAppDetailsModal isOpen uid="app-1" appName="News Summarizer" prdUrl="https://s3.example/prd.md" onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/page/ai-apps/ai-app-feedback-page.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-feedback-page.test.tsx
@@ -62,7 +62,7 @@ describe('AiAppFeedbackPage', () => {
 
     render(<AiAppFeedbackPage />);
 
-    expect(screen.getByRole('link', { name: /Back to AI Apps/ })).toHaveAttribute('href', '/pl-infra/ai-apps');
+    expect(screen.getByRole('link', { name: /Back to all/ })).toHaveAttribute('href', '/pl-infra/ai-apps');
   });
 
   it('shows the app-creator heading/subtitle for a non-admin reviewer', () => {

--- a/__tests__/page/ai-apps/ai-app-prd-page.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-prd-page.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { AiAppPrdPage } from '@/components/page/ai-apps/AiAppPrdPage';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+let mockUseAiAppReturn: { app: AiApp | null; errorKind: string | null; isLoading: boolean };
+jest.mock('@/services/ai-apps/hooks/useAiApp', () => ({
+  useAiApp: () => mockUseAiAppReturn,
+}));
+
+let mockUseAiAppPrdContentReturn: { content: string | null; error: string | null; isLoading: boolean };
+jest.mock('@/services/ai-apps/hooks/useAiAppPrdContent', () => ({
+  useAiAppPrdContent: () => mockUseAiAppPrdContentReturn,
+}));
+
+const mockAnalytics = { onPrdPageViewed: jest.fn() };
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => mockAnalytics,
+}));
+
+jest.mock('@/components/page/ai-apps/components/PrdViewerBody', () => ({
+  PrdViewerBody: ({ isLoading, error, content }: { isLoading: boolean; error: string | null; content: string | null }) => (
+    <div data-testid="prd-viewer-body">{isLoading ? 'loading' : error ?? content}</div>
+  ),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'READY',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    prd: 'https://bucket.s3.us-east-1.amazonaws.com/ai-app-prds/app-1.md',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+const idlePrdQuery = { content: null, error: null, isLoading: false };
+
+describe('AiAppPrdPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a loading state (no header) while the app is loading', () => {
+    mockUseAiAppReturn = { app: null, errorKind: null, isLoading: true };
+    mockUseAiAppPrdContentReturn = idlePrdQuery;
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('loading');
+    expect(screen.queryByRole('link', { name: /back to app/i })).not.toBeInTheDocument();
+  });
+
+  it.each(['not-found', 'forbidden'])('collapses %s into a generic "not found" message with no header', (errorKind) => {
+    mockUseAiAppReturn = { app: null, errorKind, isLoading: false };
+    mockUseAiAppPrdContentReturn = idlePrdQuery;
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByText('This app could not be found.')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /back to app/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a distinct message for a network error', () => {
+    mockUseAiAppReturn = { app: null, errorKind: 'network', isLoading: false };
+    mockUseAiAppPrdContentReturn = idlePrdQuery;
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
+  });
+
+  it('shows a distinct empty state (with header) when the app has no prd', () => {
+    mockUseAiAppReturn = { app: buildApp({ prd: null }), errorKind: null, isLoading: false };
+    mockUseAiAppPrdContentReturn = idlePrdQuery;
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByText('This app no longer has a one-pager.')).toBeInTheDocument();
+    expect(screen.getByText('News Summarizer')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to app/i })).toHaveAttribute('href', '/pl-infra/ai-apps/app-1');
+  });
+
+  it('shows a loading indicator (with header) while the prd content is loading', () => {
+    mockUseAiAppReturn = { app: buildApp(), errorKind: null, isLoading: false };
+    mockUseAiAppPrdContentReturn = { content: null, error: null, isLoading: true };
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('loading');
+    expect(screen.getByText('News Summarizer')).toBeInTheDocument();
+  });
+
+  it('shows the prd content error via PrdViewerBody', () => {
+    mockUseAiAppReturn = { app: buildApp(), errorKind: null, isLoading: false };
+    mockUseAiAppPrdContentReturn = { content: null, error: 'One-pager could not be loaded', isLoading: false };
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('One-pager could not be loaded');
+  });
+
+  it('renders the content and fires onPrdPageViewed once on success', () => {
+    mockUseAiAppReturn = { app: buildApp(), errorKind: null, isLoading: false };
+    mockUseAiAppPrdContentReturn = { content: '# Hello', error: null, isLoading: false };
+
+    const { rerender } = render(<AiAppPrdPage uid="app-1" />);
+
+    expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('# Hello');
+    expect(mockAnalytics.onPrdPageViewed).toHaveBeenCalledTimes(1);
+    expect(mockAnalytics.onPrdPageViewed).toHaveBeenCalledWith('app-1', 'News Summarizer');
+
+    rerender(<AiAppPrdPage uid="app-1" />);
+    expect(mockAnalytics.onPrdPageViewed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onPrdPageViewed for the error/no-prd states', () => {
+    mockUseAiAppReturn = { app: buildApp({ prd: null }), errorKind: null, isLoading: false };
+    mockUseAiAppPrdContentReturn = idlePrdQuery;
+
+    render(<AiAppPrdPage uid="app-1" />);
+
+    expect(mockAnalytics.onPrdPageViewed).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/page/ai-apps/ai-app-prd-page.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-prd-page.test.tsx
@@ -25,15 +25,6 @@ jest.mock('@/components/page/ai-apps/components/PrdViewerBody', () => ({
   ),
 }));
 
-jest.mock('next/link', () => ({
-  __esModule: true,
-  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
-}));
-
 function buildApp(overrides: Partial<AiApp> = {}): AiApp {
   return {
     uid: 'app-1',
@@ -65,24 +56,22 @@ describe('AiAppPrdPage', () => {
     jest.clearAllMocks();
   });
 
-  it('shows a loading state (no header) while the app is loading', () => {
+  it('shows a loading state while the app is loading', () => {
     mockUseAiAppReturn = { app: null, errorKind: null, isLoading: true };
     mockUseAiAppPrdContentReturn = idlePrdQuery;
 
     render(<AiAppPrdPage uid="app-1" />);
 
     expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('loading');
-    expect(screen.queryByRole('link', { name: /back to app/i })).not.toBeInTheDocument();
   });
 
-  it.each(['not-found', 'forbidden'])('collapses %s into a generic "not found" message with no header', (errorKind) => {
+  it.each(['not-found', 'forbidden'])('collapses %s into a generic "not found" message', (errorKind) => {
     mockUseAiAppReturn = { app: null, errorKind, isLoading: false };
     mockUseAiAppPrdContentReturn = idlePrdQuery;
 
     render(<AiAppPrdPage uid="app-1" />);
 
     expect(screen.getByText('This app could not be found.')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /back to app/i })).not.toBeInTheDocument();
   });
 
   it('shows a distinct message for a network error', () => {
@@ -94,25 +83,22 @@ describe('AiAppPrdPage', () => {
     expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
   });
 
-  it('shows a distinct empty state (with header) when the app has no prd', () => {
+  it('shows a distinct empty state when the app has no prd', () => {
     mockUseAiAppReturn = { app: buildApp({ prd: null }), errorKind: null, isLoading: false };
     mockUseAiAppPrdContentReturn = idlePrdQuery;
 
     render(<AiAppPrdPage uid="app-1" />);
 
     expect(screen.getByText('This app no longer has a one-pager.')).toBeInTheDocument();
-    expect(screen.getByText('News Summarizer')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /back to app/i })).toHaveAttribute('href', '/pl-infra/ai-apps/app-1');
   });
 
-  it('shows a loading indicator (with header) while the prd content is loading', () => {
+  it('shows a loading indicator while the prd content is loading', () => {
     mockUseAiAppReturn = { app: buildApp(), errorKind: null, isLoading: false };
     mockUseAiAppPrdContentReturn = { content: null, error: null, isLoading: true };
 
     render(<AiAppPrdPage uid="app-1" />);
 
     expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('loading');
-    expect(screen.getByText('News Summarizer')).toBeInTheDocument();
   });
 
   it('shows the prd content error via PrdViewerBody', () => {
@@ -124,13 +110,14 @@ describe('AiAppPrdPage', () => {
     expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('One-pager could not be loaded');
   });
 
-  it('renders the content and fires onPrdPageViewed once on success', () => {
+  it('renders the content and fires onPrdPageViewed once on success, with no other chrome', () => {
     mockUseAiAppReturn = { app: buildApp(), errorKind: null, isLoading: false };
     mockUseAiAppPrdContentReturn = { content: '# Hello', error: null, isLoading: false };
 
     const { rerender } = render(<AiAppPrdPage uid="app-1" />);
 
     expect(screen.getByTestId('prd-viewer-body')).toHaveTextContent('# Hello');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
     expect(mockAnalytics.onPrdPageViewed).toHaveBeenCalledTimes(1);
     expect(mockAnalytics.onPrdPageViewed).toHaveBeenCalledWith('app-1', 'News Summarizer');
 

--- a/__tests__/page/ai-apps/delete-ai-app-dialog.test.tsx
+++ b/__tests__/page/ai-apps/delete-ai-app-dialog.test.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { DeleteAiAppDialog } from '@/components/page/ai-apps/AiAppsPage/components/DeleteAiAppDialog';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+const mockAnalytics = {
+  onDeleteAppOpened: jest.fn(),
+  onDeleteAppCancelled: jest.fn(),
+  onDeleteAppConfirmed: jest.fn(),
+  onDeleteAppFailed: jest.fn(),
+};
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => mockAnalytics,
+}));
+
+const mockMutateAsync = jest.fn();
+jest.mock('@/services/ai-apps/hooks/useDeleteAiApp', () => ({
+  useDeleteAiApp: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+}));
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'READY',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+describe('DeleteAiAppDialog — onDeleteSucceeded', () => {
+  const onClose = jest.fn();
+  const onDeleteSucceeded = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fires onDeleteSucceeded (after onClose) only when the delete actually succeeds', async () => {
+    mockMutateAsync.mockResolvedValue({ ok: true });
+    render(<DeleteAiAppDialog app={buildApp()} onClose={onClose} onDeleteSucceeded={onDeleteSucceeded} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete app/i }));
+
+    await waitFor(() => expect(onDeleteSucceeded).toHaveBeenCalled());
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not fire onDeleteSucceeded on cancel', () => {
+    render(<DeleteAiAppDialog app={buildApp()} onClose={onClose} onDeleteSucceeded={onDeleteSucceeded} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onDeleteSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onDeleteSucceeded when the delete fails', async () => {
+    mockMutateAsync.mockResolvedValue({ ok: false, error: 'Deleting failed. Please try again.' });
+    render(<DeleteAiAppDialog app={buildApp()} onClose={onClose} onDeleteSucceeded={onDeleteSucceeded} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete app/i }));
+
+    await waitFor(() => expect(screen.getByText('Deleting failed. Please try again.')).toBeInTheDocument());
+    expect(onDeleteSucceeded).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('omitting onDeleteSucceeded (the grid usage) does not throw', async () => {
+    mockMutateAsync.mockResolvedValue({ ok: true });
+    render(<DeleteAiAppDialog app={buildApp()} onClose={onClose} />);
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: /delete app/i }))).not.toThrow();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/__tests__/page/ai-apps/deployment-settings-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-settings-modal.test.tsx
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { DeploymentSettingsModal } from '@/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+const mockAnalytics = {
+  onDeploymentSettingsOpened: jest.fn(),
+  onSecretsDeployClicked: jest.fn(),
+  onSecretsDeploySucceeded: jest.fn(),
+  onSecretsDeployFailed: jest.fn(),
+};
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => mockAnalytics,
+}));
+
+const mockDeployAiApp = jest.fn();
+jest.mock('@/services/ai-apps/ai-apps.service', () => ({
+  ...jest.requireActual('@/services/ai-apps/ai-apps.service'),
+  deployAiApp: (...args: unknown[]) => mockDeployAiApp(...args),
+}));
+
+let mockUseAiAppReturn: { app: AiApp | null };
+jest.mock('@/services/ai-apps/hooks/useAiApp', () => ({
+  useAiApp: () => mockUseAiAppReturn,
+}));
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'READY',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+describe('DeploymentSettingsModal — onDeployingChange', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fires true synchronously on click — before the deploy request resolves', async () => {
+    let resolveDeploy!: (value: { app: AiApp; error: null }) => void;
+    mockDeployAiApp.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDeploy = resolve;
+      }),
+    );
+    const app = buildApp();
+    mockUseAiAppReturn = { app };
+    const onDeployingChange = jest.fn();
+
+    render(<DeploymentSettingsModal app={app} onClose={onClose} onDeployingChange={onDeployingChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^redeploy$/i }));
+
+    // Fired synchronously off the click — well before the network call below resolves.
+    expect(onDeployingChange).toHaveBeenCalledWith(true);
+
+    resolveDeploy({ app: { ...app, status: 'DEPLOYING' }, error: null });
+    await waitFor(() => expect(screen.getByText(/redeploying news summarizer/i)).toBeInTheDocument());
+  });
+
+  it('resets to false on unmount even if dismissed mid-deploy', () => {
+    mockDeployAiApp.mockReturnValue(new Promise(() => {})); // never resolves
+    const app = buildApp();
+    mockUseAiAppReturn = { app };
+    const onDeployingChange = jest.fn();
+
+    const { unmount } = render(
+      <DeploymentSettingsModal app={app} onClose={onClose} onDeployingChange={onDeployingChange} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^redeploy$/i }));
+    expect(onDeployingChange).toHaveBeenLastCalledWith(true);
+
+    unmount();
+    expect(onDeployingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('omitting onDeployingChange (the grid usage) does not throw', () => {
+    mockDeployAiApp.mockReturnValue(new Promise(() => {}));
+    const app = buildApp();
+    mockUseAiAppReturn = { app };
+
+    render(<DeploymentSettingsModal app={app} onClose={onClose} />);
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: /^redeploy$/i }))).not.toThrow();
+  });
+});

--- a/__tests__/page/ai-apps/derive-prd-page-state.test.ts
+++ b/__tests__/page/ai-apps/derive-prd-page-state.test.ts
@@ -1,0 +1,91 @@
+import { derivePrdPageState } from '@/components/page/ai-apps/AiAppPrdPage/derivePrdPageState';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'READY',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    prd: 'https://bucket.s3.us-east-1.amazonaws.com/ai-app-prds/app-1.md',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+const idlePrdQuery = { content: null, error: null, isLoading: false };
+
+describe('derivePrdPageState', () => {
+  it('is "loading" while the app query is loading, regardless of the prd query', () => {
+    expect(derivePrdPageState({ app: null, errorKind: null, isLoading: true }, idlePrdQuery)).toEqual({
+      status: 'loading',
+    });
+  });
+
+  it.each(['not-found', 'forbidden', 'network'] as const)('is "app-error" with errorKind %s', (errorKind) => {
+    expect(derivePrdPageState({ app: null, errorKind, isLoading: false }, idlePrdQuery)).toEqual({
+      status: 'app-error',
+      errorKind,
+    });
+  });
+
+  it('is "no-prd" when the app loaded but has no prd', () => {
+    expect(
+      derivePrdPageState({ app: buildApp({ prd: null }), errorKind: null, isLoading: false }, idlePrdQuery),
+    ).toEqual({ status: 'no-prd' });
+  });
+
+  it('is "no-prd" when prd is an empty/whitespace-only string', () => {
+    expect(
+      derivePrdPageState({ app: buildApp({ prd: '   ' }), errorKind: null, isLoading: false }, idlePrdQuery),
+    ).toEqual({ status: 'no-prd' });
+  });
+
+  it('is "prd-loading" once the app has a prd but its content is still loading', () => {
+    expect(
+      derivePrdPageState(
+        { app: buildApp(), errorKind: null, isLoading: false },
+        { content: null, error: null, isLoading: true },
+      ),
+    ).toEqual({ status: 'prd-loading' });
+  });
+
+  it('is "prd-error" with a default message when the content query errors with no message', () => {
+    expect(
+      derivePrdPageState(
+        { app: buildApp(), errorKind: null, isLoading: false },
+        { content: null, error: null, isLoading: false },
+      ),
+    ).toEqual({ status: 'prd-error', error: 'One-pager could not be loaded' });
+  });
+
+  it('is "prd-error" preserving a specific error message', () => {
+    expect(
+      derivePrdPageState(
+        { app: buildApp(), errorKind: null, isLoading: false },
+        { content: null, error: 'Custom failure', isLoading: false },
+      ),
+    ).toEqual({ status: 'prd-error', error: 'Custom failure' });
+  });
+
+  it('is "ready" with the content once everything resolved successfully', () => {
+    expect(
+      derivePrdPageState(
+        { app: buildApp(), errorKind: null, isLoading: false },
+        { content: '# Hello', error: null, isLoading: false },
+      ),
+    ).toEqual({ status: 'ready', prd: '# Hello' });
+  });
+});

--- a/__tests__/page/ai-apps/prd-viewer-body.test.tsx
+++ b/__tests__/page/ai-apps/prd-viewer-body.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { PrdViewerBody } from '@/components/page/ai-apps/components/PrdViewerBody';
+
+jest.mock('@/components/ui/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+jest.mock('@/components/page/ai-apps/components/PrdContent', () => ({
+  PrdContent: ({ prd }: { prd: string }) => <div data-testid="prd-content">{prd}</div>,
+}));
+
+describe('PrdViewerBody', () => {
+  it('shows a spinner while loading, regardless of error/content', () => {
+    render(<PrdViewerBody isLoading error={null} content={null} />);
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.queryByTestId('prd-content')).not.toBeInTheDocument();
+  });
+
+  it('shows the error message when an error is present', () => {
+    render(<PrdViewerBody isLoading={false} error="Custom failure" content={null} />);
+    expect(screen.getByText('Custom failure')).toBeInTheDocument();
+  });
+
+  it('falls back to a default message when content is null with no explicit error', () => {
+    render(<PrdViewerBody isLoading={false} error={null} content={null} />);
+    expect(screen.getByText('One-pager could not be loaded')).toBeInTheDocument();
+  });
+
+  it('renders PrdContent once loading is done and content resolved', () => {
+    render(<PrdViewerBody isLoading={false} error={null} content="# Hello" />);
+    expect(screen.getByTestId('prd-content')).toHaveTextContent('# Hello');
+  });
+});

--- a/__tests__/utils/isBareRoute.test.ts
+++ b/__tests__/utils/isBareRoute.test.ts
@@ -1,0 +1,27 @@
+import { isBareRoute } from '@/utils/isBareRoute';
+
+describe('isBareRoute', () => {
+  it('matches the AI App PRD viewer route', () => {
+    expect(isBareRoute('/pl-infra/ai-apps/app-1/prd')).toBe(true);
+  });
+
+  it('matches with a trailing slash', () => {
+    expect(isBareRoute('/pl-infra/ai-apps/app-1/prd/')).toBe(true);
+  });
+
+  it('does not match the app detail route itself', () => {
+    expect(isBareRoute('/pl-infra/ai-apps/app-1')).toBe(false);
+  });
+
+  it('does not match the ai-apps list route', () => {
+    expect(isBareRoute('/pl-infra/ai-apps')).toBe(false);
+  });
+
+  it('does not match an unrelated route', () => {
+    expect(isBareRoute('/members')).toBe(false);
+  });
+
+  it('does not match a nested path beyond /prd', () => {
+    expect(isBareRoute('/pl-infra/ai-apps/app-1/prd/extra')).toBe(false);
+  });
+});

--- a/analytics/ai-apps.analytics.ts
+++ b/analytics/ai-apps.analytics.ts
@@ -80,5 +80,9 @@ export function useAiAppsAnalytics() {
     onDeleteAppFailed: (appUid: string) => capture(AI_APPS_ANALYTICS.DELETE_APP_FAILED, { appUid }),
     onAppDetailsOpened: (appUid: string, appName: string) =>
       capture(AI_APPS_ANALYTICS.APP_DETAILS_OPENED, { appUid, appName }),
+    onPrdOpenInNewTabClicked: (appUid: string, appName: string) =>
+      capture(AI_APPS_ANALYTICS.PRD_OPEN_IN_NEW_TAB_CLICKED, { appUid, appName }),
+    onPrdPageViewed: (appUid: string, appName: string) =>
+      capture(AI_APPS_ANALYTICS.PRD_PAGE_VIEWED, { appUid, appName }),
   };
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import Navbar from '../components/core/navbar/nav-bar';
 import './globals.scss';
 import '../styles/index.scss';
 import StyledJsxRegistry from '../providers/registry';
@@ -15,7 +14,7 @@ import StoreInitializer from '@/providers/StoreInitializer';
 // import { OnboardingFlowTrigger } from '@/components/page/onboarding/components/OnboardingFlowTrigger';
 import PostHogIdentifier from '@/components/page/posthog-identifier';
 import PostLoginRedirectHandler from '@/components/page/recommendations/components/RecommendationsPreloader/PostLoginRedirectHandler';
-import { CompleteYourProfile } from '@/components/core/navbar/components/CompleteYourProfile';
+import { SiteHeader } from '@/components/core/navbar/components/SiteHeader';
 import { LoginFlowTrigger } from '@/components/page/onboarding/components/LoginFlowTrigger';
 import { UserInfoChecker, UserInfoValidator } from '@/components/core/login';
 import { MobileBottomNav } from '@/components/core/MobileBottomNav';
@@ -23,7 +22,6 @@ import { DemoDayStats } from '@/components/core/DemoDayStats';
 import { ContactSupport } from '@/components/ContactSupport/ContactSupport';
 import { ContactSupportUrlSync } from '@/components/ContactSupport/ContactSupportUrlSync';
 import { PushNotificationsProvider } from '@/providers/PushNotificationsProvider';
-import { PlaaBanner } from '@/components/core/navbar/components/PlaaBanner';
 import {
   Loader,
   AuthBox,
@@ -77,13 +75,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <StoreInitializer userInfo={userInfo} />
                 <PostHogIdentifier />
                 <ContactSupportUrlSync />
-                <header className="layout__header">
-                  {/* <DemoDayBanner /> */}
-                  <PlaaBanner />
-                  {/*<SubscribeToRecoomendations userInfo={userInfo} />*/}
-                  <CompleteYourProfile />
-                  <Navbar isLoggedIn={isLoggedIn} userInfo={userInfo} authToken={authToken} />
-                </header>
+                <SiteHeader userInfo={userInfo} isLoggedIn={isLoggedIn} authToken={authToken} />
                 <AuthBox isLoggedIn={isLoggedIn} />
                 <ContactSupport userInfo={userInfo} />
                 <DemoDayStats />

--- a/app/pl-infra/ai-apps/[id]/prd/page.tsx
+++ b/app/pl-infra/ai-apps/[id]/prd/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { use } from 'react';
+
+import { AiAppPrdPage } from '@/components/page/ai-apps/AiAppPrdPage';
+import { AiAppsAccessGuard } from '@/components/page/ai-apps/AiAppsPage/components/AiAppsAccessGuard';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default function Page(props: Props) {
+  const params = use(props.params);
+
+  return (
+    <AiAppsAccessGuard>
+      <AiAppPrdPage uid={params.id} />
+    </AiAppsAccessGuard>
+  );
+}

--- a/components/core/MobileBottomNav/MobileBottomNav.tsx
+++ b/components/core/MobileBottomNav/MobileBottomNav.tsx
@@ -17,6 +17,7 @@ import { ISubItem } from '@/components/core/navbar/type';
 import { useDemoDayAnalyticsAccess } from '@/services/rbac/hooks/useDemoDayAnalyticsAccess';
 import { useMoreNavItems } from '@/components/core/navbar/components/navItems/MoreNavItems/hooks/useMoreNavItems';
 import { useGetPlInfraNavItems } from '@/components/core/navbar/components/navItems/PLInfraNavItems/hook/useGetPlInfraNavItems';
+import { isBareRoute } from '@/utils/isBareRoute';
 
 import { NavigationMenu } from '@base-ui-components/react';
 
@@ -35,6 +36,8 @@ export function MobileBottomNav() {
   const baseMoreItems = useMoreNavItems();
   const moreItems = useMemo(() => [FORUM_LINK, ...baseMoreItems], [baseMoreItems]);
   const plInfraItems: ISubItem[] = useGetPlInfraNavItems();
+
+  if (isBareRoute(pathname)) return null;
 
   return (
     <div

--- a/components/core/navbar/components/SiteHeader/SiteHeader.tsx
+++ b/components/core/navbar/components/SiteHeader/SiteHeader.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import Navbar from '@/components/core/navbar/nav-bar';
+import { PlaaBanner } from '@/components/core/navbar/components/PlaaBanner';
+import { CompleteYourProfile } from '@/components/core/navbar/components/CompleteYourProfile';
+import { IUserInfo } from '@/types/shared.types';
+import { isBareRoute } from '@/utils/isBareRoute';
+
+interface Props {
+  userInfo: IUserInfo;
+  isLoggedIn: boolean;
+  authToken: string;
+}
+
+/** Hidden on bare/full-screen document routes (see isBareRoute) — those pages want no site chrome at all. */
+export function SiteHeader({ userInfo, isLoggedIn, authToken }: Props) {
+  const pathname = usePathname();
+  if (isBareRoute(pathname ?? '')) return null;
+
+  return (
+    <header className="layout__header">
+      {/* <DemoDayBanner /> */}
+      <PlaaBanner />
+      {/*<SubscribeToRecoomendations userInfo={userInfo} />*/}
+      <CompleteYourProfile />
+      <Navbar isLoggedIn={isLoggedIn} userInfo={userInfo} authToken={authToken} />
+    </header>
+  );
+}

--- a/components/core/navbar/components/SiteHeader/index.ts
+++ b/components/core/navbar/components/SiteHeader/index.ts
@@ -1,0 +1,1 @@
+export { SiteHeader } from './SiteHeader';

--- a/components/icons/DocumentIcon.tsx
+++ b/components/icons/DocumentIcon.tsx
@@ -1,0 +1,15 @@
+import { SVGProps } from 'react';
+
+export function DocumentIcon(props?: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" {...props}>
+      <path
+        d="M4 1.5h5L13 5.5V13a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 13V3A1.5 1.5 0 0 1 4 1.5Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path d="M8.5 1.5V6h4.5" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -37,3 +37,4 @@ export * from './QuestionCircleStrokeIcon';
 export * from './ChartIcon';
 export * from './BookmarkIcon';
 export * from './ConfettiIcon';
+export * from './DocumentIcon';

--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.module.scss
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.module.scss
@@ -120,29 +120,6 @@
   gap: 16px;
 }
 
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  width: fit-content;
-  padding: 0;
-  border: none;
-  background: none;
-  font-size: 14px;
-  font-weight: 500;
-  color: #455468;
-  cursor: pointer;
-
-  &:hover {
-    color: #0a0c11;
-  }
-
-  &:disabled {
-    color: #94a3b8;
-    cursor: default;
-  }
-}
-
 .setupCard {
   width: 100%;
   max-width: 560px;
@@ -218,12 +195,13 @@
   color: #64748b;
 }
 
-.secretsBar {
+.topBar {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
-  /* Horizontal padding mirrors the navbar (NavBar.module.scss), so the toggle
-     and form line up with the header logo. */
+  /* Horizontal padding mirrors the navbar (NavBar.module.scss), so the bar's
+     content lines up with the header logo. */
   padding: 8px 16px;
   border-bottom: 1px solid #e2e8f0;
   background: #f8fafc;
@@ -233,23 +211,66 @@
   }
 }
 
-.secretsToggle {
-  align-self: flex-start;
-  padding: 4px 0;
-  border: none;
-  background: none;
-  font-size: 13px;
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  font-size: 14px;
   font-weight: 500;
-  color: #156ff7;
-  cursor: pointer;
+  color: var(--foreground-neutral-secondary, #455468);
+  text-decoration: none;
 
   &:hover {
-    text-decoration: underline;
+    color: var(--foreground-neutral-primary, #0a0c11);
   }
+}
 
-  &:disabled {
-    color: #94a3b8;
-    cursor: default;
-    text-decoration: none;
+.topBarActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+// Matches AiAppCard's "App Details" button/badge (AiAppCard.module.scss),
+// minus the absolute-positioning bits that only make sense floating over a
+// stretched card link.
+.detailsButton {
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 2px;
+    border-radius: 26px;
   }
+}
+
+.detailsBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: fit-content;
+  padding: 3px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+  background: var(--transparent-dark-2, rgba(14, 15, 17, 0.02));
+  color: var(--foreground-neutral-secondary, #455468);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  white-space: nowrap;
+  transition: background 0.15s;
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
+.detailsButton:hover .detailsBadge {
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
 }

--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
@@ -274,7 +274,7 @@ export function AiAppDetailPage(props: Props) {
       <div className={s.topBar}>
         <Link href="/pl-infra/ai-apps" className={s.backLink}>
           <ArrowBackIcon width={16} height={16} />
-          Back to AI Apps
+          Back to all
         </Link>
         <div className={s.topBarActions}>
           {hasPrd(app) && (
@@ -313,11 +313,7 @@ export function AiAppDetailPage(props: Props) {
       )}
       {action === 'edit' && <EditAiAppModal app={app} onClose={() => setAction(null)} />}
       {action === 'deployment' && (
-        <DeploymentSettingsModal
-          app={app}
-          onClose={() => setAction(null)}
-          onDeployingChange={setIsRedeploying}
-        />
+        <DeploymentSettingsModal app={app} onClose={() => setAction(null)} onDeployingChange={setIsRedeploying} />
       )}
       {action === 'delete' && (
         <DeleteAiAppDialog

--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
@@ -1,12 +1,22 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useAiApp } from '@/services/ai-apps/hooks/useAiApp';
-import { checkAiAppLive } from '@/services/ai-apps/ai-apps.service';
-import { ArrowBackIcon } from '@/components/icons';
+import { useAiAppManageAccess } from '@/services/ai-apps/hooks/useAiAppManageAccess';
+import { checkAiAppLive, hasPrd } from '@/services/ai-apps/ai-apps.service';
+import { ArrowBackIcon, DocumentIcon } from '@/components/icons';
+import { AppActionsMenu } from '@/components/page/ai-apps/AiAppsPage/components/AppActionsMenu';
+import {
+  EditAiAppModal,
+  DeploymentSettingsModal,
+  DeleteAiAppDialog,
+  AiAppDetailsModal,
+} from '@/components/page/ai-apps/dynamicActionModals';
 import { FloatingFeedbackButton } from '../components/FloatingFeedbackButton';
 
 import { AppSecretsPanel } from './components/AppSecretsPanel';
@@ -16,6 +26,8 @@ import s from './AiAppDetailPage.module.scss';
 interface Props {
   uid: string;
 }
+
+type Action = 'edit' | 'deployment' | 'delete';
 
 const SETUP_STATUS_LABELS: Record<string, string> = {
   DRAFT: 'Draft',
@@ -43,12 +55,15 @@ export function AiAppDetailPage(props: Props) {
 
   const { app, isLoading, isError } = useAiApp(uid);
   const { currentUser } = useCurrentUserStore();
+  const { canLikelyManage } = useAiAppManageAccess();
+  const router = useRouter();
   const analytics = useAiAppsAnalytics();
   const trackedAppUid = useRef<string | null>(null);
   const trackedDraftSetupUid = useRef<string | null>(null);
   const iframeTracked = useRef<string | null>(null);
-  const [showSecrets, setShowSecrets] = useState(false);
   const [isRedeploying, setIsRedeploying] = useState(false);
+  const [action, setAction] = useState<Action | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
   // Bumped by "Try again" to restart the polling effect after it gave up.
   const [retryToken, setRetryToken] = useState(0);
   // Result of the liveness polling, tagged with the generation it probed. A new
@@ -63,14 +78,19 @@ export function AiAppDetailPage(props: Props) {
   }, [app, analytics]);
 
   const requiredEnvVars = app?.requiredEnvVars ?? [];
-  const needsSetup = !!app && requiredEnvVars.length > 0 && app.status !== 'READY';
+  // Genuinely "never deployed" only means DRAFT — DEPLOYING/ERROR have their
+  // own dedicated flags below (which correctly respect `isRedeploying`).
+  // Checking `status !== 'READY'` here too would also catch a DEPLOYING app
+  // between polls of our own voluntary redeploy, bypassing that guard and
+  // yanking into this mandatory branch mid-flight.
+  const needsSetup = !!app && requiredEnvVars.length > 0 && app.status === 'DRAFT';
   // A failed deploy (runner error, or a stuck deploy the backend settled to
   // ERROR) is surfaced as a full status card — never a broken iframe — with the
   // error notes and a retry path for the creator/admin.
   const deployFailed = app?.status === 'ERROR';
   // An in-flight deploy someone else started (agent redeploy, another admin).
-  // While OUR deploy runs (isRedeploying) the secrets panel owns the UI instead,
-  // so its result/error handling is never unmounted mid-flight.
+  // While OUR deploy runs (isRedeploying) the secrets panel or the deployment
+  // settings modal owns the UI instead, so neither is unmounted mid-flight.
   const deployInProgress = app?.status === 'DEPLOYING' && !isRedeploying;
 
   useEffect(() => {
@@ -78,19 +98,6 @@ export function AiAppDetailPage(props: Props) {
     trackedDraftSetupUid.current = app.uid;
     analytics.onDraftSetupViewed({ appUid: app.uid, appName: app.name });
   }, [app, needsSetup, analytics]);
-
-  const openSecrets = () => {
-    if (!app) return;
-    analytics.onSecretsPanelOpened({ appUid: app.uid, isDraft: false });
-    setShowSecrets(true);
-  };
-
-  const closeSecrets = () => {
-    // A deploy in flight owns the panel's error state — leaving mid-deploy
-    // would unmount AppSecretsPanel and silently discard a failed-deploy error.
-    if (isRedeploying) return;
-    setShowSecrets(false);
-  };
 
   useEffect(() => {
     if (isError && uid) {
@@ -164,23 +171,12 @@ export function AiAppDetailPage(props: Props) {
   const isCreator = app.canManage ?? (!!currentUser?.uid && currentUser.uid === app.member?.uid);
 
   // Shown both for an app that genuinely isn't deployed yet (needsSetup) and
-  // for a healthy, running app whose creator opted into updating its secrets
-  // (showSecrets) — same centered card either way, so a voluntary redeploy
-  // gets the identical experience to a first deploy or a failed one.
-  if (needsSetup || deployFailed || deployInProgress || showSecrets) {
-    // Back link only when the creator opened the card voluntarily over a
-    // healthy app — for a failed/undeployed/deploying app there is nothing
-    // usable behind it to go back to.
-    const cameFromHealthyApp = showSecrets && !needsSetup && !deployFailed && !deployInProgress;
+  // for a deploy in progress or failed — the top bar's "Deployment settings"
+  // menu item is the only voluntary entry point for a healthy app now.
+  if (needsSetup || deployFailed || deployInProgress) {
     return (
       <div className={s.setupPage}>
         <div className={s.setupContent}>
-          {cameFromHealthyApp && (
-            <button type="button" className={s.backLink} onClick={closeSecrets} disabled={isRedeploying}>
-              <ArrowBackIcon width={16} height={16} />
-              Back to app
-            </button>
-          )}
           <div className={s.setupCard}>
             <div className={s.setupHeader}>
               <h1 className={s.setupTitle}>{app.name}</h1>
@@ -200,7 +196,7 @@ export function AiAppDetailPage(props: Props) {
                 </p>
               </div>
             ) : isCreator ? (
-              <AppSecretsPanel app={app} onDeployingChange={setIsRedeploying} onDeploySucceeded={closeSecrets} />
+              <AppSecretsPanel app={app} onDeployingChange={setIsRedeploying} />
             ) : (
               <p className={s.setupInfo}>
                 {deployFailed
@@ -275,15 +271,61 @@ export function AiAppDetailPage(props: Props) {
 
   return (
     <div className={s.root}>
-      {isCreator && requiredEnvVars.length > 0 && (
-        <div className={s.secretsBar}>
-          <button type="button" className={s.secretsToggle} onClick={openSecrets}>
-            Update secrets & redeploy
-          </button>
+      <div className={s.topBar}>
+        <Link href="/pl-infra/ai-apps" className={s.backLink}>
+          <ArrowBackIcon width={16} height={16} />
+          Back to AI Apps
+        </Link>
+        <div className={s.topBarActions}>
+          {hasPrd(app) && (
+            <button
+              type="button"
+              className={s.detailsButton}
+              onClick={() => setShowDetails(true)}
+              aria-label={`App details for ${app.name}`}
+            >
+              <span className={s.detailsBadge}>
+                <DocumentIcon aria-hidden />
+                App Details
+              </span>
+            </button>
+          )}
+          {canLikelyManage(app.member.uid) && (
+            <AppActionsMenu
+              app={app}
+              onEdit={() => setAction('edit')}
+              onDeployment={() => setAction('deployment')}
+              onDelete={() => setAction('delete')}
+            />
+          )}
         </div>
-      )}
+      </div>
       {renderFrameArea()}
       <FloatingFeedbackButton appUid={app.uid} appName={app.name} />
+      {showDetails && (
+        <AiAppDetailsModal
+          isOpen
+          uid={app.uid}
+          appName={app.name}
+          prdUrl={app.prd as string}
+          onClose={() => setShowDetails(false)}
+        />
+      )}
+      {action === 'edit' && <EditAiAppModal app={app} onClose={() => setAction(null)} />}
+      {action === 'deployment' && (
+        <DeploymentSettingsModal
+          app={app}
+          onClose={() => setAction(null)}
+          onDeployingChange={setIsRedeploying}
+        />
+      )}
+      {action === 'delete' && (
+        <DeleteAiAppDialog
+          app={app}
+          onClose={() => setAction(null)}
+          onDeleteSucceeded={() => router.push('/pl-infra/ai-apps')}
+        />
+      )}
     </div>
   );
 }

--- a/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.tsx
+++ b/components/page/ai-apps/AiAppFeedbackPage/AiAppFeedbackPage.tsx
@@ -69,7 +69,7 @@ export function AiAppFeedbackPage() {
       <div className={s.content}>
         <Link href="/pl-infra/ai-apps" className={s.backLink}>
           <ArrowBackIcon width={16} height={16} />
-          Back to AI Apps
+          Back to all
         </Link>
 
         <div className={s.titleBlock}>

--- a/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
+++ b/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
@@ -1,0 +1,67 @@
+@use 'styles/media';
+
+.root {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--app-header-height));
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 20px 24px 0;
+
+  @include media.tablet-landscape {
+    padding: 24px 32px 0;
+  }
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--foreground-neutral-secondary, #455468);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.viewport {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 20px 24px 40px;
+
+  // Same reading-column width as the modal's `.modal` max-width, so the
+  // rendered one-pager looks identical whether opened inline or full-page.
+  > * {
+    width: 100%;
+    max-width: 760px;
+  }
+
+  @include media.tablet-landscape {
+    padding: 24px 32px 48px;
+  }
+}
+
+.stateText {
+  margin: auto;
+  font-size: 14px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}

--- a/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
+++ b/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
@@ -1,44 +1,13 @@
 @use 'styles/media';
 
+// This is a bare route (see isBareRoute) — the site navbar/bottom nav are
+// hidden entirely, so this page owns the full viewport, not the space below
+// a header.
 .root {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - var(--app-header-height));
+  min-height: 100vh;
   width: 100%;
-}
-
-.header {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 20px 24px 0;
-
-  @include media.tablet-landscape {
-    padding: 24px 32px 0;
-  }
-}
-
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--foreground-neutral-secondary, #455468);
-  text-decoration: none;
-
-  &:hover {
-    color: var(--foreground-neutral-primary, #0a0c11);
-  }
-}
-
-.title {
-  margin: 0;
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 600;
-  color: var(--foreground-neutral-primary, #0a0c11);
 }
 
 .viewport {
@@ -46,7 +15,7 @@
   flex: 1;
   align-items: flex-start;
   justify-content: center;
-  padding: 20px 24px 40px;
+  padding: 40px 24px;
 
   // Same reading-column width as the modal's `.modal` max-width, so the
   // rendered one-pager looks identical whether opened inline or full-page.

--- a/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
+++ b/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.module.scss
@@ -17,13 +17,6 @@
   justify-content: center;
   padding: 40px 24px;
 
-  // Same reading-column width as the modal's `.modal` max-width, so the
-  // rendered one-pager looks identical whether opened inline or full-page.
-  > * {
-    width: 100%;
-    max-width: 760px;
-  }
-
   @include media.tablet-landscape {
     padding: 24px 32px 48px;
   }

--- a/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.tsx
+++ b/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import Link from 'next/link';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
-import { ArrowBackIcon } from '@/components/icons';
 import { useAiApp } from '@/services/ai-apps/hooks/useAiApp';
 import { useAiAppPrdContent } from '@/services/ai-apps/hooks/useAiAppPrdContent';
 
@@ -27,6 +25,7 @@ const APP_ERROR_MESSAGES: Record<'not-found' | 'forbidden' | 'network', string> 
   network: 'Something went wrong. Please try again.',
 };
 
+/** Renders as a bare document viewer (see isBareRoute) — no site chrome, no in-page back link, just the one-pager. */
 export function AiAppPrdPage({ uid }: Props) {
   const { app, errorKind, isLoading: isAppLoading } = useAiApp(uid);
   const { content, error: prdError, isLoading: isPrdLoading } = useAiAppPrdContent(app?.prd ?? null, {
@@ -46,15 +45,6 @@ export function AiAppPrdPage({ uid }: Props) {
     analytics.onPrdPageViewed(app.uid, app.name);
   }, [state.status, app, analytics]);
 
-  const backLink = (
-    <Link href={`/pl-infra/ai-apps/${encodeURIComponent(uid)}`} className={s.backLink}>
-      <ArrowBackIcon width={16} height={16} />
-      Back to app
-    </Link>
-  );
-
-  const showHeader = state.status !== 'loading' && state.status !== 'app-error' && !!app;
-
   const renderViewport = () => {
     switch (state.status) {
       case 'loading':
@@ -73,12 +63,6 @@ export function AiAppPrdPage({ uid }: Props) {
 
   return (
     <div className={s.root}>
-      {showHeader && (
-        <div className={s.header}>
-          {backLink}
-          <p className={s.title}>{app?.name}</p>
-        </div>
-      )}
       <div className={s.viewport}>{renderViewport()}</div>
     </div>
   );

--- a/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.tsx
+++ b/components/page/ai-apps/AiAppPrdPage/AiAppPrdPage.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+
+import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
+import { ArrowBackIcon } from '@/components/icons';
+import { useAiApp } from '@/services/ai-apps/hooks/useAiApp';
+import { useAiAppPrdContent } from '@/services/ai-apps/hooks/useAiAppPrdContent';
+
+import { PrdViewerBody } from '../components/PrdViewerBody';
+
+import { derivePrdPageState } from './derivePrdPageState';
+
+import s from './AiAppPrdPage.module.scss';
+
+interface Props {
+  uid: string;
+}
+
+const APP_ERROR_MESSAGES: Record<'not-found' | 'forbidden' | 'network', string> = {
+  // Collapsed on purpose — the coarse client-side guard doesn't check
+  // per-app authorization, so a 'forbidden' app must look identical to a
+  // 'not-found' one to avoid confirming its existence to an unauthorized viewer.
+  'not-found': 'This app could not be found.',
+  forbidden: 'This app could not be found.',
+  network: 'Something went wrong. Please try again.',
+};
+
+export function AiAppPrdPage({ uid }: Props) {
+  const { app, errorKind, isLoading: isAppLoading } = useAiApp(uid);
+  const { content, error: prdError, isLoading: isPrdLoading } = useAiAppPrdContent(app?.prd ?? null, {
+    enabled: !!app && !!app.prd,
+  });
+  const analytics = useAiAppsAnalytics();
+  const trackedAppUid = useRef<string | null>(null);
+
+  const state = derivePrdPageState(
+    { app, errorKind, isLoading: isAppLoading },
+    { content, error: prdError, isLoading: isPrdLoading },
+  );
+
+  useEffect(() => {
+    if (state.status !== 'ready' || !app || trackedAppUid.current === app.uid) return;
+    trackedAppUid.current = app.uid;
+    analytics.onPrdPageViewed(app.uid, app.name);
+  }, [state.status, app, analytics]);
+
+  const backLink = (
+    <Link href={`/pl-infra/ai-apps/${encodeURIComponent(uid)}`} className={s.backLink}>
+      <ArrowBackIcon width={16} height={16} />
+      Back to app
+    </Link>
+  );
+
+  const showHeader = state.status !== 'loading' && state.status !== 'app-error' && !!app;
+
+  const renderViewport = () => {
+    switch (state.status) {
+      case 'loading':
+      case 'prd-loading':
+        return <PrdViewerBody isLoading error={null} content={null} />;
+      case 'app-error':
+        return <p className={s.stateText}>{APP_ERROR_MESSAGES[state.errorKind]}</p>;
+      case 'no-prd':
+        return <p className={s.stateText}>This app no longer has a one-pager.</p>;
+      case 'prd-error':
+        return <PrdViewerBody isLoading={false} error={state.error} content={null} />;
+      case 'ready':
+        return <PrdViewerBody isLoading={false} error={null} content={state.prd} />;
+    }
+  };
+
+  return (
+    <div className={s.root}>
+      {showHeader && (
+        <div className={s.header}>
+          {backLink}
+          <p className={s.title}>{app?.name}</p>
+        </div>
+      )}
+      <div className={s.viewport}>{renderViewport()}</div>
+    </div>
+  );
+}

--- a/components/page/ai-apps/AiAppPrdPage/derivePrdPageState.ts
+++ b/components/page/ai-apps/AiAppPrdPage/derivePrdPageState.ts
@@ -1,0 +1,37 @@
+import { AiApp, AiAppFetchErrorKind, hasPrd } from '@/services/ai-apps/ai-apps.service';
+
+export type PrdPageState =
+  | { status: 'loading' }
+  | { status: 'app-error'; errorKind: AiAppFetchErrorKind }
+  | { status: 'no-prd' }
+  | { status: 'prd-loading' }
+  | { status: 'prd-error'; error: string }
+  | { status: 'ready'; prd: string };
+
+interface AppQuery {
+  app: AiApp | null;
+  errorKind: AiAppFetchErrorKind | null;
+  isLoading: boolean;
+}
+
+interface PrdContentQuery {
+  content: string | null;
+  error: string | null;
+  isLoading: boolean;
+}
+
+/**
+ * Pure derivation over the two hooks' results — unit-testable without
+ * rendering, and a missed case here is a TypeScript error rather than a
+ * silent blank page.
+ */
+export function derivePrdPageState(appQuery: AppQuery, prdQuery: PrdContentQuery): PrdPageState {
+  if (appQuery.isLoading) return { status: 'loading' };
+  if (appQuery.errorKind) return { status: 'app-error', errorKind: appQuery.errorKind };
+  if (!appQuery.app || !hasPrd(appQuery.app)) return { status: 'no-prd' };
+  if (prdQuery.isLoading) return { status: 'prd-loading' };
+  if (prdQuery.error || prdQuery.content === null) {
+    return { status: 'prd-error', error: prdQuery.error ?? 'One-pager could not be loaded' };
+  }
+  return { status: 'ready', prd: prdQuery.content };
+}

--- a/components/page/ai-apps/AiAppPrdPage/index.ts
+++ b/components/page/ai-apps/AiAppPrdPage/index.ts
@@ -1,0 +1,1 @@
+export { AiAppPrdPage } from './AiAppPrdPage';

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
@@ -99,6 +99,7 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
       {viewerApp && hasPrd(viewerApp) && (
         <AiAppDetailsModal
           isOpen
+          uid={viewerApp.uid}
           appName={viewerApp.name}
           prdUrl={viewerApp.prd as string}
           onClose={() => setViewerUid(null)}

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import dynamic from 'next/dynamic';
 import { motion, useReducedMotion } from 'framer-motion';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { useAiApps } from '@/services/ai-apps/hooks/useAiApps';
 import { useAiAppManageAccess } from '@/services/ai-apps/hooks/useAiAppManageAccess';
 import { hasPrd } from '@/services/ai-apps/ai-apps.service';
+import {
+  EditAiAppModal,
+  DeploymentSettingsModal,
+  DeleteAiAppDialog,
+  AiAppDetailsModal,
+} from '@/components/page/ai-apps/dynamicActionModals';
 
 import { AddAiAppCard } from '../AddAiAppCard';
 
@@ -15,21 +20,6 @@ import { getAddCardVariants, getCardVariants, getContainerVariants } from './AiA
 import { AiAppCard } from './components/AiAppCard';
 
 import s from './AiAppsGrid.module.scss';
-
-// The modals (and the markdown pipeline inside the details viewer) must not
-// ride in the list route's initial chunk — they load on first open.
-const EditAiAppModal = dynamic(() => import('../EditAiAppModal').then((m) => m.EditAiAppModal), { ssr: false });
-const DeploymentSettingsModal = dynamic(
-  () => import('../DeploymentSettingsModal').then((m) => m.DeploymentSettingsModal),
-  { ssr: false },
-);
-const DeleteAiAppDialog = dynamic(() => import('../DeleteAiAppDialog').then((m) => m.DeleteAiAppDialog), {
-  ssr: false,
-});
-const AiAppDetailsModal = dynamic(
-  () => import('@/components/page/ai-apps/components/AiAppDetailsModal').then((m) => m.AiAppDetailsModal),
-  { ssr: false },
-);
 
 type ActionType = 'edit' | 'deployment' | 'delete';
 

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { clsx } from 'clsx';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
+import { DocumentIcon } from '@/components/icons';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { AiApp, hasPrd } from '@/services/ai-apps/ai-apps.service';
 
@@ -100,15 +101,7 @@ export function AiAppCard(props: Props) {
           aria-label={`App details for ${app.name}`}
         >
           <span className={s.detailsBadge}>
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
-              <path
-                d="M4 1.5h5L13 5.5V13a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 13V3A1.5 1.5 0 0 1 4 1.5Z"
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinejoin="round"
-              />
-              <path d="M8.5 1.5V6h4.5" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-            </svg>
+            <DocumentIcon aria-hidden />
             App Details
           </span>
         </button>

--- a/components/page/ai-apps/AiAppsPage/components/DeleteAiAppDialog/DeleteAiAppDialog.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeleteAiAppDialog/DeleteAiAppDialog.tsx
@@ -13,6 +13,8 @@ import s from './DeleteAiAppDialog.module.scss';
 interface Props {
   app: AiApp;
   onClose: () => void;
+  /** Fires once the delete succeeds, after `onClose()` — e.g. to navigate away from a page showing the now-gone app. */
+  onDeleteSucceeded?: () => void;
 }
 
 /**
@@ -21,7 +23,7 @@ interface Props {
  * deliberate, single-purpose action. Single-flight: a second click while the
  * DELETE is in flight is a no-op, and a 404 (already gone) counts as done.
  */
-export function DeleteAiAppDialog({ app, onClose }: Props) {
+export function DeleteAiAppDialog({ app, onClose, onDeleteSucceeded }: Props) {
   const analytics = useAiAppsAnalytics();
   const { mutateAsync: deleteApp, isPending: isDeleting } = useDeleteAiApp(app.uid);
   const [error, setError] = useState<string | null>(null);
@@ -55,6 +57,7 @@ export function DeleteAiAppDialog({ app, onClose }: Props) {
     didConfirmRef.current = true;
     analytics.onDeleteAppConfirmed(app.uid, app.name);
     onClose();
+    onDeleteSucceeded?.();
   };
 
   return (

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal/DeploymentSettingsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal/DeploymentSettingsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
@@ -19,6 +19,12 @@ type Phase = 'form' | 'deploying' | 'done';
 interface Props {
   app: AiApp;
   onClose: () => void;
+  /**
+   * Fires while a redeploy started from this modal is in flight, so a parent
+   * page can suppress a competing "app is deploying" view for the duration —
+   * mirrors AppSecretsPanel's prop of the same name/purpose.
+   */
+  onDeployingChange?: (deploying: boolean) => void;
 }
 
 /**
@@ -32,7 +38,7 @@ interface Props {
  * live record, and rows must not remount/lock mid-keystroke under the user.
  * Only `status` is read live, to drive the deploying → done/failed phases.
  */
-export function DeploymentSettingsModal({ app, onClose }: Props) {
+export function DeploymentSettingsModal({ app, onClose, onDeployingChange }: Props) {
   const analytics = useAiAppsAnalytics();
   const queryClient = useQueryClient();
 
@@ -81,6 +87,23 @@ export function DeploymentSettingsModal({ app, onClose }: Props) {
       setError(liveNotes ? `Deploy failed: ${liveNotes}` : 'Deploy failed. Please try again.');
     }
   }, [phase, liveStatus, deployObserved, liveNotes]);
+
+  // Include `isSubmitting`, not just `phase` — the redeploy request is fired
+  // synchronously on click (see handleRedeploy), well before `phase` itself
+  // flips to 'deploying' once the response resolves. A parent relying only on
+  // the `phase` transition would have a window where the backend has already
+  // moved the app to DEPLOYING but this callback hasn't fired yet, letting an
+  // independent poller elsewhere race ahead of it.
+  useEffect(() => {
+    onDeployingChange?.(isSubmitting || phase === 'deploying');
+  }, [isSubmitting, phase, onDeployingChange]);
+
+  // Unconditional unmount reset: if this modal is dismissed mid-'deploying'
+  // (its own header close button isn't guarded against that, unlike
+  // AppSecretsPanel's closeSecrets), the effect above never gets a chance to
+  // fire `false` again — without this, a parent's "is a redeploy in flight"
+  // flag would be stranded `true` for the rest of the page's session.
+  useEffect(() => () => onDeployingChange?.(false), [onDeployingChange]);
 
   const onChange = (name: string, value: string) => {
     setValues((prev) => ({ ...prev, [name]: value }));

--- a/components/page/ai-apps/components/AiAppDetailsModal/AiAppDetailsModal.module.scss
+++ b/components/page/ai-apps/components/AiAppDetailsModal/AiAppDetailsModal.module.scss
@@ -34,6 +34,48 @@
   white-space: nowrap;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.openTab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+  background: none;
+  font-size: 13px;
+  line-height: 18px;
+  font-weight: 500;
+  color: var(--foreground-neutral-secondary, #455468);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    color 0.15s;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    border-color: var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 2px;
+  }
+}
+
 .close {
   display: flex;
   flex-shrink: 0;
@@ -58,29 +100,8 @@
   background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
 }
 
-.errorText {
-  margin: auto;
-  font-size: 14px;
-  color: var(--foreground-neutral-tertiary, #8897ae);
-}
-
-// The rendered one-pager sits on a white "document page", echoing the
-// prototype's PDF viewer.
-.page {
-  width: 100%;
-  padding: 28px 32px;
-  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
-  border-radius: 4px;
-  background: #ffffff;
-  box-shadow: 0 1px 4px var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
-}
-
 @media (max-width: 639px) {
   .viewport {
     padding: 12px;
-  }
-
-  .page {
-    padding: 20px 16px;
   }
 }

--- a/components/page/ai-apps/components/AiAppDetailsModal/AiAppDetailsModal.tsx
+++ b/components/page/ai-apps/components/AiAppDetailsModal/AiAppDetailsModal.tsx
@@ -1,16 +1,20 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
+import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { Modal } from '@/components/common/Modal/Modal';
-import { CloseIcon } from '@/components/icons';
-import { Spinner } from '@/components/ui/Spinner';
+import { ArrowUpRightIcon, CloseIcon } from '@/components/icons';
+import { AiAppsQueryKeys } from '@/services/ai-apps/constants';
+import { fetchAiAppPrdContent } from '@/services/ai-apps/ai-apps.service';
 import { useAiAppPrdContent } from '@/services/ai-apps/hooks/useAiAppPrdContent';
 
-import { PrdContent } from '../PrdContent';
+import { PrdViewerBody } from '../PrdViewerBody';
 
 import s from './AiAppDetailsModal.module.scss';
 
 interface Props {
   isOpen: boolean;
+  uid: string;
   appName: string;
   /** URL to the stored one-pager file (Markdown or HTML). The caller gates on hasPrd(). */
   prdUrl: string;
@@ -24,29 +28,57 @@ interface Props {
  * rendering is delegated to PrdContent, which sanitizes user-authored HTML
  * and escapes HTML embedded in Markdown.
  */
-export function AiAppDetailsModal({ isOpen, appName, prdUrl, onClose }: Props) {
+export function AiAppDetailsModal({ isOpen, uid, appName, prdUrl, onClose }: Props) {
   const { content, error, isLoading } = useAiAppPrdContent(prdUrl, { enabled: isOpen });
+  const analytics = useAiAppsAnalytics();
+  const queryClient = useQueryClient();
+
+  const prdHref = `/pl-infra/ai-apps/${encodeURIComponent(uid)}/prd`;
+
+  // Priming just the (slower, S3-proxied) PRD content query — the new page's
+  // own useAiApp(uid) call is a lightweight metadata fetch not worth seeding
+  // with a synthetic partial AiApp object here.
+  const primeCache = () => {
+    queryClient.prefetchQuery({
+      queryKey: [AiAppsQueryKeys.AI_APP_PRD_CONTENT, prdUrl],
+      queryFn: () => fetchAiAppPrdContent(prdUrl),
+    });
+  };
+
+  const handleOpenInNewTabClick = () => {
+    try {
+      analytics.onPrdOpenInNewTabClicked(uid, appName);
+    } catch {
+      // A broken analytics client must never block the link's native navigation.
+    }
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} className={s.modal}>
       <div className={s.content}>
         <div className={s.header}>
           <p className={s.title}>{appName}</p>
-          <button type="button" className={s.close} onClick={onClose} aria-label="Close">
-            <CloseIcon width={20} height={20} />
-          </button>
+          <div className={s.headerActions}>
+            <a
+              href={prdHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={s.openTab}
+              onMouseEnter={primeCache}
+              onPointerDown={primeCache}
+              onClick={handleOpenInNewTabClick}
+            >
+              <ArrowUpRightIcon width={16} height={16} />
+              Open in new tab
+            </a>
+            <button type="button" className={s.close} onClick={onClose} aria-label="Close">
+              <CloseIcon width={20} height={20} />
+            </button>
+          </div>
         </div>
 
         <div className={s.viewport}>
-          {isLoading ? (
-            <Spinner />
-          ) : error || content === null ? (
-            <p className={s.errorText}>{error ?? 'One-pager could not be loaded'}</p>
-          ) : (
-            <div className={s.page}>
-              <PrdContent prd={content} />
-            </div>
-          )}
+          <PrdViewerBody isLoading={isLoading} error={error} content={content} />
         </div>
       </div>
     </Modal>

--- a/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.module.scss
+++ b/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.module.scss
@@ -8,6 +8,7 @@
 // prototype's PDF viewer.
 .page {
   width: 100%;
+  max-width: 760px;
   padding: 28px 32px;
   border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
   border-radius: 4px;

--- a/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.module.scss
+++ b/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.module.scss
@@ -1,0 +1,22 @@
+.errorText {
+  margin: auto;
+  font-size: 14px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+// The rendered one-pager sits on a white "document page", echoing the
+// prototype's PDF viewer.
+.page {
+  width: 100%;
+  padding: 28px 32px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 4px;
+  background: #ffffff;
+  box-shadow: 0 1px 4px var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+}
+
+@media (max-width: 639px) {
+  .page {
+    padding: 20px 16px;
+  }
+}

--- a/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.tsx
+++ b/components/page/ai-apps/components/PrdViewerBody/PrdViewerBody.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Spinner } from '@/components/ui/Spinner';
+
+import { PrdContent } from '../PrdContent';
+
+import s from './PrdViewerBody.module.scss';
+
+interface Props {
+  isLoading: boolean;
+  error: string | null;
+  content: string | null;
+}
+
+/**
+ * Renders the one-pager's loading/error/content states on a white "document
+ * page" — shared by the modal viewer and the full-page viewer so both stay
+ * visually consistent as the same underlying `PrdContent` renderer evolves.
+ */
+export function PrdViewerBody({ isLoading, error, content }: Props) {
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (error || content === null) {
+    return <p className={s.errorText}>{error ?? 'One-pager could not be loaded'}</p>;
+  }
+
+  return (
+    <div className={s.page}>
+      <PrdContent prd={content} />
+    </div>
+  );
+}

--- a/components/page/ai-apps/components/PrdViewerBody/index.ts
+++ b/components/page/ai-apps/components/PrdViewerBody/index.ts
@@ -1,0 +1,1 @@
+export { PrdViewerBody } from './PrdViewerBody';

--- a/components/page/ai-apps/dynamicActionModals.ts
+++ b/components/page/ai-apps/dynamicActionModals.ts
@@ -1,0 +1,25 @@
+import dynamic from 'next/dynamic';
+
+// The modals (and the markdown pipeline inside the details viewer) must not
+// ride in either the list route's or the detail route's initial chunk — they
+// load on first open. Shared by AiAppsGrid and AiAppDetailPage, the two
+// surfaces that manage an app's edit/deployment/delete/details actions.
+export const EditAiAppModal = dynamic(
+  () => import('@/components/page/ai-apps/AiAppsPage/components/EditAiAppModal').then((m) => m.EditAiAppModal),
+  { ssr: false },
+);
+export const DeploymentSettingsModal = dynamic(
+  () =>
+    import('@/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal').then(
+      (m) => m.DeploymentSettingsModal,
+    ),
+  { ssr: false },
+);
+export const DeleteAiAppDialog = dynamic(
+  () => import('@/components/page/ai-apps/AiAppsPage/components/DeleteAiAppDialog').then((m) => m.DeleteAiAppDialog),
+  { ssr: false },
+);
+export const AiAppDetailsModal = dynamic(
+  () => import('@/components/page/ai-apps/components/AiAppDetailsModal').then((m) => m.AiAppDetailsModal),
+  { ssr: false },
+);

--- a/prototypes/entries/ai-apps-feedback/FeedbackPage.tsx
+++ b/prototypes/entries/ai-apps-feedback/FeedbackPage.tsx
@@ -75,9 +75,7 @@ export function FeedbackPage({ scopedApps, feedback, isAdmin, initialAppFilter, 
   // Ownership signal: whose feedback this is. Stays fixed by role — the filter
   // tabs narrow the table, not the page's identity.
   const title = isAdmin ? 'All app feedback' : 'Feedback on your apps';
-  const subtitle = isAdmin
-    ? 'Every app across the directory.'
-    : 'Only the apps you build — not every app on the page.';
+  const subtitle = isAdmin ? 'Every app across the directory.' : 'Only the apps you build — not every app on the page.';
 
   const tabs = [
     { value: 'all', label: 'All apps', count: feedback.length },
@@ -121,7 +119,7 @@ export function FeedbackPage({ scopedApps, feedback, isAdmin, initialAppFilter, 
     <div className={s.pageWrap}>
       <button type="button" className={s.linkButton} onClick={onBack}>
         <ArrowBackIcon width={16} height={16} />
-        Back to AI Apps
+        Back to all
       </button>
 
       <div className={page.titleBlock}>

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2375,4 +2375,6 @@ export const AI_APPS_ANALYTICS = {
   DELETE_APP_CONFIRMED: 'ai_apps_delete_app_confirmed',
   DELETE_APP_FAILED: 'ai_apps_delete_app_failed',
   APP_DETAILS_OPENED: 'ai_apps_app_details_opened',
+  PRD_OPEN_IN_NEW_TAB_CLICKED: 'ai_apps_prd_open_in_new_tab_clicked',
+  PRD_PAGE_VIEWED: 'ai_apps_prd_page_viewed',
 };

--- a/utils/isBareRoute.ts
+++ b/utils/isBareRoute.ts
@@ -1,0 +1,10 @@
+/**
+ * Routes that render as a standalone document/viewer with no site chrome
+ * (navbar, banners, bottom nav) — e.g. the full-page AI App PRD viewer,
+ * meant to feel like opening a file in its own tab.
+ */
+const BARE_ROUTE_PATTERNS = [/^\/pl-infra\/ai-apps\/[^/]+\/prd\/?$/];
+
+export function isBareRoute(pathname: string): boolean {
+  return BARE_ROUTE_PATTERNS.some((pattern) => pattern.test(pathname));
+}


### PR DESCRIPTION
## Summary

### 1. Open AI App PRD one-pager in a new tab
- Adds an "Open in new tab" link to the AI App PRD (one-pager) viewer modal, linking to a new full-page route (`/pl-infra/ai-apps/[id]/prd`) so the one-pager can be bookmarked/shared instead of only viewed inline in a modal.
- The full-page viewer is chrome-free by design (no site navbar, no bottom nav, no in-page back link) — it reads like opening a document in its own tab, via a new `isBareRoute()` check.
- Shares rendering between the modal and the new page through an extracted `PrdViewerBody` component, and models the new page's states (loading / not-found+forbidden collapsed / network error / no-prd / prd-loading / ready) as a discriminated union (`derivePrdPageState`) that's independently unit-tested.
- Adds two new analytics events (`onPrdOpenInNewTabClicked`, `onPrdPageViewed`) — deliberately not reusing an existing-but-unused event that looked scoped for a different feature (opening a deployed app's live URL).
- Includes a follow-up fix for a CSS bug where the loading spinner rendered as a corrupted diagonal line on the full-page viewer (a `.viewport > *` rule was stretching the spinner's div along with real content).

### 2. Detail page top bar (Back / App Details / manage menu)
- Replaces the AI App detail page's conditional "Update secrets & redeploy" strip with a persistent top bar: "Back to AI Apps" link, "App Details" popup (when the app has a one-pager), and the existing "⋮" manage menu (Edit / Deployment settings / Delete) — all reused from the grid card.
- Retires the old voluntary redeploy entry point in favor of "Deployment settings" in the new menu, since both were confirmed to call the exact same underlying `deployAiApp` logic.
- Deletes from the detail page now redirect to the AI Apps list (new optional `onDeleteSucceeded` prop on `DeleteAiAppDialog`, additive and backward-compatible with the grid's existing usage).
- Adds `onDeployingChange` to `DeploymentSettingsModal` (mirroring `AppSecretsPanel`'s existing prop) so starting a redeploy from the new menu doesn't get the page yanked into the mandatory "Deploying" card mid-interaction — fired synchronously on click and reset on unmount to avoid a race/stuck-flag.
- Fixes a related latent bug the new redeploy path exposed: `needsSetup` independently bypassed the `isRedeploying` guard for apps with required env vars (it treated any non-`READY` status the same); tightened to check `DRAFT` specifically. Caught by a new regression test.
- Extracts `AiAppCard`'s inline "App Details" icon into a shared `DocumentIcon`, and the grid's `dynamic()` modal imports into one shared module now used by both the grid and the detail page.

## Testing
- 26 + 27 new tests added across both features (`PrdViewerBody`, `derivePrdPageState`, `AiAppDetailsModal`, `AiAppPrdPage`, `isBareRoute`, `SiteHeader`, `AiAppDetailPage`, `DeleteAiAppDialog`, `DeploymentSettingsModal`).
- Full suite passes (121 test suites / 769 tests), lint and typecheck are clean on every file this change touches (pre-existing issues elsewhere in the repo are unrelated/untouched).
- Verified the PRD route compiles/serves against a local dev server; full authenticated browser verification (Privy login + `AiAppsAccessGuard`) was not performed since I don't have test credentials — one real bug (the spinner CSS corruption) was caught from a screenshot shared mid-review, and a second real bug (the `needsSetup`/redeploy race) was caught by a test written specifically to probe that interaction.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)