### PR TITLE
feat(team-news): show multiple sources on a single news card

### DIFF
--- a/__tests__/page/home/source-list.test.tsx
+++ b/__tests__/page/home/source-list.test.tsx
@@ -1,0 +1,257 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SourceList } from '@/components/page/home/TeamNews/components/SourceList/SourceList';
+import { getNewsSources, hasNewsSource } from '@/components/page/home/TeamNews/utils/getNewsSources';
+import { NewsCard } from '@/components/page/home/TeamNews/components/NewsCard/NewsCard';
+import { NewsGroupCard } from '@/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard';
+import type { ITeamNewsItem, TeamCluster, TeamNewsEventType } from '@/types/team-news.types';
+
+const mockOnSourcesExpanded = jest.fn();
+const mockOnSourceLinkClicked = jest.fn();
+const mockOnCardClicked = jest.fn();
+
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({
+    onTeamNewsSourcesExpanded: (...a: unknown[]) => mockOnSourcesExpanded(...a),
+    onTeamNewsSourceLinkClicked: (...a: unknown[]) => mockOnSourceLinkClicked(...a),
+    onTeamNewsCardClicked: (...a: unknown[]) => mockOnCardClicked(...a),
+  }),
+}));
+
+jest.mock('@/services/auth/store', () => ({
+  useCurrentUserStore: () => ({ currentUser: { uid: 'm-1' }, isHydrated: true }),
+}));
+
+jest.mock('@/components/page/home/TeamNews/components/NewsCard/components/StartConversationButton', () => ({
+  StartConversationButton: () => <button type="button">Discuss</button>,
+}));
+
+jest.mock('@/utils/formatTimeAgo', () => ({
+  formatTimeAgo: () => '2d ago',
+}));
+
+const PRIMARY_URL = 'https://protocol.ai/blog/story';
+const SECOND_URL = 'https://techcrunch.com/story';
+const TWO_SOURCE_URLS = [PRIMARY_URL, SECOND_URL];
+
+const makeItem = (uid: string, overrides: Partial<ITeamNewsItem> = {}): ITeamNewsItem => ({
+  uid,
+  teamUid: 'team-1',
+  teamName: 'Protocol Labs',
+  teamLogoUrl: null,
+  eventType: 'ANNOUNCEMENT' as TeamNewsEventType,
+  eventDate: '2026-06-01T00:00:00.000Z',
+  title: `Headline ${uid}`,
+  summary: null,
+  sourceUrl: PRIMARY_URL,
+  sourceDomain: 'protocol.ai',
+  tags: [],
+  focusAreas: [],
+  subFocusAreas: [],
+  createdAt: '2026-06-02T00:00:00.000Z',
+  discussion: { count: 0, latestTopicUrl: null },
+  ...overrides,
+});
+
+let windowOpenSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+});
+
+afterEach(() => {
+  windowOpenSpy.mockRestore();
+});
+
+describe('getNewsSources', () => {
+  it('derives display domains from URLs, stripping a leading www.', () => {
+    const item = makeItem('a', { sourceUrls: [PRIMARY_URL, 'https://www.coindesk.com/tech/story'] });
+    expect(getNewsSources(item)).toEqual([
+      { domain: 'protocol.ai', url: PRIMARY_URL },
+      { domain: 'coindesk.com', url: 'https://www.coindesk.com/tech/story' },
+    ]);
+  });
+
+  it('keeps the backend-computed sourceDomain for the primary entry', () => {
+    const item = makeItem('a', { sourceDomain: 'blog.protocol.ai', sourceUrls: TWO_SOURCE_URLS });
+    expect(getNewsSources(item)[0]).toEqual({ domain: 'blog.protocol.ai', url: PRIMARY_URL });
+  });
+
+  it('drops malformed URLs instead of rendering broken rows', () => {
+    const item = makeItem('a', { sourceUrls: ['not a url', SECOND_URL] });
+    expect(getNewsSources(item)).toEqual([{ domain: 'techcrunch.com', url: SECOND_URL }]);
+  });
+
+  it('returns empty when sourceUrls is absent', () => {
+    expect(getNewsSources(makeItem('a'))).toEqual([]);
+  });
+});
+
+describe('hasNewsSource', () => {
+  it('is true for a plain sourceDomain, a single-entry sourceUrls, and multi-source items', () => {
+    expect(hasNewsSource(makeItem('a'))).toBe(true);
+    expect(hasNewsSource(makeItem('b', { sourceDomain: null, sourceUrls: [SECOND_URL] }))).toBe(true);
+    expect(hasNewsSource(makeItem('c', { sourceUrls: TWO_SOURCE_URLS }))).toBe(true);
+  });
+
+  it('is false when there is neither a sourceDomain nor sourceUrls', () => {
+    expect(hasNewsSource(makeItem('a', { sourceDomain: null }))).toBe(false);
+    expect(hasNewsSource(makeItem('b', { sourceDomain: null, sourceUrls: [] }))).toBe(false);
+  });
+});
+
+describe('SourceList', () => {
+  it('renders the plain domain with no pill when sourceUrls is absent', () => {
+    render(<SourceList item={makeItem('a')} />);
+    expect(screen.getByText('protocol.ai')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a single sourceUrls entry as a plain derived domain (no pill)', () => {
+    render(<SourceList item={makeItem('a', { sourceDomain: null, sourceUrls: ['https://www.fil.org/x'] })} />);
+    expect(screen.getByText('fil.org')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no domain at all', () => {
+    const { container } = render(<SourceList item={makeItem('a', { sourceDomain: null })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a collapsed "N sources" pill for a multi-source item', () => {
+    render(<SourceList item={makeItem('a', { sourceUrls: TWO_SOURCE_URLS })} />);
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+    expect(pill).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles the popover on pill clicks and reports the expand only on open', () => {
+    render(
+      <SourceList
+        item={makeItem('a', { sourceUrls: TWO_SOURCE_URLS })}
+        position={2}
+        analyticsSource="team-profile-modal"
+      />,
+    );
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute('aria-expanded', 'true');
+    expect(mockOnSourcesExpanded).toHaveBeenCalledTimes(1);
+    expect(mockOnSourcesExpanded).toHaveBeenCalledWith(expect.objectContaining({ uid: 'a' }), 2, 'team-profile-modal');
+
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute('aria-expanded', 'false');
+    expect(mockOnSourcesExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists every outlet as a new-tab anchor and reports + closes on source click', () => {
+    render(<SourceList item={makeItem('a', { sourceUrls: TWO_SOURCE_URLS })} />);
+    fireEvent.click(screen.getByRole('button', { name: /2 sources/i }));
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', PRIMARY_URL);
+    expect(links[0]).toHaveTextContent('protocol.ai');
+    expect(links[1]).toHaveAttribute('href', SECOND_URL);
+    expect(links[1]).toHaveTextContent('techcrunch.com');
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    fireEvent.click(links[1]);
+    expect(mockOnSourceLinkClicked).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'a' }),
+      0,
+      { domain: 'techcrunch.com', url: SECOND_URL },
+      'home',
+    );
+    expect(screen.getByRole('button', { name: /2 sources/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes on Escape and returns focus to the pill', () => {
+    render(<SourceList item={makeItem('a', { sourceUrls: TWO_SOURCE_URLS })} />);
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+    fireEvent.click(pill);
+    fireEvent.keyDown(screen.getAllByRole('link')[0], { key: 'Escape' });
+    expect(pill).toHaveAttribute('aria-expanded', 'false');
+    expect(pill).toHaveFocus();
+  });
+
+  it('closes when a press lands outside the segment', () => {
+    render(<SourceList item={makeItem('a', { sourceUrls: TWO_SOURCE_URLS })} />);
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+    fireEvent.click(pill);
+    fireEvent.pointerDown(document.body);
+    expect(pill).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('NewsCard with a multi-source item', () => {
+  const item = makeItem('a', { sourceUrls: TWO_SOURCE_URLS });
+
+  it('shows the pill in the meta line and keeps the card click on the primary source', () => {
+    const onClick = jest.fn();
+    render(<NewsCard item={item} onClick={onClick} />);
+
+    expect(screen.getByRole('button', { name: /2 sources/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Headline a'));
+    expect(onClick).toHaveBeenCalledWith(item);
+    expect(windowOpenSpy).toHaveBeenCalledWith(PRIMARY_URL, '_blank', 'noopener,noreferrer');
+  });
+
+  it('never opens the article from pill interactions (click, Enter, Space)', () => {
+    const onClick = jest.fn();
+    render(<NewsCard item={item} onClick={onClick} />);
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+
+    fireEvent.click(pill);
+    fireEvent.keyDown(pill, { key: 'Enter' });
+    fireEvent.keyDown(pill, { key: ' ' });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the single-source meta line as plain text', () => {
+    render(<NewsCard item={makeItem('b')} />);
+    expect(screen.getByText('protocol.ai')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /sources/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('NewsGroupCard with a multi-source story', () => {
+  const story = makeItem('a', { sourceUrls: TWO_SOURCE_URLS, upvoteCount: 3 });
+  const cluster: TeamCluster = {
+    teamUid: 'team-1',
+    teamName: 'Protocol Labs',
+    teamLogoUrl: null,
+    items: [story],
+  };
+
+  it('shows the pill in the story row', () => {
+    render(<NewsGroupCard cluster={cluster} />);
+    expect(screen.getByRole('button', { name: /2 sources/i })).toBeInTheDocument();
+  });
+
+  it('does not open the story when the pill is activated by keyboard or click', () => {
+    render(<NewsGroupCard cluster={cluster} />);
+    const pill = screen.getByRole('button', { name: /2 sources/i });
+
+    fireEvent.keyDown(pill, { key: 'Enter' });
+    fireEvent.keyDown(pill, { key: ' ' });
+    fireEvent.click(pill);
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('still opens the story on Enter pressed on the row itself', () => {
+    render(<NewsGroupCard cluster={cluster} />);
+    const row = document.querySelector('[data-story-uid="a"]') as HTMLElement;
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(windowOpenSpy).toHaveBeenCalledWith(PRIMARY_URL, '_blank', 'noopener,noreferrer');
+  });
+});

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -104,6 +104,42 @@ export const useTeamNewsAnalytics = () => {
       eventType: item.eventType,
       sourceDomain: item.sourceDomain,
       sourceUrl: item.sourceUrl,
+      sourceCount: item.sourceUrls?.length ?? 1,
+      position,
+      source,
+    });
+  };
+
+  // Fired on explicit click-open of the "N sources" popover only — the CSS
+  // hover preview on pointer devices intentionally doesn't emit (it would fire
+  // on every incidental mouse pass over the meta line).
+  const onTeamNewsSourcesExpanded = (item: ITeamNewsItem, position: number, source: TeamNewsAnalyticsSource) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_SOURCES_EXPANDED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      teamName: item.teamName,
+      eventType: item.eventType,
+      sourceCount: item.sourceUrls?.length ?? 1,
+      position,
+      source,
+    });
+  };
+
+  const onTeamNewsSourceLinkClicked = (
+    item: ITeamNewsItem,
+    position: number,
+    clicked: { domain: string; url: string },
+    source: TeamNewsAnalyticsSource,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_SOURCE_LINK_CLICKED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      teamName: item.teamName,
+      eventType: item.eventType,
+      sourceCount: item.sourceUrls?.length ?? 1,
+      clickedDomain: clicked.domain,
+      clickedUrl: clicked.url,
+      isPrimary: clicked.url === item.sourceUrl,
       position,
       source,
     });
@@ -200,6 +236,8 @@ export const useTeamNewsAnalytics = () => {
     onTeamNewsViewAllClicked,
     onTeamNewsShowMoreClicked,
     onTeamNewsCardClicked,
+    onTeamNewsSourcesExpanded,
+    onTeamNewsSourceLinkClicked,
     onTeamNewsStartConversationClicked,
     onTeamNewsJoinDiscussionClicked,
     onTeamNewsSearch,

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
@@ -13,7 +13,9 @@
   text-decoration: none;
   color: inherit;
   transition: box-shadow 0.12s ease;
-  overflow: hidden;
+  // No overflow: hidden — the SourceList popover must escape the card bounds.
+  // Children that need clipping do it themselves (headline line-clamp,
+  // teamName ellipsis, logo border-radius).
   cursor: pointer;
 
   &:hover {

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
@@ -10,9 +10,11 @@ import { FollowButton } from '@/components/ui/FollowButton';
 
 import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
 import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
+import { hasNewsSource } from '../../utils/getNewsSources';
 
 import { StartConversationButton } from './components/StartConversationButton';
 import { UpvoteButton } from './components/UpvoteButton/UpvoteButton';
+import { SourceList } from '../SourceList/SourceList';
 import { TruncatedSummary } from './TruncatedSummary';
 
 import s from './NewsCard.module.scss';
@@ -150,10 +152,10 @@ export const NewsCard = ({
             <span className={`${s.eventDot} ${eventTypeDotClassName}`} aria-hidden="true" />
             <span className={clsx(s.eventLabel, compact && s.eventLabelCompact)}>{eventTypeLabel}</span>
           </span>
-          {item.sourceDomain && (
+          {hasNewsSource(item) && (
             <>
               <span className={s.sep} aria-hidden="true" />
-              <span className={s.source}>{item.sourceDomain}</span>
+              <SourceList item={item} position={position} analyticsSource={analyticsSource} compact={compact} />
             </>
           )}
           <span className={s.sep} aria-hidden="true" />

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -14,6 +14,8 @@ import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
 import { sortAllTabItemsByEventDate } from '../../utils/sortAllTabItemsByEventDate';
 import { StartConversationButton } from '../NewsCard/components/StartConversationButton';
 import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
+import { SourceList } from '../SourceList/SourceList';
+import { hasNewsSource } from '../../utils/getNewsSources';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
 import s from './NewsGroupCard.module.scss';
@@ -119,6 +121,10 @@ export function NewsGroupCard({
             className={s.storyRow}
             onClick={() => openStory(story)}
             onKeyDown={(e) => {
+              // Only act on keys pressed on the row itself — Enter/Space on a
+              // nested control (Upvote/Discuss/SourceList) must not also open
+              // the article. Same guard as NewsCard's handleKeyDown.
+              if (e.target !== e.currentTarget) return;
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 openStory(story);
@@ -133,10 +139,10 @@ export function NewsGroupCard({
                   <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
                   <span className={newsCardStyles.eventLabel}>{label}</span>
                 </span>
-                {story.sourceDomain && (
+                {hasNewsSource(story) && (
                   <>
                     <span className={newsCardStyles.sep} aria-hidden="true" />
-                    <span className={newsCardStyles.source}>{story.sourceDomain}</span>
+                    <SourceList item={story} position={storyIndex} analyticsSource={analyticsSource} />
                   </>
                 )}
                 <span className={newsCardStyles.sep} aria-hidden="true" />

--- a/components/page/home/TeamNews/components/SourceList/SourceList.module.scss
+++ b/components/page/home/TeamNews/components/SourceList/SourceList.module.scss
@@ -1,0 +1,164 @@
+// Multi-source segment of the meta line ("N sources" pill + popover).
+// Single-source stories never mount these classes — SourceList renders the
+// plain NewsCard `.source` span for them.
+
+.wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.pill {
+  appearance: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px 2px 10px;
+  border-radius: 9999px;
+  border: 1px solid rgba(27, 56, 96, 0.12);
+  background: #ffffff;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: #455468;
+  white-space: nowrap;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+
+  &:hover {
+    border-color: rgba(27, 56, 96, 0.24);
+    background: rgba(14, 15, 17, 0.04);
+    color: #0a0c11;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1b4dff;
+    outline-offset: 2px;
+  }
+}
+
+// Sized to the .metaCompact treatment (team-profile rail/modal).
+.compact .pill {
+  font-size: 11px;
+  line-height: 15px;
+  padding: 1px 5px 1px 8px;
+}
+
+.caret {
+  width: 13px;
+  height: 13px;
+  transition: transform 0.12s ease;
+}
+
+.pill[aria-expanded='true'] .caret {
+  transform: rotate(180deg);
+}
+
+// Positioning shell. Opens upward (the meta line sits at the card's bottom
+// edge, inside scrollable columns where a downward popover would be clipped).
+// The shell is transparent and carries the 6px gap as padding, so the cursor
+// never crosses a dead zone between pill and panel — the panel inside owns
+// the visual card and its own scroll.
+.popover {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  z-index: 10;
+  padding-bottom: 6px;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition:
+    opacity 0.12s ease,
+    transform 0.12s ease,
+    visibility 0.12s;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 160px;
+  max-width: 240px;
+  // ~6 rows + header; longer source lists scroll inside the panel.
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 8px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid rgba(27, 56, 96, 0.12);
+  box-shadow:
+    0px 0px 1px 0px rgba(15, 23, 42, 0.12),
+    0px 8px 20px 0px rgba(15, 23, 42, 0.1);
+}
+
+// Pinned open via the pill (JS state — what aria-expanded reports).
+.popoverOpen {
+  opacity: 1;
+  visibility: visible;
+  transform: none;
+  pointer-events: auto;
+}
+
+// Hover preview on pointer devices only: sticky :hover on touch would keep a
+// just-dismissed popover visible. visibility:hidden while closed also keeps
+// the row links out of the tab order — keyboard users open via the pill.
+@media (hover: hover) {
+  .wrapper:hover .popover {
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    pointer-events: auto;
+  }
+
+  .wrapper:hover .caret {
+    transform: rotate(180deg);
+  }
+}
+
+.panelHead {
+  padding: 2px 6px 4px;
+  font-size: 11px;
+  line-height: 15px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  color: #8897ae;
+  flex-shrink: 0;
+}
+
+.row {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 5px 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  letter-spacing: -0.2px;
+  color: #455468;
+  text-decoration: none;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+
+  &:hover {
+    background: rgba(14, 15, 17, 0.04);
+    color: #1b4dff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1b4dff;
+    outline-offset: -2px;
+  }
+}

--- a/components/page/home/TeamNews/components/SourceList/SourceList.tsx
+++ b/components/page/home/TeamNews/components/SourceList/SourceList.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import clsx from 'clsx';
+import { useEffect, useRef, useState } from 'react';
+
+import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+import { getNewsSources } from '../../utils/getNewsSources';
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+import s from './SourceList.module.scss';
+
+interface SourceListProps {
+  item: ITeamNewsItem;
+  position?: number;
+  analyticsSource?: TeamNewsAnalyticsSource;
+  compact?: boolean;
+}
+
+/**
+ * The source segment of a story's meta line. One outlet → the plain domain
+ * span, unchanged from before `sources[]` existed. Several outlets covering
+ * the same story → a compact "N sources" pill whose popover lists each outlet
+ * as its own link, so an aggregated story reads as one card, not N.
+ *
+ * The pill is a disclosure button: its click-toggled state is what
+ * `aria-expanded` reports (Escape closes and refocuses it; clicking outside or
+ * choosing a source closes it). On hover-capable devices CSS also previews the
+ * popover on hover — a preview, deliberately not mirrored into `aria-expanded`
+ * and not emitting the expand analytics event.
+ *
+ * The popover opens upward: the meta line sits at the card's bottom edge, and
+ * cards live in scrollable columns where a downward popover would be clipped.
+ */
+export const SourceList = ({ item, position = 0, analyticsSource = 'home', compact = false }: SourceListProps) => {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const pillRef = useRef<HTMLButtonElement>(null);
+  const { onTeamNewsSourcesExpanded, onTeamNewsSourceLinkClicked } = useTeamNewsAnalytics();
+
+  const sources = getNewsSources(item);
+  const isMulti = sources.length > 1;
+
+  // Close a pinned-open popover when a press lands outside the pill + panel.
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  if (!isMulti) {
+    const domain = sources[0]?.domain ?? item.sourceDomain;
+    if (!domain) return null;
+    return <span className={newsCardStyles.source}>{domain}</span>;
+  }
+
+  const handleToggle = () => {
+    const next = !open;
+    if (next) onTeamNewsSourcesExpanded(item, position, analyticsSource);
+    setOpen(next);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // The whole card/row is role="link" with its own key handler — no key
+    // pressed inside the source segment may bubble up and open the article.
+    e.stopPropagation();
+    if (e.key === 'Escape' && open) {
+      setOpen(false);
+      pillRef.current?.focus();
+    }
+  };
+
+  return (
+    // Clicks anywhere in the segment (pill, panel padding, header) must not
+    // reach the card's onClick — hence stopPropagation on the wrapper.
+    <span
+      ref={wrapperRef}
+      className={clsx(s.wrapper, compact && s.compact)}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={handleKeyDown}
+    >
+      <button ref={pillRef} type="button" className={s.pill} aria-expanded={open} onClick={handleToggle}>
+        {sources.length} sources
+        <svg className={s.caret} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M4 6L8 10L12 6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {/* Always in the DOM (CSS-hidden) so the hover preview needs no JS; the
+          shell's padding doubles as the hover bridge across the 6px gap. */}
+      <span className={clsx(s.popover, open && s.popoverOpen)}>
+        <span className={s.panel}>
+          <span className={s.panelHead}>Sources</span>
+          {sources.map((src, index) => (
+            <a
+              // Same outlet can cover a story twice (two URLs, one domain), so
+              // never key by domain alone.
+              key={`${src.url}-${index}`}
+              href={src.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={s.row}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTeamNewsSourceLinkClicked(item, position, src, analyticsSource);
+                setOpen(false);
+              }}
+            >
+              {src.domain}
+            </a>
+          ))}
+        </span>
+      </span>
+    </span>
+  );
+};

--- a/components/page/home/TeamNews/utils/getNewsSources.ts
+++ b/components/page/home/TeamNews/utils/getNewsSources.ts
@@ -1,0 +1,34 @@
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+/** A source row for the SourceList popover: the article URL plus the display
+ *  domain derived from it (the API sends bare `sourceUrls`, no domains). */
+export interface NewsSourceLink {
+  domain: string;
+  url: string;
+}
+
+function deriveDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '') || null;
+  } catch {
+    // Malformed entry from enrichment — drop it rather than render a broken row.
+    return null;
+  }
+}
+
+/** Maps the item's `sourceUrls` to displayable {domain, url} rows, in API
+ *  order. The primary entry (matching `sourceUrl`) keeps the backend-computed
+ *  `sourceDomain` so single- and multi-source renders never disagree. */
+export function getNewsSources(item: ITeamNewsItem): NewsSourceLink[] {
+  const links: NewsSourceLink[] = [];
+  for (const url of item.sourceUrls ?? []) {
+    const domain = url === item.sourceUrl && item.sourceDomain ? item.sourceDomain : deriveDomain(url);
+    if (domain) links.push({ domain, url });
+  }
+  return links;
+}
+
+/** Whether the meta line has a source segment to render — drives the caller's
+ *  separator dot, mirroring the old `item.sourceDomain &&` condition. */
+export const hasNewsSource = (item: ITeamNewsItem): boolean =>
+  getNewsSources(item).length > 0 || Boolean(item.sourceDomain);

--- a/services/team-news/team-news.mock-data.ts
+++ b/services/team-news/team-news.mock-data.ts
@@ -38,6 +38,9 @@ const PROTOCOL_LABS_INFRA: ITeamNewsItem[] = [
     summary:
       'The upgrade introduces a new content-routing layer that cuts average retrieval latency by roughly a third. Rollout starts with gateway operators in July.',
     sourceDomain: 'protocol.ai',
+    sourceUrl: 'https://protocol.ai/blog/ipfs-mainnet-upgrade',
+    // Exactly 2 sources — the smallest multi-source shape ("2 sources" pill).
+    sourceUrls: ['https://protocol.ai/blog/ipfs-mainnet-upgrade', 'https://www.coindesk.com/tech/ipfs-mainnet-upgrade'],
     discussion: { count: 4, latestTopicUrl: '/forum/t/1' },
     isFollowed: true,
     upvoteCount: 12,
@@ -121,6 +124,17 @@ const LATTICE: ITeamNewsItem[] = [
     title: 'Lattice Compute raises $4.2M seed extension',
     summary:
       'The $4.2M extension was led by existing backers and funds a marketplace matching idle GPU capacity with verifiable workloads.',
+    sourceDomain: 'techcrunch.com',
+    sourceUrl: 'https://techcrunch.com/2026/07/03/lattice-compute-seed-extension',
+    // Funding gets picked up widely — 5 sources exercises the popover's
+    // max-height scroll, and the last entry's long domain its row ellipsis.
+    sourceUrls: [
+      'https://techcrunch.com/2026/07/03/lattice-compute-seed-extension',
+      'https://theblock.co/post/lattice-compute-seed-extension',
+      'https://www.coindesk.com/business/lattice-compute-seed-extension',
+      'https://fortune.com/2026/07/03/lattice-compute-gpu-marketplace',
+      'https://decentralized-infrastructure-weekly.substack.com/p/lattice-compute-seed-extension',
+    ],
     discussion: { count: 2, latestTopicUrl: '/forum/t/3' },
     upvoteCount: 14, // highest count in the fixture set — the clear "Popular this week" #1
     viewerHasUpvoted: true, // demos the viewer-already-upvoted state

--- a/types/team-news.types.ts
+++ b/types/team-news.types.ts
@@ -16,6 +16,13 @@ export interface ITeamNewsItem {
   summary: string | null;
   sourceUrl: string;
   sourceDomain: string | null;
+  /** Article URLs of every outlet that covered this story, primary first —
+   *  `sourceUrls[0]` is expected to equal `sourceUrl` (the card click always
+   *  trusts `sourceUrl`). Absent or length ≤ 1 means single-source (render
+   *  `sourceDomain` as before). Rendered in API order; display domains are
+   *  derived from the URLs client-side (see getNewsSources). Not sent by the
+   *  API yet; the UI lights up automatically once it is. */
+  sourceUrls?: string[];
   tags: string[];
   focusAreas: string[];
   subFocusAreas: string[];

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -592,6 +592,8 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_VIEW_ALL_CLICKED: 'team-news-view-all-clicked',
   TEAM_NEWS_SHOW_MORE_CLICKED: 'team-news-show-more-clicked',
   TEAM_NEWS_CARD_CLICKED: 'team-news-card-clicked',
+  TEAM_NEWS_SOURCES_EXPANDED: 'team-news-sources-expanded',
+  TEAM_NEWS_SOURCE_LINK_CLICKED: 'team-news-source-link-clicked',
   TEAM_NEWS_START_CONVERSATION_CLICKED: 'team-news-start-conversation-clicked',
   TEAM_NEWS_JOIN_DISCUSSION_CLICKED: 'team-news-join-discussion-clicked',
   TEAM_NEWS_SEARCH_REQUESTED: 'team-news-search-requested',


### PR DESCRIPTION
## Summary
- When a Team News story has been covered by multiple outlets, we now show **one card** with an **"N sources" pill** in the meta line instead of repeating the story — on the Home feed (`NewsGroupCard` rows) and team profile news rail/modal (shared `NewsCard`). Design matches the approved `newsfeed-v0` prototype.
- **Ships dark**: the API contract is a new optional `sourceUrls: string[]` on `ITeamNewsItem` (primary first — confirmed with the backend team). Items without it (everything today) render byte-identical to before. Display domains are derived client-side (`getNewsSources`: hostname, `www.` stripped, malformed URLs dropped, primary keeps the backend's `sourceDomain`).
- The pill is a disclosure button: popover opens **upward** (meta line sits at the card's bottom edge inside scrollable columns — required removing the card's `overflow: hidden`), rows are real `<a target="_blank">` links, closes on Escape (refocuses pill), outside press, or choosing a source. Desktop also gets a CSS hover preview (`@media (hover: hover)` only, so no sticky-hover on touch).
- Card click behavior unchanged: opens the primary `sourceUrl`; all pill/popover interaction is isolated from the card link (click + keydown stopPropagation).
- **Bonus fix**: `NewsGroupCard` story rows were missing NewsCard's keydown target guard — Enter/Space on a nested control (Upvote/Discuss) also opened the article. Fixed with the same `e.target !== e.currentTarget` guard.
- Analytics: new `team-news-sources-expanded` (click-open only, not hover preview) and `team-news-source-link-clicked` (with `clickedDomain`/`clickedUrl`/`isPrimary`) events; `team-news-card-clicked` now carries `sourceCount`.
- Mock data: two grouped-feed items carry `sourceUrls` (2-source and 5-source incl. a long domain) so `MOCK_TEAM_NEWS=true` exercises all states.

## Backend dependency
The API does not send `sourceUrls` yet — LAB-2133 dedup currently keeps one URL (last-write-wins). Contract shared with BE: `sourceUrls: string[]`, primary first, `sourceUrls[0] === sourceUrl`; frontend renders it verbatim (ordering/uniqueness are the backend's contract).

## Testing
- 20 new Jest tests (`__tests__/page/home/source-list.test.tsx`): domain derivation (www-strip, malformed URLs, primary keeps `sourceDomain`), single-source fallback, toggle + `aria-expanded`, anchor semantics, Escape/outside-click dismissal, and event isolation in both `NewsCard` and `NewsGroupCard` (click, Enter, Space).
- Full suite green: 789 passed. Touched files lint clean (repo-wide lint has pre-existing failures). `tsc --noEmit` introduces no new errors.
- **Visual QA** (dev server + `MOCK_TEAM_NEWS=true`, headless browser): 2-source and 5-source popovers open upward and float over adjacent cards without clipping; long domain ellipsizes; caret rotates; expanded state correct. Home feed verified live; team profile rail/modal use the same component — recommend a design pass on dev once deployed.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)