### PR TITLE
fix(team-news): freeze upvote-driven feed ordering until page reload

### DIFF
--- a/__tests__/page/home/sort-team-news-clusters.test.ts
+++ b/__tests__/page/home/sort-team-news-clusters.test.ts
@@ -1,0 +1,106 @@
+import { clusterByTeam } from '@/components/page/home/TeamNews/utils/clusterByTeam';
+import { sortTeamNewsClusters } from '@/components/page/home/TeamNews/utils/sortTeamNewsClusters';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+const makeItem = (
+  uid: string,
+  teamUid: string,
+  teamName: string,
+  overrides: Partial<ITeamNewsItem> = {},
+): ITeamNewsItem => ({
+  uid,
+  teamUid,
+  teamName,
+  teamLogoUrl: null,
+  eventType: 'ANNOUNCEMENT',
+  eventDate: '2026-05-01T12:00:00.000Z',
+  title: `Headline ${uid}`,
+  summary: null,
+  sourceUrl: `https://example.com/${uid}`,
+  sourceDomain: 'example.com',
+  tags: [],
+  focusAreas: [],
+  subFocusAreas: [],
+  createdAt: '2026-05-01T12:00:00.000Z',
+  discussion: { count: 0, latestTopicUrl: null },
+  ...overrides,
+});
+
+const teamOrder = (clusters: ReturnType<typeof clusterByTeam>) => clusters.map((c) => c.teamUid);
+
+const NO_FOLLOWS: ReadonlySet<string> = new Set();
+
+describe('sortTeamNewsClusters', () => {
+  // Live item counts say beta > alpha, but the counts map pins the page-load
+  // ranking (alpha 5, beta 1) — the map must win, or an optimistic upvote
+  // written into the items would reorder the feed mid-session.
+  const alpha = makeItem('a-1', 'team-alpha', 'Alpha', { upvoteCount: 6 });
+  const beta = makeItem('b-1', 'team-beta', 'Beta', { upvoteCount: 9 });
+  const pinnedCounts: ReadonlyMap<string, number> = new Map([
+    ['a-1', 5],
+    ['b-1', 1],
+  ]);
+
+  describe("'popular'", () => {
+    it('ranks by the passed counts map, not the items’ live upvoteCount', () => {
+      const clusters = clusterByTeam([beta, alpha]); // insertion order would put beta first
+      const sorted = sortTeamNewsClusters(clusters, 'popular', NO_FOLLOWS, pinnedCounts);
+      expect(teamOrder(sorted)).toEqual(['team-alpha', 'team-beta']);
+    });
+
+    it('respects a 0 in the map over a positive item count (?? not ||)', () => {
+      const zeroed = makeItem('z-1', 'team-zeta', 'Zeta', { upvoteCount: 100 });
+      const one = makeItem('o-1', 'team-omega', 'Omega', { upvoteCount: 0 });
+      const counts: ReadonlyMap<string, number> = new Map([
+        ['z-1', 0],
+        ['o-1', 1],
+      ]);
+      const sorted = sortTeamNewsClusters(clusterByTeam([zeroed, one]), 'popular', NO_FOLLOWS, counts);
+      expect(teamOrder(sorted)).toEqual(['team-omega', 'team-zeta']);
+    });
+
+    it('falls back to the item’s upvoteCount (then 0) for a uid absent from the map', () => {
+      const known = makeItem('k-1', 'team-known', 'Known', { upvoteCount: 1 });
+      const unknownCounted = makeItem('u-1', 'team-unknown', 'Unknown', { upvoteCount: 3 });
+      const unknownBare = makeItem('n-1', 'team-none', 'None'); // no upvoteCount at all → 0
+      const counts: ReadonlyMap<string, number> = new Map([['k-1', 2]]);
+      const sorted = sortTeamNewsClusters(
+        clusterByTeam([known, unknownCounted, unknownBare]),
+        'popular',
+        NO_FOLLOWS,
+        counts,
+      );
+      expect(teamOrder(sorted)).toEqual(['team-unknown', 'team-known', 'team-none']);
+    });
+  });
+
+  describe("'following'", () => {
+    it('keeps followed-first partitioning, then tie-breaks within each group by the counts map', () => {
+      const followedLow = makeItem('f-1', 'team-followed', 'Followed', { upvoteCount: 0 });
+      const clusters = clusterByTeam([beta, alpha, followedLow]);
+      const counts = new Map(pinnedCounts).set('f-1', 0);
+      const sorted = sortTeamNewsClusters(clusters, 'following', new Set(['team-followed']), counts);
+      expect(teamOrder(sorted)).toEqual(['team-followed', 'team-alpha', 'team-beta']);
+    });
+  });
+
+  describe("'latest'", () => {
+    it('orders by event date and ignores the counts map entirely', () => {
+      const older = makeItem('old-1', 'team-old', 'Old', {
+        eventDate: '2026-04-01T12:00:00.000Z',
+        upvoteCount: 0,
+      });
+      const newer = makeItem('new-1', 'team-new', 'New', {
+        eventDate: '2026-06-01T12:00:00.000Z',
+        upvoteCount: 0,
+      });
+      // Map ranks the older story far higher — must not matter under 'latest'.
+      const counts: ReadonlyMap<string, number> = new Map([
+        ['old-1', 999],
+        ['new-1', 0],
+      ]);
+      const sorted = sortTeamNewsClusters(clusterByTeam([older, newer]), 'latest', NO_FOLLOWS, counts);
+      expect(teamOrder(sorted)).toEqual(['team-new', 'team-old']);
+    });
+  });
+});

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -731,8 +731,7 @@ describe('TeamNews', () => {
     // Insertion order alpha, beta, zeta — followed-first sorting must pin Zeta on mount.
     const frozenGroups: ITeamNewsGroup[] = [{ focusArea: FA_AI, total: 3, items: [alpha, beta, zeta] }];
 
-    const getTeamOrder = () =>
-      screen.getAllByRole('link', { name: /^(Zeta|Alpha|Beta)/ }).map((l) => l.textContent);
+    const getTeamOrder = () => screen.getAllByRole('link', { name: /^(Zeta|Alpha|Beta)/ }).map((l) => l.textContent);
 
     // FollowButton only renders hydrated + signed-in (same setup as the upvotes block).
     beforeEach(() => {
@@ -792,6 +791,93 @@ describe('TeamNews', () => {
       ];
       renderTeamNews(<TeamNews groups={reloadedGroups} />);
       expect(getTeamOrder()).toEqual(['Beta', 'Alpha', 'Zeta']);
+    });
+  });
+
+  describe('upvote — session-stable ordering (frozen until reload)', () => {
+    // No followed items → default sort resolves to 'popular', which ranks clusters
+    // by upvote count. Equal counts keep insertion order (stable sort), so upvoting
+    // Yankee (1 → 2) would rank it above Xray without the mount-time count snapshot.
+    const xray = {
+      ...makeItem('ux-1', 'FUNDING', ['AI & Robotics']),
+      teamUid: 'team-xray',
+      teamName: 'Xray',
+      upvoteCount: 1,
+    };
+    const yankee = {
+      ...makeItem('uy-1', 'LAUNCH', ['AI & Robotics']),
+      teamUid: 'team-yankee',
+      teamName: 'Yankee',
+      upvoteCount: 1,
+    };
+    const frozenGroups: ITeamNewsGroup[] = [{ focusArea: FA_AI, total: 2, items: [xray, yankee] }];
+
+    const getTeamOrder = () => screen.getAllByRole('link', { name: /^(Xray|Yankee)/ }).map((l) => l.textContent);
+    // Both stories start at count 1, so the buttons share a name — index 1 is
+    // Yankee's, matching the rendered [Xray, Yankee] order asserted first.
+    const getYankeeUpvoteButton = () => screen.getAllByRole('button', { name: 'Upvote (1)' })[1];
+
+    // UpvoteButton redirects anonymous clicks to login — sign in (same setup as
+    // the upvotes block above).
+    beforeEach(() => {
+      useCurrentUserStore.setState({ currentUser: { uid: 'user-1' }, isHydrated: true });
+    });
+    afterEach(() => {
+      useCurrentUserStore.setState({ currentUser: null, isHydrated: false });
+    });
+
+    it('upvoting flips the button and count immediately but does not move the cluster', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']);
+
+      fireEvent.click(getYankeeUpvoteButton());
+
+      expect(screen.getByRole('button', { name: 'Remove upvote (2)' })).toBeInTheDocument();
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']); // order frozen until reload
+
+      // Removing the upvote is symmetric: count drops back, cluster still doesn't move.
+      fireEvent.click(screen.getByRole('button', { name: 'Remove upvote (2)' }));
+      expect(screen.getAllByRole('button', { name: 'Upvote (1)' })).toHaveLength(2);
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']);
+    });
+
+    it('reverts the button (but not the order) when the mutation fails', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+      fireEvent.click(getYankeeUpvoteButton());
+      expect(screen.getByRole('button', { name: 'Remove upvote (2)' })).toBeInTheDocument();
+
+      const options = mockUpvoteMutate.mock.calls[0][1];
+      act(() => options.onError());
+
+      expect(screen.getAllByRole('button', { name: 'Upvote (1)' })).toHaveLength(2);
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']); // frozen order untouched by the revert
+    });
+
+    it('reconciling with a different server count updates the button only, never the order', () => {
+      renderTeamNews(<TeamNews groups={frozenGroups} />);
+      fireEvent.click(getYankeeUpvoteButton());
+
+      // Concurrent voters: server's authoritative count differs from the optimistic +1.
+      const options = mockUpvoteMutate.mock.calls[0][1];
+      act(() => options.onSuccess({ viewerHasUpvoted: true, upvoteCount: 7 }));
+
+      expect(screen.getByRole('button', { name: 'Remove upvote (7)' })).toBeInTheDocument();
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']); // still ranked by page-load counts
+    });
+
+    it('a fresh mount applies the new count order (simulates page reload)', () => {
+      const { unmount } = renderTeamNews(<TeamNews groups={frozenGroups} />);
+      fireEvent.click(getYankeeUpvoteButton());
+      expect(getTeamOrder()).toEqual(['Xray', 'Yankee']);
+      // rerender() would NOT reset the snapshot (state persists) — a reload is a fresh
+      // mount with fresh SSR counts, so unmount and render anew with the server's truth.
+      unmount();
+
+      const reloadedGroups: ITeamNewsGroup[] = [
+        { focusArea: FA_AI, total: 2, items: [xray, { ...yankee, upvoteCount: 2, viewerHasUpvoted: true }] },
+      ];
+      renderTeamNews(<TeamNews groups={reloadedGroups} />);
+      expect(getTeamOrder()).toEqual(['Yankee', 'Xray']);
     });
   });
 

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -97,8 +97,10 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   // `groups` is an SSR prop, not a React Query cache — there's nothing here for a
   // useArticleLike-style setQueryData patch to act on. Upvote state is tracked the
   // same way follow state already is (see followedTeamUids below): a local overlay,
-  // applied once in this memo, so every derived view (tabs, clusters, the Popular
-  // rail) reads the same merged item and can never drift out of sync with itself.
+  // merged once into allItems. NOTE the merge currently reaches only allItems-derived
+  // views (the All tab): focus-area tabs read raw group.items (see itemsForActiveTab)
+  // and the Popular rail reads the separate server-ranked popularItems prop, so
+  // neither reflects the overlay — a known gap, tracked separately.
   const [upvoteOverlay, setUpvoteOverlay] = useState<Map<string, { viewerHasUpvoted: boolean; upvoteCount: number }>>(
     () => new Map(),
   );
@@ -126,6 +128,15 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   // snapshot is captured during render (first paint is already sorted) and its
   // identity never changes; the copy severs aliasing with the live set.
   const [initialFollowedTeamUids] = useState<ReadonlySet<string>>(() => new Set(followedTeamUids));
+
+  // Same freeze for upvotes: captured while upvoteOverlay is still empty (its initial
+  // state), so these are the server-rendered counts. Drives sorting only — the live
+  // overlay keeps driving the buttons — so an optimistic upvote can never reorder the
+  // feed mid-session; the new ranking applies on the next page load. Seeded from
+  // allItems (not the active tab) so every tab's clusters rank consistently.
+  const [initialUpvoteCounts] = useState<ReadonlyMap<string, number>>(
+    () => new Map(allItems.map((i) => [i.uid, i.upvoteCount ?? 0])),
+  );
 
   // Default: Following when the user follows any teams; otherwise Most popular.
   const [sort, setSort] = useState<TeamNewsSort>(() => (initialFollowedTeamUids.size > 0 ? 'following' : 'popular'));
@@ -171,8 +182,8 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   const clusters = useMemo(() => clusterByTeam(searchedItems), [searchedItems]);
 
   const sortedClusters = useMemo(
-    () => sortTeamNewsClusters(clusters, sort, initialFollowedTeamUids),
-    [clusters, sort, initialFollowedTeamUids],
+    () => sortTeamNewsClusters(clusters, sort, initialFollowedTeamUids, initialUpvoteCounts),
+    [clusters, sort, initialFollowedTeamUids, initialUpvoteCounts],
   );
 
   const visibleClusters = expanded ? sortedClusters : sortedClusters.slice(0, pageSize);

--- a/components/page/home/TeamNews/utils/sortTeamNewsClusters.ts
+++ b/components/page/home/TeamNews/utils/sortTeamNewsClusters.ts
@@ -8,7 +8,12 @@ export const SORT_OPTIONS = [
   { value: 'popular', label: 'Most popular' },
 ] as const satisfies ReadonlyArray<{ value: TeamNewsSort; label: string }>;
 
-const clusterUpvotes = (c: TeamCluster): number => c.items.reduce((max, i) => Math.max(max, i.upvoteCount ?? 0), 0);
+// Ranks by the caller-provided counts (a mount-time snapshot in TeamNews) rather than
+// the items' live upvoteCount, so optimistic upvotes never reorder the feed mid-session.
+// The item fallback can't fire for TeamNews today (its snapshot covers every uid) but
+// keeps the util total for any future caller.
+const clusterUpvotes = (c: TeamCluster, counts: ReadonlyMap<string, number>): number =>
+  c.items.reduce((max, i) => Math.max(max, counts.get(i.uid) ?? i.upvoteCount ?? 0), 0);
 
 const compareClusterLatest = (a: TeamCluster, b: TeamCluster): number => {
   let aEvent = '';
@@ -38,9 +43,10 @@ export function sortTeamNewsClusters(
   clusters: TeamCluster[],
   sort: TeamNewsSort,
   followedTeamUids: ReadonlySet<string>,
+  upvoteCounts: ReadonlyMap<string, number>,
 ): TeamCluster[] {
   if (sort === 'popular') {
-    return [...clusters].sort((a, b) => clusterUpvotes(b) - clusterUpvotes(a));
+    return [...clusters].sort((a, b) => clusterUpvotes(b, upvoteCounts) - clusterUpvotes(a, upvoteCounts));
   }
 
   if (sort === 'latest') {
@@ -51,6 +57,6 @@ export function sortTeamNewsClusters(
   return [...clusters].sort((a, b) => {
     const followDiff = Number(followedTeamUids.has(b.teamUid)) - Number(followedTeamUids.has(a.teamUid));
     if (followDiff !== 0) return followDiff;
-    return clusterUpvotes(b) - clusterUpvotes(a);
+    return clusterUpvotes(b, upvoteCounts) - clusterUpvotes(a, upvoteCounts);
   });
 }


### PR DESCRIPTION
## Summary

On `/home`, upvoting a story further down the Team News feed made the feed re-sort instantly — the optimistic count bump flowed through `upvoteOverlay` → `allItems` → `sortTeamNewsClusters`, where both the **Most popular** sort and the **Following** sort's tie-break rank clusters by upvote count. The upvoted card jumped toward the top and the user lost their place.

**Fix:** cluster ordering now ranks against a mount-time snapshot of upvote counts (`initialUpvoteCounts`, the same setter-less `useState` idiom as `initialFollowedTeamUids` directly above it — the pattern shipped for the follow-sort freeze). Upvote buttons keep their live optimistic count/state; the new ranking applies on the next page load, exactly like Follow.

- `TeamNews.tsx`: add `initialUpvoteCounts` snapshot (captured while the overlay is still empty, so it equals the server-rendered counts), pass it to the sort; corrected the overlay comment that inaccurately claimed tabs and the Popular rail read merged items.
- `sortTeamNewsClusters.ts`: `clusterUpvotes` ranks by the passed counts map (`counts.get(uid) ?? item.upvoteCount ?? 0`); `'latest'` untouched.
- Error rollback and `onSuccess` server reconcile are now display-only by construction — neither can reorder the feed.

**Accepted tradeoff** (same class as the follow freeze): mid-session a cluster displaying 5 upvotes can sit below one displaying 4, since order is pinned to page-load counts.

**Found during research, deliberately out of scope:** the upvote overlay never applies on focus-area tabs (`itemsForActiveTab` returns raw `group.items`), so upvote state there is stale today and a re-click can POST a duplicate upvote — pre-existing, tracked separately.

## Testing

- New unit suite `__tests__/page/home/sort-team-news-clusters.test.ts`: pinned counts win over live item counts in `'popular'` and the `'following'` tie-break; `0` in the map respected (`??` not `||`); fallback for uids absent from the map; `'latest'` ignores the map.
- New `upvote — session-stable ordering` block in `team-news.test.tsx` (mirrors the follow-freeze block): upvote/un-upvote flips button without moving clusters; error rollback keeps order; server reconcile with a different count updates the button only; fresh mount applies the new order.
- All 88 tests in the 6 affected suites pass; changed files are eslint- and prettier-clean.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)