### PR TITLE
feat(ai-apps): Deployment logs UI — build & runtime logs for owners/admins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,6 @@ NEXT_PUBLIC_PL_EVENTS_URL=
 # Botpress Activity Assistant webchat (alignment-asset pages only)
 NEXT_PUBLIC_BOTPRESS_WEBCHAT_ENABLED=
 
-# AI Apps "Deployment logs" UI — enable only once the backend logs endpoints accept owner/admin user tokens
-NEXT_PUBLIC_AI_APPS_LOGS_ENABLED=
-
 #PLAA backend API URL
 PLAA_API_URL=
 

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ NEXT_PUBLIC_PL_EVENTS_URL=
 # Botpress Activity Assistant webchat (alignment-asset pages only)
 NEXT_PUBLIC_BOTPRESS_WEBCHAT_ENABLED=
 
+# AI Apps "Deployment logs" UI — enable only once the backend logs endpoints accept owner/admin user tokens
+NEXT_PUBLIC_AI_APPS_LOGS_ENABLED=
+
 #PLAA backend API URL
 PLAA_API_URL=
 

--- a/__tests__/page/ai-apps/ai-app-card-failure-strip.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-card-failure-strip.test.tsx
@@ -4,14 +4,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { AiAppCard } from '@/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard';
 import { AiApp } from '@/services/ai-apps/ai-apps.service';
 
-const mockFlags = { logs: true };
-jest.mock('@/utils/feature-flags', () => ({
-  ...jest.requireActual('@/utils/feature-flags'),
-  get AI_APPS_LOGS_ENABLED() {
-    return mockFlags.logs;
-  },
-}));
-
 jest.mock('@/analytics/ai-apps.analytics', () => ({
   useAiAppsAnalytics: () => ({ onCardClicked: jest.fn(), onAuthorClicked: jest.fn() }),
 }));
@@ -48,7 +40,6 @@ const manageHandlers = {
 describe('AiAppCard failure strip', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFlags.logs = true;
   });
 
   it('replaces the inline badge with one strip — never two "Deploy failed" indicators', () => {
@@ -75,14 +66,6 @@ describe('AiAppCard failure strip', () => {
     expect(seeLogs.closest('a')).toBeNull();
     // Its only button ancestor is itself — not the card's select button.
     expect(seeLogs.parentElement?.closest('button')).toBeNull();
-  });
-
-  it('keeps the plain error badge and no strip while the flag is off', () => {
-    mockFlags.logs = false;
-    render(<AiAppCard app={buildApp()} canManage {...manageHandlers} onLogs={jest.fn()} />);
-
-    expect(screen.getAllByText('Deploy failed')).toHaveLength(1);
-    expect(screen.queryByRole('button', { name: /see logs/i })).not.toBeInTheDocument();
   });
 
   it('shows no strip for healthy apps', () => {

--- a/__tests__/page/ai-apps/ai-app-card-failure-strip.test.tsx
+++ b/__tests__/page/ai-apps/ai-app-card-failure-strip.test.tsx
@@ -1,0 +1,92 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { AiAppCard } from '@/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard';
+import { AiApp } from '@/services/ai-apps/ai-apps.service';
+
+const mockFlags = { logs: true };
+jest.mock('@/utils/feature-flags', () => ({
+  ...jest.requireActual('@/utils/feature-flags'),
+  get AI_APPS_LOGS_ENABLED() {
+    return mockFlags.logs;
+  },
+}));
+
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => ({ onCardClicked: jest.fn(), onAuthorClicked: jest.fn() }),
+}));
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'ERROR',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+const manageHandlers = {
+  onEdit: jest.fn(),
+  onDeployment: jest.fn(),
+  onDelete: jest.fn(),
+};
+
+describe('AiAppCard failure strip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlags.logs = true;
+  });
+
+  it('replaces the inline badge with one strip — never two "Deploy failed" indicators', () => {
+    render(<AiAppCard app={buildApp()} />);
+    expect(screen.getAllByText('Deploy failed')).toHaveLength(1);
+  });
+
+  it('shows "See logs" only to managers, wired with the failure-strip source', () => {
+    const onLogs = jest.fn();
+    const { unmount } = render(<AiAppCard app={buildApp()} canManage {...manageHandlers} onLogs={onLogs} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /see logs/i }));
+    expect(onLogs).toHaveBeenCalledWith('failure-strip');
+    unmount();
+
+    render(<AiAppCard app={buildApp()} onLogs={onLogs} />);
+    expect(screen.queryByRole('button', { name: /see logs/i })).not.toBeInTheDocument();
+  });
+
+  it('the strip link is never nested inside the card link or select button', () => {
+    render(<AiAppCard app={buildApp()} canManage {...manageHandlers} onLogs={jest.fn()} onSelect={jest.fn()} />);
+
+    const seeLogs = screen.getByRole('button', { name: /see logs/i });
+    expect(seeLogs.closest('a')).toBeNull();
+    // Its only button ancestor is itself — not the card's select button.
+    expect(seeLogs.parentElement?.closest('button')).toBeNull();
+  });
+
+  it('keeps the plain error badge and no strip while the flag is off', () => {
+    mockFlags.logs = false;
+    render(<AiAppCard app={buildApp()} canManage {...manageHandlers} onLogs={jest.fn()} />);
+
+    expect(screen.getAllByText('Deploy failed')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: /see logs/i })).not.toBeInTheDocument();
+  });
+
+  it('shows no strip for healthy apps', () => {
+    render(<AiAppCard app={buildApp({ status: 'READY' })} />);
+    expect(screen.queryByText('Deploy failed')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/page/ai-apps/app-secrets-panel.test.tsx
+++ b/__tests__/page/ai-apps/app-secrets-panel.test.tsx
@@ -14,7 +14,7 @@ const mockAnalytics = {
 
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
-  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries, removeQueries: jest.fn() }),
 }));
 
 jest.mock('@/analytics/ai-apps.analytics', () => ({

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { DeploymentLogsModal } from '@/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal';
-import { AiApp, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+import { AiApp, AiAppFetchErrorKind, AiAppLogEvent } from '@/services/ai-apps/ai-apps.service';
 
 const mockAnalytics = {
   onDeploymentLogsTabSwitched: jest.fn(),
@@ -13,11 +13,16 @@ jest.mock('@/analytics/ai-apps.analytics', () => ({
 }));
 
 type HookReturn = {
-  result: FetchAiAppLogsResult | null;
+  events: AiAppLogEvent[] | null;
+  pageCount: number;
+  errorKind: AiAppFetchErrorKind | null;
+  loadMoreFailed: boolean;
   isLoading: boolean;
-  isRefetching: boolean;
-  isError: boolean;
-  refetch: jest.Mock;
+  hasMore: boolean;
+  canAutoLoad: boolean;
+  isLoadingMore: boolean;
+  loadMore: jest.Mock;
+  refresh: jest.Mock;
 };
 
 let mockStreams: Record<'build' | 'runtime', HookReturn>;
@@ -26,15 +31,18 @@ jest.mock('@/services/ai-apps/hooks/useAiAppLogs', () => ({
   useAiAppLogs: (_uid: string, stream: 'build' | 'runtime') => mockStreams[stream],
 }));
 
-const loaded = (
-  events: FetchAiAppLogsResult['events'],
-  termination: FetchAiAppLogsResult['termination'] = { reason: 'complete' },
-): HookReturn => ({
-  result: { events, termination },
+const loaded = (events: AiAppLogEvent[] | null, extra: Partial<HookReturn> = {}): HookReturn => ({
+  events,
+  pageCount: events ? 1 : 0,
+  errorKind: null,
+  loadMoreFailed: false,
   isLoading: false,
-  isRefetching: false,
-  isError: false,
-  refetch: jest.fn(),
+  hasMore: false,
+  canAutoLoad: false,
+  isLoadingMore: false,
+  loadMore: jest.fn(),
+  refresh: jest.fn().mockResolvedValue(undefined),
+  ...extra,
 });
 
 function buildApp(overrides: Partial<AiApp> = {}): AiApp {
@@ -100,7 +108,7 @@ describe('DeploymentLogsModal', () => {
     expect(screen.getByText('npm install completed')).toBeInTheDocument();
     // The count is split by a <strong>, so match on the whole span's text.
     expect(
-      screen.getByText((_, el) => el?.tagName === 'SPAN' && /Showing 1 of 2 events/.test(el.textContent ?? '')),
+      screen.getByText((_, el) => el?.tagName === 'SPAN' && /Showing 1 of 2 loaded events/.test(el.textContent ?? '')),
     ).toBeInTheDocument();
 
     fireEvent.change(search, { target: { value: 'zzz' } });
@@ -109,7 +117,7 @@ describe('DeploymentLogsModal', () => {
   });
 
   it('renders a dedicated forbidden state without a retry button', () => {
-    mockStreams.runtime = loaded([], { reason: 'failed', errorKind: 'forbidden' });
+    mockStreams.runtime = loaded(null, { errorKind: 'forbidden' });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByText(/don’t have access to logs/i)).toBeInTheDocument();
@@ -117,12 +125,12 @@ describe('DeploymentLogsModal', () => {
   });
 
   it('renders a retryable error state on network failure', () => {
-    mockStreams.runtime = loaded([], { reason: 'failed', errorKind: 'network' });
+    mockStreams.runtime = loaded(null, { errorKind: 'network' });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByText(/unable to load logs/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
-    expect(mockStreams.runtime.refetch).toHaveBeenCalled();
+    expect(mockStreams.runtime.refresh).toHaveBeenCalled();
   });
 
   it('shows the neutral windowed empty state for runtime — never a "never ran" claim', () => {
@@ -134,22 +142,31 @@ describe('DeploymentLogsModal', () => {
     expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
   });
 
-  it('notes truncation only when the fetch actually truncated', () => {
-    const { unmount } = render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
-    expect(screen.queryByText(/truncated/)).not.toBeInTheDocument();
-    unmount();
-
-    mockStreams.runtime = loaded([line(3, 'x')], { reason: 'truncated' });
+  it('marks continuation with a +count, a scroll hint, and a Load more row', () => {
+    mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, canAutoLoad: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
-    expect(screen.getByText(/log truncated to the 2,000-line limit/)).toBeInTheDocument();
+
+    expect(screen.getByRole('tab', { name: /runtime/i })).toHaveTextContent('1+');
+    expect(screen.getByText(/scroll to load more/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }));
+    expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });
 
-  it('Refresh refetches both streams', () => {
+  it('offers an inline retry when loading a later page failed', () => {
+    mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, loadMoreFailed: true });
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
+  });
+
+  it('Refresh restarts both streams from page 1', () => {
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
-    expect(mockStreams.build.refetch).toHaveBeenCalled();
-    expect(mockStreams.runtime.refetch).toHaveBeenCalled();
+    expect(mockStreams.build.refresh).toHaveBeenCalled();
+    expect(mockStreams.runtime.refresh).toHaveBeenCalled();
   });
 
   it('Export copies the filtered lines and reports only the row count to analytics', async () => {

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -142,21 +142,21 @@ describe('DeploymentLogsModal', () => {
     expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
   });
 
-  it('marks continuation with a +count, a scroll hint, and a Load more row', () => {
+  it('marks continuation with a +count, a scroll hint, and a Load earlier row', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, canAutoLoad: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByRole('tab', { name: /runtime/i })).toHaveTextContent('1+');
-    expect(screen.getByText(/scroll to load more/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /load more/i }));
+    expect(screen.getByText(/newest first — scroll for earlier logs/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load earlier logs/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });
 
-  it('offers an inline retry when loading a later page failed', () => {
+  it('offers an inline retry when loading an earlier page failed', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, loadMoreFailed: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
-    expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
+    expect(screen.getByText(/couldn’t load earlier lines/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -1,0 +1,182 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { DeploymentLogsModal } from '@/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal';
+import { AiApp, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+
+const mockAnalytics = {
+  onDeploymentLogsTabSwitched: jest.fn(),
+  onDeploymentLogsExported: jest.fn(),
+};
+jest.mock('@/analytics/ai-apps.analytics', () => ({
+  useAiAppsAnalytics: () => mockAnalytics,
+}));
+
+type HookReturn = {
+  result: FetchAiAppLogsResult | null;
+  isLoading: boolean;
+  isRefetching: boolean;
+  isError: boolean;
+  refetch: jest.Mock;
+};
+
+let mockStreams: Record<'build' | 'runtime', HookReturn>;
+jest.mock('@/services/ai-apps/hooks/useAiAppLogs', () => ({
+  ...jest.requireActual('@/services/ai-apps/hooks/useAiAppLogs'),
+  useAiAppLogs: (_uid: string, stream: 'build' | 'runtime') => mockStreams[stream],
+}));
+
+const loaded = (events: FetchAiAppLogsResult['events'], termination: FetchAiAppLogsResult['termination'] = { reason: 'complete' }): HookReturn => ({
+  result: { events, termination },
+  isLoading: false,
+  isRefetching: false,
+  isError: false,
+  refetch: jest.fn(),
+});
+
+function buildApp(overrides: Partial<AiApp> = {}): AiApp {
+  return {
+    uid: 'app-1',
+    memberUid: 'member-1',
+    appId: 'news-summarizer',
+    name: 'News Summarizer',
+    description: 'Summarize recent news.',
+    status: 'READY',
+    notes: null,
+    url: null,
+    httpUrl: null,
+    host: null,
+    port: null,
+    deploymentId: 'deploy-1',
+    requiredEnvVars: [],
+    providedEnvVars: [],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    member: { uid: 'member-1', name: 'Ada', image: null },
+    ...overrides,
+  };
+}
+
+const line = (timestamp: number, message: string) => ({ timestamp, message });
+
+describe('DeploymentLogsModal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreams = {
+      build: loaded([line(1, 'Step 1/5 : FROM node:20'), line(2, 'npm install completed')]),
+      runtime: loaded([line(3, 'server listening on 3000')]),
+    };
+  });
+
+  it('defaults to the Runtime tab for a healthy app and Build for a failed one', () => {
+    const { unmount } = render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+    expect(screen.getByRole('tab', { name: /runtime/i })).toHaveAttribute('aria-selected', 'true');
+    unmount();
+
+    render(<DeploymentLogsModal app={buildApp({ status: 'ERROR' })} onClose={onClose} />);
+    expect(screen.getByRole('tab', { name: /build/i })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('shows log lines with counts, and switching tabs fires analytics and resets search', () => {
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    expect(screen.getByText('server listening on 3000')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /build/i }));
+    expect(screen.getByText('Step 1/5 : FROM node:20')).toBeInTheDocument();
+    expect(mockAnalytics.onDeploymentLogsTabSwitched).toHaveBeenCalledWith('app-1', 'build');
+  });
+
+  it('filters lines by search and offers a clear CTA when nothing matches', () => {
+    render(<DeploymentLogsModal app={buildApp({ status: 'ERROR' })} onClose={onClose} />);
+
+    const search = screen.getByRole('searchbox', { name: /search deployment logs/i });
+    fireEvent.change(search, { target: { value: 'npm' } });
+    expect(screen.queryByText('Step 1/5 : FROM node:20')).not.toBeInTheDocument();
+    expect(screen.getByText('npm install completed')).toBeInTheDocument();
+    expect(screen.getByText(/1 of 2 lines/)).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: 'zzz' } });
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+    expect(screen.getByText('Step 1/5 : FROM node:20')).toBeInTheDocument();
+  });
+
+  it('renders a dedicated forbidden state without a retry button', () => {
+    mockStreams.runtime = loaded([], { reason: 'failed', errorKind: 'forbidden' });
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    expect(screen.getByText(/don’t have access to logs/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a retryable error state on network failure', () => {
+    mockStreams.runtime = loaded([], { reason: 'failed', errorKind: 'network' });
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    expect(screen.getByText(/unable to load logs/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockStreams.runtime.refetch).toHaveBeenCalled();
+  });
+
+  it('shows the neutral windowed empty state for runtime — never a "never ran" claim', () => {
+    mockStreams.runtime = loaded([]);
+    render(<DeploymentLogsModal app={buildApp({ status: 'ERROR' })} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /runtime/i }));
+    expect(screen.getByText(/no runtime logs in this window/i)).toBeInTheDocument();
+    expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
+  });
+
+  it('notes truncation only when the fetch actually truncated', () => {
+    const { unmount } = render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+    expect(screen.queryByText(/truncated/)).not.toBeInTheDocument();
+    unmount();
+
+    mockStreams.runtime = loaded([line(3, 'x')], { reason: 'truncated' });
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+    expect(screen.getByText(/log truncated to the 2,000-line limit/)).toBeInTheDocument();
+  });
+
+  it('Refresh refetches both streams', () => {
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(mockStreams.build.refetch).toHaveBeenCalled();
+    expect(mockStreams.runtime.refetch).toHaveBeenCalled();
+  });
+
+  it('Export copies the filtered lines and reports only the row count to analytics', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<DeploymentLogsModal app={buildApp({ status: 'ERROR' })} onClose={onClose} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search deployment logs/i }), {
+      target: { value: 'npm' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('npm install completed');
+    expect(writeText.mock.calls[0][0]).not.toContain('Step 1/5');
+    await screen.findByRole('button', { name: /copied/i });
+    expect(mockAnalytics.onDeploymentLogsExported).toHaveBeenCalledWith('app-1', 'build', 1);
+    // Counts only — never message or query text.
+    expect(JSON.stringify(mockAnalytics.onDeploymentLogsExported.mock.calls)).not.toContain('npm');
+  });
+
+  it('marks the log pane and search as ph-no-capture so session replay never sees log text', () => {
+    const { container } = render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    expect(container.ownerDocument.querySelector('[role="region"][aria-label="Deployment logs"]')?.className).toContain(
+      'ph-no-capture',
+    );
+    expect(screen.getByRole('searchbox', { name: /search deployment logs/i }).className).toContain('ph-no-capture');
+  });
+
+  it('hints that a deploy is in progress for DEPLOYING apps', () => {
+    render(<DeploymentLogsModal app={buildApp({ status: 'DEPLOYING' })} onClose={onClose} />);
+    expect(screen.getByText(/deploy in progress/i)).toBeInTheDocument();
+    expect(screen.getByText('Deploying')).toBeInTheDocument();
+  });
+});

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -26,7 +26,10 @@ jest.mock('@/services/ai-apps/hooks/useAiAppLogs', () => ({
   useAiAppLogs: (_uid: string, stream: 'build' | 'runtime') => mockStreams[stream],
 }));
 
-const loaded = (events: FetchAiAppLogsResult['events'], termination: FetchAiAppLogsResult['termination'] = { reason: 'complete' }): HookReturn => ({
+const loaded = (
+  events: FetchAiAppLogsResult['events'],
+  termination: FetchAiAppLogsResult['termination'] = { reason: 'complete' },
+): HookReturn => ({
   result: { events, termination },
   isLoading: false,
   isRefetching: false,

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -140,32 +140,21 @@ describe('DeploymentLogsModal', () => {
     expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
   });
 
-  it('marks continuation with a +count, a footer note, and a manual Load newer row', () => {
+  it('marks continuation with a +count, a footer hint, and a Load earlier row', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByRole('tab', { name: /runtime/i })).toHaveTextContent('1+');
-    expect(screen.getByText(/newer lines available/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /load newer logs/i }));
+    expect(screen.getByText(/newest first — scroll for earlier logs/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load earlier logs/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
   });
 
-  it('never fetches further pages from scroll events — loading more is button-only', () => {
-    mockStreams.runtime = loaded(
-      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
-      { hasMore: true },
-    );
-    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
-
-    fireEvent.scroll(screen.getByRole('region', { name: /deployment logs/i }));
-    expect(mockStreams.runtime.loadMore).not.toHaveBeenCalled();
-  });
-
-  it('offers an inline retry when loading a further page failed', () => {
+  it('offers an inline retry when loading an earlier page failed', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, loadMoreFailed: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
-    expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
+    expect(screen.getByText(/couldn’t load earlier lines/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -19,7 +19,6 @@ type HookReturn = {
   loadMoreFailed: boolean;
   isLoading: boolean;
   hasMore: boolean;
-  canAutoLoad: boolean;
   isLoadingMore: boolean;
   loadMore: jest.Mock;
   refresh: jest.Mock;
@@ -38,7 +37,6 @@ const loaded = (events: AiAppLogEvent[] | null, extra: Partial<HookReturn> = {})
   loadMoreFailed: false,
   isLoading: false,
   hasMore: false,
-  canAutoLoad: false,
   isLoadingMore: false,
   loadMore: jest.fn(),
   refresh: jest.fn().mockResolvedValue(undefined),
@@ -142,14 +140,25 @@ describe('DeploymentLogsModal', () => {
     expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
   });
 
-  it('marks continuation with a +count, a scroll hint, and a Load more row', () => {
-    mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, canAutoLoad: true });
+  it('marks continuation with a +count, a footer note, and a manual Load newer row', () => {
+    mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByRole('tab', { name: /runtime/i })).toHaveTextContent('1+');
-    expect(screen.getByText(/newest loaded first — scroll to load the rest/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /load more logs/i }));
-    expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
+    expect(screen.getByText(/newer lines available/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load newer logs/i }));
+    expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fetches further pages from scroll events — loading more is button-only', () => {
+    mockStreams.runtime = loaded(
+      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
+      { hasMore: true },
+    );
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    fireEvent.scroll(screen.getByRole('region', { name: /deployment logs/i }));
+    expect(mockStreams.runtime.loadMore).not.toHaveBeenCalled();
   });
 
   it('offers an inline retry when loading a further page failed', () => {
@@ -159,36 +168,6 @@ describe('DeploymentLogsModal', () => {
     expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
-  });
-
-  it('auto-loads on scroll near the bottom, but only via user scroll events', () => {
-    mockStreams.runtime = loaded(
-      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
-      { hasMore: true, canAutoLoad: true },
-    );
-    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
-
-    const pane = screen.getByRole('region', { name: /deployment logs/i });
-    // jsdom has zero layout, so scrollHeight - scrollTop - clientHeight === 0 → "near bottom".
-    fireEvent.scroll(pane);
-    expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
-
-    // No further fetch without another scroll — appends must never self-chain.
-    expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not auto-load on scroll while a search filter is active', () => {
-    mockStreams.runtime = loaded(
-      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
-      { hasMore: true, canAutoLoad: true },
-    );
-    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
-
-    fireEvent.change(screen.getByRole('searchbox', { name: /search deployment logs/i }), {
-      target: { value: 'row' },
-    });
-    fireEvent.scroll(screen.getByRole('region', { name: /deployment logs/i }));
-    expect(mockStreams.runtime.loadMore).not.toHaveBeenCalled();
   });
 
   it('Refresh restarts both streams from page 1', () => {

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -98,7 +98,10 @@ describe('DeploymentLogsModal', () => {
     fireEvent.change(search, { target: { value: 'npm' } });
     expect(screen.queryByText('Step 1/5 : FROM node:20')).not.toBeInTheDocument();
     expect(screen.getByText('npm install completed')).toBeInTheDocument();
-    expect(screen.getByText(/1 of 2 lines/)).toBeInTheDocument();
+    // The count is split by a <strong>, so match on the whole span's text.
+    expect(
+      screen.getByText((_, el) => el?.tagName === 'SPAN' && /Showing 1 of 2 events/.test(el.textContent ?? '')),
+    ).toBeInTheDocument();
 
     fireEvent.change(search, { target: { value: 'zzz' } });
     fireEvent.click(screen.getByRole('button', { name: /clear search/i }));

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -19,6 +19,7 @@ type HookReturn = {
   loadMoreFailed: boolean;
   isLoading: boolean;
   hasMore: boolean;
+  pagesNewestFirst: boolean;
   isLoadingMore: boolean;
   loadMore: jest.Mock;
   refresh: jest.Mock;
@@ -37,6 +38,7 @@ const loaded = (events: AiAppLogEvent[] | null, extra: Partial<HookReturn> = {})
   loadMoreFailed: false,
   isLoading: false,
   hasMore: false,
+  pagesNewestFirst: true,
   isLoadingMore: false,
   loadMore: jest.fn(),
   refresh: jest.fn().mockResolvedValue(undefined),
@@ -150,11 +152,22 @@ describe('DeploymentLogsModal', () => {
     expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
   });
 
+  it('degrades to a neutral manual button when the backend ignored order=desc', () => {
+    mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, pagesNewestFirst: false });
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    // No "earlier" claim (forward pages actually bring newer lines) and no
+    // scroll hint — auto-load is disarmed against legacy backends.
+    expect(screen.getByRole('button', { name: /load more logs/i })).toBeInTheDocument();
+    expect(screen.queryByText(/scroll for earlier logs/)).not.toBeInTheDocument();
+    expect(screen.getByText(/more lines available/)).toBeInTheDocument();
+  });
+
   it('offers an inline retry when loading an earlier page failed', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, loadMoreFailed: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
-    expect(screen.getByText(/couldn’t load earlier lines/i)).toBeInTheDocument();
+    expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });

--- a/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
+++ b/__tests__/page/ai-apps/deployment-logs-modal.test.tsx
@@ -142,23 +142,53 @@ describe('DeploymentLogsModal', () => {
     expect(screen.queryByText(/never ran/i)).not.toBeInTheDocument();
   });
 
-  it('marks continuation with a +count, a scroll hint, and a Load earlier row', () => {
+  it('marks continuation with a +count, a scroll hint, and a Load more row', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, canAutoLoad: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
     expect(screen.getByRole('tab', { name: /runtime/i })).toHaveTextContent('1+');
-    expect(screen.getByText(/newest first — scroll for earlier logs/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /load earlier logs/i }));
+    expect(screen.getByText(/newest loaded first — scroll to load the rest/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load more logs/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
   });
 
-  it('offers an inline retry when loading an earlier page failed', () => {
+  it('offers an inline retry when loading a further page failed', () => {
     mockStreams.runtime = loaded([line(3, 'x')], { hasMore: true, loadMoreFailed: true });
     render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
 
-    expect(screen.getByText(/couldn’t load earlier lines/i)).toBeInTheDocument();
+    expect(screen.getByText(/couldn’t load more lines/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(mockStreams.runtime.loadMore).toHaveBeenCalled();
+  });
+
+  it('auto-loads on scroll near the bottom, but only via user scroll events', () => {
+    mockStreams.runtime = loaded(
+      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
+      { hasMore: true, canAutoLoad: true },
+    );
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    const pane = screen.getByRole('region', { name: /deployment logs/i });
+    // jsdom has zero layout, so scrollHeight - scrollTop - clientHeight === 0 → "near bottom".
+    fireEvent.scroll(pane);
+    expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
+
+    // No further fetch without another scroll — appends must never self-chain.
+    expect(mockStreams.runtime.loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto-load on scroll while a search filter is active', () => {
+    mockStreams.runtime = loaded(
+      Array.from({ length: 20 }, (_, i) => line(i, `row ${i}`)),
+      { hasMore: true, canAutoLoad: true },
+    );
+    render(<DeploymentLogsModal app={buildApp()} onClose={onClose} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search deployment logs/i }), {
+      target: { value: 'row' },
+    });
+    fireEvent.scroll(screen.getByRole('region', { name: /deployment logs/i }));
+    expect(mockStreams.runtime.loadMore).not.toHaveBeenCalled();
   });
 
   it('Refresh restarts both streams from page 1', () => {

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -1,0 +1,177 @@
+import { customFetch } from '@/utils/fetch-wrapper';
+import { fetchAiAppLogs } from '@/services/ai-apps/ai-apps.service';
+
+jest.mock('@/utils/fetch-wrapper', () => ({
+  customFetch: jest.fn(),
+}));
+
+const mockCustomFetch = customFetch as jest.MockedFunction<typeof customFetch>;
+
+const jsonResponse = (status: number, body: unknown = {}) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+const event = (timestamp: number, message = `line at ${timestamp}`) => ({ timestamp, message });
+
+describe('fetchAiAppLogs', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('resolves complete on a single non-empty page without a nextToken', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1), event(2)] }));
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [event(1), event(2)],
+      termination: { reason: 'complete' },
+    });
+    expect(mockCustomFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks truncated when a non-empty page comes with a fresh nextToken (more log remains)', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)], nextToken: 'more' }));
+
+    const result = await fetchAiAppLogs('a1', 'runtime');
+    expect(result.termination).toEqual({ reason: 'truncated' });
+    // v1 never chains past the first non-empty page.
+    expect(mockCustomFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('sorts events ascending by timestamp regardless of server order', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(30), event(10), event(20)] }));
+
+    const result = await fetchAiAppLogs('a1', 'runtime');
+    expect(result.events.map((e) => e.timestamp)).toEqual([10, 20, 30]);
+  });
+
+  it('treats a repeated nextToken on an empty page as end-of-stream (CloudWatch never nulls it)', async () => {
+    mockCustomFetch
+      .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'tok' }))
+      .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'tok' }));
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [],
+      termination: { reason: 'complete' },
+    });
+    expect(mockCustomFetch).toHaveBeenCalledTimes(2);
+    // The second request carried the token from the first.
+    expect(mockCustomFetch.mock.calls[1][0]).toContain(`nextToken=tok`);
+  });
+
+  it('skips empty pages and returns the first non-empty one', async () => {
+    mockCustomFetch
+      .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 't1' }))
+      .mockResolvedValueOnce(jsonResponse(200, { events: [event(5)] }));
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [event(5)],
+      termination: { reason: 'complete' },
+    });
+  });
+
+  it('gives up as truncated after the page budget while empty pages keep advancing the token', async () => {
+    for (let i = 0; i < 10; i++) {
+      mockCustomFetch.mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: `t${i}` }));
+    }
+
+    const result = await fetchAiAppLogs('a1', 'runtime');
+    expect(result).toEqual({ events: [], termination: { reason: 'truncated' } });
+    expect(mockCustomFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('gives up as truncated when the wall-clock budget is exhausted', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValue(60_000);
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [], nextToken: 'fresh' }));
+
+    const result = await fetchAiAppLogs('a1', 'runtime');
+    expect(result.termination).toEqual({ reason: 'truncated' });
+    nowSpy.mockRestore();
+  });
+
+  it.each([
+    [403, 'forbidden'],
+    [404, 'not-found'],
+    [502, 'network'],
+  ] as const)('discriminates a %s response as failed/%s', async (status, errorKind) => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(status));
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [],
+      termination: { reason: 'failed', errorKind },
+    });
+  });
+
+  it('maps a missing response (logout/refresh path) to failed/network', async () => {
+    mockCustomFetch.mockResolvedValue(undefined as unknown as Response);
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [],
+      termination: { reason: 'failed', errorKind: 'network' },
+    });
+  });
+
+  it('rethrows AbortError instead of resolving — a cancelled fetch must not cache a snapshot', async () => {
+    const abort = new DOMException('The operation was aborted.', 'AbortError');
+    mockCustomFetch.mockRejectedValue(abort);
+
+    await expect(fetchAiAppLogs('a1', 'runtime')).rejects.toBe(abort);
+  });
+
+  it('maps a non-abort rejection to failed/network', async () => {
+    mockCustomFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [],
+      termination: { reason: 'failed', errorKind: 'network' },
+    });
+  });
+
+  it('treats a non-JSON body as an empty stream, not a crash', async () => {
+    mockCustomFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error('bad json')),
+    } as unknown as Response);
+
+    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+      events: [],
+      termination: { reason: 'complete' },
+    });
+  });
+
+  it('drops malformed entries without a string message', async () => {
+    mockCustomFetch.mockResolvedValue(
+      jsonResponse(200, { events: [event(1), { timestamp: 2 }, null, 'junk', event(3)] }),
+    );
+
+    const result = await fetchAiAppLogs('a1', 'build');
+    expect(result.events).toEqual([event(1), event(3)]);
+  });
+
+  it('sends limit always, sinceMinutes only when provided, and passes the signal through', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)] }));
+    const controller = new AbortController();
+
+    await fetchAiAppLogs('a1', 'runtime', { signal: controller.signal, sinceMinutes: 1440 });
+    const [url, init] = mockCustomFetch.mock.calls[0];
+    expect(url).toContain('/a1/logs/runtime?');
+    expect(url).toContain('limit=2000');
+    expect(url).toContain('sinceMinutes=1440');
+    expect((init as RequestInit).signal).toBe(controller.signal);
+
+    mockCustomFetch.mockClear();
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)] }));
+    await fetchAiAppLogs('a1', 'build');
+    expect(mockCustomFetch.mock.calls[0][0]).not.toContain('sinceMinutes');
+  });
+
+  it('URL-encodes tokens with reserved characters', async () => {
+    mockCustomFetch
+      .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'a/b+c' }))
+      .mockResolvedValueOnce(jsonResponse(200, { events: [event(1)] }));
+
+    await fetchAiAppLogs('a1', 'build');
+    expect(mockCustomFetch.mock.calls[1][0]).toContain('nextToken=a%2Fb%2Bc');
+  });
+});

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -1,5 +1,5 @@
 import { customFetch } from '@/utils/fetch-wrapper';
-import { fetchAiAppLogs } from '@/services/ai-apps/ai-apps.service';
+import { fetchAiAppLogsPage, AiAppLogsError } from '@/services/ai-apps/ai-apps.service';
 
 jest.mock('@/utils/fetch-wrapper', () => ({
   customFetch: jest.fn(),
@@ -16,33 +16,49 @@ const jsonResponse = (status: number, body: unknown = {}) =>
 
 const event = (timestamp: number, message = `line at ${timestamp}`) => ({ timestamp, message });
 
-describe('fetchAiAppLogs', () => {
+const errorKindOf = async (promise: Promise<unknown>) => {
+  try {
+    await promise;
+    return null;
+  } catch (error) {
+    return error instanceof AiAppLogsError ? error.errorKind : error;
+  }
+};
+
+describe('fetchAiAppLogsPage', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('resolves complete on a single non-empty page without a nextToken', async () => {
+  it('returns an end-of-stream page (no nextToken) when the response has none', async () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1), event(2)] }));
 
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
+    await expect(fetchAiAppLogsPage('a1', 'build')).resolves.toEqual({
       events: [event(1), event(2)],
-      termination: { reason: 'complete' },
+      nextToken: undefined,
     });
     expect(mockCustomFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('marks truncated when a non-empty page comes with a fresh nextToken (more log remains)', async () => {
+  it('surfaces a fresh nextToken so the next scroll-step can resume', async () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)], nextToken: 'more' }));
 
-    const result = await fetchAiAppLogs('a1', 'runtime');
-    expect(result.termination).toEqual({ reason: 'truncated' });
-    // v1 never chains past the first non-empty page.
+    const page = await fetchAiAppLogsPage('a1', 'runtime');
+    expect(page.nextToken).toBe('more');
+    // One non-empty page per step — never chained inside the fetcher.
     expect(mockCustomFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes from the caller-provided nextToken', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(9)] }));
+
+    await fetchAiAppLogsPage('a1', 'build', { nextToken: 'cursor-1' });
+    expect(mockCustomFetch.mock.calls[0][0]).toContain('nextToken=cursor-1');
   });
 
   it('sorts events ascending by timestamp regardless of server order', async () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(30), event(10), event(20)] }));
 
-    const result = await fetchAiAppLogs('a1', 'runtime');
-    expect(result.events.map((e) => e.timestamp)).toEqual([10, 20, 30]);
+    const page = await fetchAiAppLogsPage('a1', 'runtime');
+    expect(page.events.map((e) => e.timestamp)).toEqual([10, 20, 30]);
   });
 
   it('treats a repeated nextToken on an empty page as end-of-stream (CloudWatch never nulls it)', async () => {
@@ -50,42 +66,45 @@ describe('fetchAiAppLogs', () => {
       .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'tok' }))
       .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'tok' }));
 
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [],
-      termination: { reason: 'complete' },
-    });
+    await expect(fetchAiAppLogsPage('a1', 'build')).resolves.toEqual({ events: [] });
     expect(mockCustomFetch).toHaveBeenCalledTimes(2);
-    // The second request carried the token from the first.
-    expect(mockCustomFetch.mock.calls[1][0]).toContain(`nextToken=tok`);
+    expect(mockCustomFetch.mock.calls[1][0]).toContain('nextToken=tok');
   });
 
-  it('skips empty pages and returns the first non-empty one', async () => {
+  it('does not report a nextToken when a non-empty page echoes the token it was sent', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)], nextToken: 'cursor-1' }));
+
+    const page = await fetchAiAppLogsPage('a1', 'build', { nextToken: 'cursor-1' });
+    expect(page.nextToken).toBeUndefined();
+  });
+
+  it('skips empty pages within a step and returns the first non-empty one', async () => {
     mockCustomFetch
       .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 't1' }))
       .mockResolvedValueOnce(jsonResponse(200, { events: [event(5)] }));
 
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [event(5)],
-      termination: { reason: 'complete' },
-    });
+    await expect(fetchAiAppLogsPage('a1', 'build')).resolves.toEqual({ events: [event(5)], nextToken: undefined });
   });
 
-  it('gives up as truncated after the page budget while empty pages keep advancing the token', async () => {
-    for (let i = 0; i < 10; i++) {
+  it('yields an empty page WITH the last token when the skip budget runs out — the cursor survives', async () => {
+    // Exactly the skip budget: clearAllMocks doesn't drop unconsumed
+    // mockResolvedValueOnce queues, so extras would leak into later tests.
+    for (let i = 0; i < 5; i++) {
       mockCustomFetch.mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: `t${i}` }));
     }
 
-    const result = await fetchAiAppLogs('a1', 'runtime');
-    expect(result).toEqual({ events: [], termination: { reason: 'truncated' } });
+    const page = await fetchAiAppLogsPage('a1', 'runtime');
+    expect(page.events).toEqual([]);
+    expect(page.nextToken).toBe('t4');
     expect(mockCustomFetch).toHaveBeenCalledTimes(5);
   });
 
-  it('gives up as truncated when the wall-clock budget is exhausted', async () => {
+  it('yields an empty page WITH the last token when the wall-clock budget is exhausted', async () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValue(60_000);
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [], nextToken: 'fresh' }));
 
-    const result = await fetchAiAppLogs('a1', 'runtime');
-    expect(result.termination).toEqual({ reason: 'truncated' });
+    const page = await fetchAiAppLogsPage('a1', 'runtime');
+    expect(page).toEqual({ events: [], nextToken: 'fresh' });
     nowSpy.mockRestore();
   });
 
@@ -93,51 +112,36 @@ describe('fetchAiAppLogs', () => {
     [403, 'forbidden'],
     [404, 'not-found'],
     [502, 'network'],
-  ] as const)('discriminates a %s response as failed/%s', async (status, errorKind) => {
+  ] as const)('throws AiAppLogsError(%s → %s)', async (status, errorKind) => {
     mockCustomFetch.mockResolvedValue(jsonResponse(status));
-
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [],
-      termination: { reason: 'failed', errorKind },
-    });
+    await expect(errorKindOf(fetchAiAppLogsPage('a1', 'build'))).resolves.toBe(errorKind);
   });
 
-  it('maps a missing response (logout/refresh path) to failed/network', async () => {
+  it('maps a missing response (logout/refresh path) to a network AiAppLogsError', async () => {
     mockCustomFetch.mockResolvedValue(undefined as unknown as Response);
-
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [],
-      termination: { reason: 'failed', errorKind: 'network' },
-    });
+    await expect(errorKindOf(fetchAiAppLogsPage('a1', 'build'))).resolves.toBe('network');
   });
 
-  it('rethrows AbortError instead of resolving — a cancelled fetch must not cache a snapshot', async () => {
+  it('rethrows AbortError as-is — a cancelled fetch must not resolve or be re-wrapped', async () => {
     const abort = new DOMException('The operation was aborted.', 'AbortError');
     mockCustomFetch.mockRejectedValue(abort);
 
-    await expect(fetchAiAppLogs('a1', 'runtime')).rejects.toBe(abort);
+    await expect(fetchAiAppLogsPage('a1', 'runtime')).rejects.toBe(abort);
   });
 
-  it('maps a non-abort rejection to failed/network', async () => {
+  it('maps a non-abort rejection to a network AiAppLogsError', async () => {
     mockCustomFetch.mockRejectedValue(new TypeError('Failed to fetch'));
-
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [],
-      termination: { reason: 'failed', errorKind: 'network' },
-    });
+    await expect(errorKindOf(fetchAiAppLogsPage('a1', 'build'))).resolves.toBe('network');
   });
 
-  it('treats a non-JSON body as an empty stream, not a crash', async () => {
+  it('treats a non-JSON body as an empty end-of-stream page, not a crash', async () => {
     mockCustomFetch.mockResolvedValue({
       ok: true,
       status: 200,
       json: () => Promise.reject(new Error('bad json')),
     } as unknown as Response);
 
-    await expect(fetchAiAppLogs('a1', 'build')).resolves.toEqual({
-      events: [],
-      termination: { reason: 'complete' },
-    });
+    await expect(fetchAiAppLogsPage('a1', 'build')).resolves.toEqual({ events: [] });
   });
 
   it('drops malformed entries without a string message', async () => {
@@ -145,33 +149,31 @@ describe('fetchAiAppLogs', () => {
       jsonResponse(200, { events: [event(1), { timestamp: 2 }, null, 'junk', event(3)] }),
     );
 
-    const result = await fetchAiAppLogs('a1', 'build');
-    expect(result.events).toEqual([event(1), event(3)]);
+    const page = await fetchAiAppLogsPage('a1', 'build');
+    expect(page.events).toEqual([event(1), event(3)]);
   });
 
   it('sends limit always, sinceMinutes only when provided, and passes the signal through', async () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)] }));
     const controller = new AbortController();
 
-    await fetchAiAppLogs('a1', 'runtime', { signal: controller.signal, sinceMinutes: 1440 });
+    await fetchAiAppLogsPage('a1', 'runtime', { signal: controller.signal, sinceMinutes: 1440 });
     const [url, init] = mockCustomFetch.mock.calls[0];
     expect(url).toContain('/a1/runtime-logs?');
-    expect(url).toContain('limit=2000');
+    expect(url).toContain('limit=');
     expect(url).toContain('sinceMinutes=1440');
     expect((init as RequestInit).signal).toBe(controller.signal);
 
     mockCustomFetch.mockClear();
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)] }));
-    await fetchAiAppLogs('a1', 'build');
+    await fetchAiAppLogsPage('a1', 'build');
     expect(mockCustomFetch.mock.calls[0][0]).not.toContain('sinceMinutes');
   });
 
   it('URL-encodes tokens with reserved characters', async () => {
-    mockCustomFetch
-      .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'a/b+c' }))
-      .mockResolvedValueOnce(jsonResponse(200, { events: [event(1)] }));
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1)] }));
 
-    await fetchAiAppLogs('a1', 'build');
-    expect(mockCustomFetch.mock.calls[1][0]).toContain('nextToken=a%2Fb%2Bc');
+    await fetchAiAppLogsPage('a1', 'build', { nextToken: 'a/b+c' });
+    expect(mockCustomFetch.mock.calls[0][0]).toContain('nextToken=a%2Fb%2Bc');
   });
 });

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -155,7 +155,7 @@ describe('fetchAiAppLogs', () => {
 
     await fetchAiAppLogs('a1', 'runtime', { signal: controller.signal, sinceMinutes: 1440 });
     const [url, init] = mockCustomFetch.mock.calls[0];
-    expect(url).toContain('/a1/logs/runtime?');
+    expect(url).toContain('/a1/runtime-logs?');
     expect(url).toContain('limit=2000');
     expect(url).toContain('sinceMinutes=1440');
     expect((init as RequestInit).signal).toBe(controller.signal);

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -61,6 +61,21 @@ describe('fetchAiAppLogsPage', () => {
     expect(page.events.map((e) => e.timestamp)).toEqual([30, 20, 10]);
   });
 
+  it('sorts newest-first even when the runner sends string timestamps (seen in the wild)', async () => {
+    mockCustomFetch.mockResolvedValue(
+      jsonResponse(200, {
+        events: [
+          { timestamp: '2026-07-23T07:30:54.000Z', message: 'older iso' },
+          { timestamp: '2026-07-23T07:31:01.000Z', message: 'newer iso' },
+          { timestamp: '1784791899999', message: 'numeric string, newest' },
+        ],
+      }),
+    );
+
+    const page = await fetchAiAppLogsPage('a1', 'runtime');
+    expect(page.events.map((e) => e.message)).toEqual(['numeric string, newest', 'newer iso', 'older iso']);
+  });
+
   it('treats a repeated nextToken on an empty page as end-of-stream (CloudWatch never nulls it)', async () => {
     mockCustomFetch
       .mockResolvedValueOnce(jsonResponse(200, { events: [], nextToken: 'tok' }))

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -175,6 +175,7 @@ describe('fetchAiAppLogsPage', () => {
     await fetchAiAppLogsPage('a1', 'runtime', { signal: controller.signal, sinceMinutes: 1440 });
     const [url, init] = mockCustomFetch.mock.calls[0];
     expect(url).toContain('/a1/runtime-logs?');
+    expect(url).toContain('order=desc');
     expect(url).toContain('limit=');
     expect(url).toContain('sinceMinutes=1440');
     expect((init as RequestInit).signal).toBe(controller.signal);

--- a/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.service.test.ts
@@ -32,7 +32,7 @@ describe('fetchAiAppLogsPage', () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(1), event(2)] }));
 
     await expect(fetchAiAppLogsPage('a1', 'build')).resolves.toEqual({
-      events: [event(1), event(2)],
+      events: [event(2), event(1)],
       nextToken: undefined,
     });
     expect(mockCustomFetch).toHaveBeenCalledTimes(1);
@@ -54,11 +54,11 @@ describe('fetchAiAppLogsPage', () => {
     expect(mockCustomFetch.mock.calls[0][0]).toContain('nextToken=cursor-1');
   });
 
-  it('sorts events ascending by timestamp regardless of server order', async () => {
+  it('sorts events newest-first by timestamp regardless of server order', async () => {
     mockCustomFetch.mockResolvedValue(jsonResponse(200, { events: [event(30), event(10), event(20)] }));
 
     const page = await fetchAiAppLogsPage('a1', 'runtime');
-    expect(page.events.map((e) => e.timestamp)).toEqual([10, 20, 30]);
+    expect(page.events.map((e) => e.timestamp)).toEqual([30, 20, 10]);
   });
 
   it('treats a repeated nextToken on an empty page as end-of-stream (CloudWatch never nulls it)', async () => {
@@ -150,7 +150,7 @@ describe('fetchAiAppLogsPage', () => {
     );
 
     const page = await fetchAiAppLogsPage('a1', 'build');
-    expect(page.events).toEqual([event(1), event(3)]);
+    expect(page.events).toEqual([event(3), event(1)]);
   });
 
   it('sends limit always, sinceMinutes only when provided, and passes the signal through', async () => {

--- a/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
@@ -1,0 +1,64 @@
+import { deriveLogLevel, formatLogTimestamp, stripLogControlSequences } from '@/services/ai-apps/ai-apps-logs.utils';
+
+describe('deriveLogLevel', () => {
+  it.each([
+    ['ERROR: build failed', 'error'],
+    ['npm ERR! fatal: not a git repository', 'error'],
+    ['Unhandled exception in worker', 'error'],
+    ['panic: runtime error', 'error'],
+    ['warning: deprecated API', 'warn'],
+    ['WARN memory usage high', 'warn'],
+  ] as const)('flags %j as %s', (message, level) => {
+    expect(deriveLogLevel(message)).toBe(level);
+  });
+
+  it.each([
+    'compiled with 0 errors', // plural — whole-word match must not fire
+    'no warnings emitted',
+    'transferring context',
+    'stderr attached', // "err" inside a word
+  ])('leaves %j unmarked', (message) => {
+    expect(deriveLogLevel(message)).toBeNull();
+  });
+
+  it('prefers error over warn when a line contains both', () => {
+    expect(deriveLogLevel('warning escalated to error')).toBe('error');
+  });
+});
+
+describe('formatLogTimestamp', () => {
+  it('formats epoch milliseconds as local "MMM d HH:mm:ss"', () => {
+    expect(formatLogTimestamp(Date.UTC(2026, 6, 23, 12, 0, 5))).toMatch(/^[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('formats a parseable ISO string', () => {
+    expect(formatLogTimestamp('2026-07-23T12:00:05Z')).toMatch(/^[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it.each([
+    [NaN, 'NaN'],
+    ['not a date', 'not a date'],
+    [null, ''],
+    [undefined, ''],
+  ])('renders the raw value for unparseable input %j — never "Invalid Date"', (input, expected) => {
+    expect(formatLogTimestamp(input)).toBe(expected);
+  });
+});
+
+describe('stripLogControlSequences', () => {
+  it('removes ANSI color and cursor sequences', () => {
+    expect(stripLogControlSequences('\u001B[31mERROR\u001B[0m done \u001B[2K')).toBe('ERROR done ');
+  });
+
+  it('removes C0 controls and DEL but keeps tabs', () => {
+    expect(stripLogControlSequences('a\u0007b\tc\u007Fd')).toBe('ab\tcd');
+  });
+
+  it('removes bidi and zero-width characters that can spoof copied text', () => {
+    expect(stripLogControlSequences('safe\u202Egnp.exe\u200B')).toBe('safegnp.exe');
+  });
+
+  it('leaves ordinary text untouched', () => {
+    expect(stripLogControlSequences('Step 1/5 : FROM node:20')).toBe('Step 1/5 : FROM node:20');
+  });
+});

--- a/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
@@ -1,6 +1,7 @@
 import {
   deriveLogLevel,
   formatLogTimestamp,
+  logTimestampSortValue,
   stripCriLogPrefix,
   stripLogControlSequences,
 } from '@/services/ai-apps/ai-apps-logs.utils';
@@ -65,6 +66,20 @@ describe('stripLogControlSequences', () => {
 
   it('leaves ordinary text untouched', () => {
     expect(stripLogControlSequences('Step 1/5 : FROM node:20')).toBe('Step 1/5 : FROM node:20');
+  });
+});
+
+describe('logTimestampSortValue', () => {
+  it.each([
+    [1784791854487, 1784791854487],
+    ['2026-07-23T07:30:54.000Z', Date.parse('2026-07-23T07:30:54.000Z')],
+    ['1784791854487', 1784791854487],
+    ['not a date', 0],
+    [NaN, 0],
+    [null, 0],
+    [undefined, 0],
+  ])('maps %j to %d', (input, expected) => {
+    expect(logTimestampSortValue(input)).toBe(expected);
   });
 });
 

--- a/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
+++ b/__tests__/services/ai-apps/ai-apps-logs.utils.test.ts
@@ -1,4 +1,9 @@
-import { deriveLogLevel, formatLogTimestamp, stripLogControlSequences } from '@/services/ai-apps/ai-apps-logs.utils';
+import {
+  deriveLogLevel,
+  formatLogTimestamp,
+  stripCriLogPrefix,
+  stripLogControlSequences,
+} from '@/services/ai-apps/ai-apps-logs.utils';
 
 describe('deriveLogLevel', () => {
   it.each([
@@ -60,5 +65,20 @@ describe('stripLogControlSequences', () => {
 
   it('leaves ordinary text untouched', () => {
     expect(stripLogControlSequences('Step 1/5 : FROM node:20')).toBe('Step 1/5 : FROM node:20');
+  });
+});
+
+describe('stripCriLogPrefix', () => {
+  it('removes the Kubernetes CRI framing (timestamp, stream, tag)', () => {
+    expect(stripCriLogPrefix('2026-07-23T14:24:23.877622179Z stdout F Server listening at http://127.0.0.1:3001')).toBe(
+      'Server listening at http://127.0.0.1:3001',
+    );
+    expect(stripCriLogPrefix('2026-07-23T14:24:23.037076488Z stderr P partial line')).toBe('partial line');
+  });
+
+  it('leaves lines without the exact framing untouched', () => {
+    expect(stripCriLogPrefix('Step 1/5 : FROM node:20')).toBe('Step 1/5 : FROM node:20');
+    expect(stripCriLogPrefix('2026-07-23 something stdout-ish')).toBe('2026-07-23 something stdout-ish');
+    expect(stripCriLogPrefix('stdout F no leading timestamp')).toBe('stdout F no leading timestamp');
   });
 });

--- a/analytics/ai-apps.analytics.ts
+++ b/analytics/ai-apps.analytics.ts
@@ -71,6 +71,14 @@ export function useAiAppsAnalytics() {
     onEditDetailsFailed: (appUid: string) => capture(AI_APPS_ANALYTICS.EDIT_DETAILS_FAILED, { appUid }),
     onDeploymentSettingsOpened: (params: { appUid: string; isDraft: boolean }) =>
       capture(AI_APPS_ANALYTICS.DEPLOYMENT_SETTINGS_OPENED, params),
+    // Logs events carry uids/streams/counts ONLY — never log message text or
+    // search queries, which can contain secrets and member PII.
+    onDeploymentLogsOpened: (appUid: string, appName: string, source: 'menu' | 'failure-strip') =>
+      capture(AI_APPS_ANALYTICS.DEPLOYMENT_LOGS_OPENED, { appUid, appName, source }),
+    onDeploymentLogsTabSwitched: (appUid: string, stream: 'build' | 'runtime') =>
+      capture(AI_APPS_ANALYTICS.DEPLOYMENT_LOGS_TAB_SWITCHED, { appUid, stream }),
+    onDeploymentLogsExported: (appUid: string, stream: 'build' | 'runtime', rowCount: number) =>
+      capture(AI_APPS_ANALYTICS.DEPLOYMENT_LOGS_EXPORTED, { appUid, stream, rowCount }),
     onDeleteAppOpened: (appUid: string, appName: string) =>
       capture(AI_APPS_ANALYTICS.DELETE_APP_OPENED, { appUid, appName }),
     onDeleteAppCancelled: (appUid: string, appName: string) =>

--- a/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/AiAppDetailPage.tsx
@@ -14,6 +14,7 @@ import { AppActionsMenu } from '@/components/page/ai-apps/AiAppsPage/components/
 import {
   EditAiAppModal,
   DeploymentSettingsModal,
+  DeploymentLogsModal,
   DeleteAiAppDialog,
   AiAppDetailsModal,
 } from '@/components/page/ai-apps/dynamicActionModals';
@@ -27,7 +28,7 @@ interface Props {
   uid: string;
 }
 
-type Action = 'edit' | 'deployment' | 'delete';
+type Action = 'edit' | 'deployment' | 'logs' | 'delete';
 
 const SETUP_STATUS_LABELS: Record<string, string> = {
   DRAFT: 'Draft',
@@ -321,6 +322,10 @@ export function AiAppDetailPage(props: Props) {
               app={app}
               onEdit={() => setAction('edit')}
               onDeployment={() => setAction('deployment')}
+              onLogs={() => {
+                analytics.onDeploymentLogsOpened(app.uid, app.name, 'menu');
+                setAction('logs');
+              }}
               onDelete={() => setAction('delete')}
             />
           )}
@@ -341,6 +346,9 @@ export function AiAppDetailPage(props: Props) {
       {action === 'deployment' && (
         <DeploymentSettingsModal app={app} onClose={closeAction} onDeployingChange={setIsRedeploying} />
       )}
+      {/* Conditional render is load-bearing: unmounting on close aborts the
+          modal's in-flight log fetches (its queryFn consumes the signal). */}
+      {action === 'logs' && <DeploymentLogsModal app={app} onClose={closeAction} />}
       {action === 'delete' && (
         <DeleteAiAppDialog
           app={app}

--- a/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
+++ b/components/page/ai-apps/AiAppDetailPage/components/AppSecretsPanel/AppSecretsPanel.tsx
@@ -115,6 +115,10 @@ export function AppSecretsPanel(props: Props) {
     // Refresh in both outcomes — a failed deploy still changes the app status/notes.
     // Do it before clearing the deploying flag so the parent swaps back to the
     // iframe only once the refreshed record (fresh updatedAt) is in the cache.
+    // Logs are dropped in both outcomes too: whether the deploy shipped or
+    // failed, the interesting log lines are the new attempt's, never a cached
+    // snapshot of the previous one.
+    queryClient.removeQueries({ queryKey: [AiAppsQueryKeys.AI_APP_LOGS, app.uid] });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: [AiAppsQueryKeys.AI_APP_DETAIL, app.uid] }),
       queryClient.invalidateQueries({ queryKey: [AiAppsQueryKeys.AI_APPS_LIST] }),

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
@@ -10,6 +10,7 @@ import { hasPrd } from '@/services/ai-apps/ai-apps.service';
 import {
   EditAiAppModal,
   DeploymentSettingsModal,
+  DeploymentLogsModal,
   DeleteAiAppDialog,
   AiAppDetailsModal,
 } from '@/components/page/ai-apps/dynamicActionModals';
@@ -21,7 +22,7 @@ import { AiAppCard } from './components/AiAppCard';
 
 import s from './AiAppsGrid.module.scss';
 
-type ActionType = 'edit' | 'deployment' | 'delete';
+type ActionType = 'edit' | 'deployment' | 'logs' | 'delete';
 
 interface Props {
   onOpenCreateModal: () => void;
@@ -61,6 +62,11 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
     setViewerUid(uid);
   };
 
+  const openLogs = (app: (typeof apps)[number], source: 'menu' | 'failure-strip') => {
+    analytics.onDeploymentLogsOpened(app.uid, app.name, source);
+    setAction({ uid: app.uid, type: 'logs' });
+  };
+
   return (
     <>
       <motion.div className={s.grid} variants={containerVariants} initial="hidden" animate="show">
@@ -74,6 +80,7 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
               canManage={canLikelyManage(app.member.uid)}
               onEdit={() => setAction({ uid: app.uid, type: 'edit' })}
               onDeployment={() => setAction({ uid: app.uid, type: 'deployment' })}
+              onLogs={(source) => openLogs(app, source)}
               onDelete={() => setAction({ uid: app.uid, type: 'delete' })}
               onViewDetails={() => openViewer(app.uid, app.name)}
             />
@@ -85,6 +92,9 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
       {actionApp && action?.type === 'deployment' && (
         <DeploymentSettingsModal app={actionApp} onClose={closeAction} />
       )}
+      {/* Conditional render is load-bearing: unmounting on close is what aborts
+          the modal's in-flight log fetches (its queryFn consumes the signal). */}
+      {actionApp && action?.type === 'logs' && <DeploymentLogsModal app={actionApp} onClose={closeAction} />}
       {actionApp && action?.type === 'delete' && <DeleteAiAppDialog app={actionApp} onClose={closeAction} />}
       {viewerApp && hasPrd(viewerApp) && (
         <AiAppDetailsModal

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/AiAppsGrid.tsx
@@ -53,8 +53,8 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
   const addCardVariants = getAddCardVariants();
   const cardVariants = getCardVariants(!!shouldReduceMotion);
 
-  const actionApp = action ? apps.find((app) => app.uid === action.uid) ?? null : null;
-  const viewerApp = viewerUid ? apps.find((app) => app.uid === viewerUid) ?? null : null;
+  const actionApp = action ? (apps.find((app) => app.uid === action.uid) ?? null) : null;
+  const viewerApp = viewerUid ? (apps.find((app) => app.uid === viewerUid) ?? null) : null;
   const closeAction = () => setAction(null);
 
   const openViewer = (uid: string, name: string) => {
@@ -89,9 +89,7 @@ export function AiAppsGrid({ onOpenCreateModal }: Props) {
       </motion.div>
 
       {actionApp && action?.type === 'edit' && <EditAiAppModal app={actionApp} onClose={closeAction} />}
-      {actionApp && action?.type === 'deployment' && (
-        <DeploymentSettingsModal app={actionApp} onClose={closeAction} />
-      )}
+      {actionApp && action?.type === 'deployment' && <DeploymentSettingsModal app={actionApp} onClose={closeAction} />}
       {/* Conditional render is load-bearing: unmounting on close is what aborts
           the modal's in-flight log fetches (its queryFn consumes the signal). */}
       {actionApp && action?.type === 'logs' && <DeploymentLogsModal app={actionApp} onClose={closeAction} />}

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
@@ -205,12 +205,6 @@
   color: #92400e;
 }
 
-.errorBadge {
-  @extend .draftBadge;
-  background: #fef2f2;
-  color: #b91c1c;
-}
-
 .deployingBadge {
   @extend .draftBadge;
   background: #eff6ff;

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.module.scss
@@ -64,6 +64,64 @@
   z-index: 2;
 }
 
+// Failure notice across the card's top edge — full-bleed via negative margins
+// against .root's 24px padding. A sibling of the card's <Link>/<button> (its
+// "See logs" button must not nest inside them), floated above the stretched
+// link so the button stays clickable.
+.failStrip {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 28px;
+  margin: -24px -24px 0;
+  padding: 0 24px;
+  border-radius: 12px 12px 0 0;
+  background: #fef2f2;
+}
+
+.failStripLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  color: #b91c1c;
+
+  // The badge's dot, kept so severity isn't carried by color alone at a glance.
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+}
+
+.seeLogsButton {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  color: var(--foreground-brand-primary, #1b4dff);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+// The strip adds a 28px row + the root's 16px gap above the name row, so the
+// ⋯ menu drops by (28 + 16 - 24 + 26) to stay centered on the name line.
+.rootWithStrip .actionSlot {
+  top: 46px;
+}
+
 // Reserve room for the creator's ⋯ menu so long names ellipsize instead of
 // sliding under it. (Visitors have no corner action — the name gets full width.)
 .nameRowMenu {

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
@@ -7,6 +7,7 @@ import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { DocumentIcon } from '@/components/icons';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { AiApp, hasPrd } from '@/services/ai-apps/ai-apps.service';
+import { AI_APPS_LOGS_ENABLED } from '@/utils/feature-flags';
 
 import { AppActionsMenu } from '../../../AppActionsMenu';
 
@@ -24,12 +25,14 @@ interface Props {
   onEdit?: () => void;
   onDeployment?: () => void;
   onDelete?: () => void;
+  /** Open the deployment-logs modal; `source` says which affordance was used. */
+  onLogs?: (source: 'menu' | 'failure-strip') => void;
   /** Open the public App Details (one-pager) viewer. Shown to every viewer when a one-pager exists. */
   onViewDetails?: () => void;
 }
 
 export function AiAppCard(props: Props) {
-  const { app, onSelect, canManage, onEdit, onDeployment, onDelete, onViewDetails } = props;
+  const { app, onSelect, canManage, onEdit, onDeployment, onDelete, onLogs, onViewDetails } = props;
   const analytics = useAiAppsAnalytics();
 
   const handleAuthorClick = (e: MouseEvent) => {
@@ -47,6 +50,10 @@ export function AiAppCard(props: Props) {
 
   const showManageMenu = !!canManage && !!onEdit && !!onDeployment && !!onDelete;
   const showDetailsButton = !!onViewDetails && hasPrd(app);
+  // The strip replaces the inline errorBadge — never both. Everyone sees the
+  // strip (same information the badge carried); only managers get its link.
+  const showFailureStrip = hasDeployFailed && AI_APPS_LOGS_ENABLED;
+  const showSeeLogs = showFailureStrip && !!canManage && !!onLogs;
 
   const body = (
     <>
@@ -54,11 +61,25 @@ export function AiAppCard(props: Props) {
       <div className={clsx(s.nameRow, { [s.nameRowMenu]: showManageMenu })}>
         <h3 className={s.name}>{app.name}</h3>
         {isDraft && <span className={s.draftBadge}>Draft</span>}
-        {hasDeployFailed && <span className={s.errorBadge}>Deploy failed</span>}
+        {hasDeployFailed && !showFailureStrip && <span className={s.errorBadge}>Deploy failed</span>}
         {isDeploying && <span className={s.deployingBadge}>Deploying</span>}
       </div>
       <p className={s.description}>{app.description}</p>
     </>
+  );
+
+  // A direct child of .root, never nested in the card's <Link>/<button> —
+  // link-inside-link is invalid HTML and breaks keyboard/SR semantics. It sits
+  // above the stretched-link overlay like .actionSlot does.
+  const failureStrip = showFailureStrip && (
+    <div className={s.failStrip}>
+      <span className={s.failStripLabel}>Deploy failed</span>
+      {showSeeLogs && (
+        <button type="button" className={s.seeLogsButton} onClick={() => onLogs('failure-strip')}>
+          See logs
+        </button>
+      )}
+    </div>
   );
 
   const footer = (
@@ -111,13 +132,20 @@ export function AiAppCard(props: Props) {
 
   const actionSlot = showManageMenu && (
     <div className={s.actionSlot}>
-      <AppActionsMenu app={app} onEdit={onEdit} onDeployment={onDeployment} onDelete={onDelete} />
+      <AppActionsMenu
+        app={app}
+        onEdit={onEdit}
+        onDeployment={onDeployment}
+        onLogs={() => onLogs?.('menu')}
+        onDelete={onDelete}
+      />
     </div>
   );
 
   if (onSelect) {
     return (
-      <article className={s.root}>
+      <article className={clsx(s.root, { [s.rootWithStrip]: showFailureStrip })}>
+        {failureStrip}
         <button
           type="button"
           className={s.selectButton}
@@ -135,7 +163,8 @@ export function AiAppCard(props: Props) {
   }
 
   return (
-    <article className={s.root}>
+    <article className={clsx(s.root, { [s.rootWithStrip]: showFailureStrip })}>
+      {failureStrip}
       {/* stretchedLink expands the hit area to the whole card (the card can't BE
           the link — the footer holds a nested author link). */}
       <Link href={`/pl-infra/ai-apps/${app.uid}`} className={clsx(s.body, s.stretchedLink)} onClick={handleCardClick}>

--- a/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AiAppsGrid/components/AiAppCard/AiAppCard.tsx
@@ -7,7 +7,6 @@ import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { DocumentIcon } from '@/components/icons';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { AiApp, hasPrd } from '@/services/ai-apps/ai-apps.service';
-import { AI_APPS_LOGS_ENABLED } from '@/utils/feature-flags';
 
 import { AppActionsMenu } from '../../../AppActionsMenu';
 
@@ -50,9 +49,9 @@ export function AiAppCard(props: Props) {
 
   const showManageMenu = !!canManage && !!onEdit && !!onDeployment && !!onDelete;
   const showDetailsButton = !!onViewDetails && hasPrd(app);
-  // The strip replaces the inline errorBadge — never both. Everyone sees the
-  // strip (same information the badge carried); only managers get its link.
-  const showFailureStrip = hasDeployFailed && AI_APPS_LOGS_ENABLED;
+  // The strip took over the old inline "Deploy failed" badge's job — everyone
+  // sees it; only managers get its "See logs" link.
+  const showFailureStrip = hasDeployFailed;
   const showSeeLogs = showFailureStrip && !!canManage && !!onLogs;
 
   const body = (
@@ -61,7 +60,6 @@ export function AiAppCard(props: Props) {
       <div className={clsx(s.nameRow, { [s.nameRowMenu]: showManageMenu })}>
         <h3 className={s.name}>{app.name}</h3>
         {isDraft && <span className={s.draftBadge}>Draft</span>}
-        {hasDeployFailed && !showFailureStrip && <span className={s.errorBadge}>Deploy failed</span>}
         {isDeploying && <span className={s.deployingBadge}>Deploying</span>}
       </div>
       <p className={s.description}>{app.description}</p>

--- a/components/page/ai-apps/AiAppsPage/components/AppActionsMenu/AppActionsMenu.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AppActionsMenu/AppActionsMenu.tsx
@@ -7,7 +7,6 @@ import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { MenuIcon } from '@/components/icons';
 import { AiApp } from '@/services/ai-apps/ai-apps.service';
 import { useAiApp } from '@/services/ai-apps/hooks/useAiApp';
-import { AI_APPS_LOGS_ENABLED } from '@/utils/feature-flags';
 
 import s from './AppActionsMenu.module.scss';
 
@@ -36,10 +35,9 @@ export function AppActionsMenu({ app, onEdit, onDeployment, onLogs, onDelete }: 
   const analytics = useAiAppsAnalytics();
   const [isOpen, setIsOpen] = useState(false);
 
-  // Gated here, not in the parents, so grid and detail page can't drift: a
-  // DRAFT has never built, so it has no logs to show; the flag stays off until
-  // the backend accepts owner/admin tokens on the logs endpoints.
-  const showLogsItem = AI_APPS_LOGS_ENABLED && app.status !== 'DRAFT';
+  // Gated here, not in the parents, so grid and detail page can't drift:
+  // a DRAFT has never built, so it has no logs to show.
+  const showLogsItem = app.status !== 'DRAFT';
 
   const { app: detail, errorKind } = useAiApp(app.uid, { enabled: isOpen });
 

--- a/components/page/ai-apps/AiAppsPage/components/AppActionsMenu/AppActionsMenu.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/AppActionsMenu/AppActionsMenu.tsx
@@ -7,6 +7,7 @@ import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { MenuIcon } from '@/components/icons';
 import { AiApp } from '@/services/ai-apps/ai-apps.service';
 import { useAiApp } from '@/services/ai-apps/hooks/useAiApp';
+import { AI_APPS_LOGS_ENABLED } from '@/utils/feature-flags';
 
 import s from './AppActionsMenu.module.scss';
 
@@ -16,6 +17,8 @@ interface Props {
   onEdit: () => void;
   /** Called when "Deployment settings" is chosen. */
   onDeployment: () => void;
+  /** Called when "Deployment logs" is chosen. */
+  onLogs: () => void;
   /** Called when "Delete app" is chosen. */
   onDelete: () => void;
 }
@@ -29,9 +32,14 @@ interface Props {
  * entirely; a failed check only degrades to disabled items — it must never
  * yank the menu out from under the pointer.
  */
-export function AppActionsMenu({ app, onEdit, onDeployment, onDelete }: Props) {
+export function AppActionsMenu({ app, onEdit, onDeployment, onLogs, onDelete }: Props) {
   const analytics = useAiAppsAnalytics();
   const [isOpen, setIsOpen] = useState(false);
+
+  // Gated here, not in the parents, so grid and detail page can't drift: a
+  // DRAFT has never built, so it has no logs to show; the flag stays off until
+  // the backend accepts owner/admin tokens on the logs endpoints.
+  const showLogsItem = AI_APPS_LOGS_ENABLED && app.status !== 'DRAFT';
 
   const { app: detail, errorKind } = useAiApp(app.uid, { enabled: isOpen });
 
@@ -69,6 +77,11 @@ export function AppActionsMenu({ app, onEdit, onDeployment, onDelete }: Props) {
             <Menu.Item className={s.item} disabled={verifying} onClick={onDeployment}>
               Deployment settings
             </Menu.Item>
+            {showLogsItem && (
+              <Menu.Item className={s.item} disabled={verifying} onClick={onLogs}>
+                Deployment logs
+              </Menu.Item>
+            )}
             <div className={s.divider} role="separator" />
             <Menu.Item className={`${s.item} ${s.destructive}`} disabled={verifying} onClick={onDelete}>
               Delete app

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
@@ -197,15 +197,15 @@
   color: var(--foreground-brand-primary, #1b4dff);
 }
 
-.pane {
+/* Table transcribed from the prototype (prototypes/entries/ai-apps/
+   DeploymentLogsModal.module.scss) — literal values kept, full-bleed against
+   the panel's 24px padding. */
+.tableWrap {
   flex: 1;
   min-height: 200px;
-  overflow-y: auto;
-  padding: 8px 12px;
-  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
-  border-radius: 8px;
-  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
-  font-family: 'SF Mono', 'Roboto Mono', ui-monospace, monospace;
+  overflow: auto;
+  margin: 0 -24px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
 
   &:focus-visible {
     outline: 2px solid var(--foreground-brand-primary, #1b4dff);
@@ -213,59 +213,123 @@
   }
 }
 
-.line {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  justify-content: space-between;
-  padding: 2px 0;
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 10px 24px;
+    background: #ffffff;
+    border-bottom: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+    font-size: 13px;
+    line-height: 20px;
+    font-weight: 500;
+    color: var(--foreground-neutral-secondary, #455468);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 10px 24px;
+    border-bottom: 1px solid rgba(27, 56, 96, 0.06);
+    font-size: 14px;
+    line-height: 22px;
+    vertical-align: top;
+  }
+
+  tbody tr:hover td {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+
+  // Message takes all the slack; the timestamp is a fixed, right-aligned rail.
+  th:last-child,
+  td:last-child {
+    width: 156px;
+  }
 }
 
-.message {
-  min-width: 0;
-  font-size: 12px;
-  line-height: 18px;
-  color: var(--foreground-neutral-primary, #0a0c11);
+.messageCell {
+  color: var(--foreground-neutral-secondary, #455468);
   overflow-wrap: anywhere;
-  white-space: pre-wrap;
-
-  &[data-level='error'] {
-    color: var(--foreground-danger-primary, #d92d20);
-  }
-
-  &[data-level='warn'] {
-    color: var(--foreground-warning-primary, #b54708);
-  }
 }
 
+.messageText {
+  color: inherit;
+  white-space: pre-wrap;
+}
+
+// Only warnings and errors get a marker — quiet rows stay quiet, so the things
+// worth noticing are the only things that interrupt the scan.
 .levelDot {
   display: inline-block;
   width: 6px;
   height: 6px;
-  margin-right: 6px;
+  margin-right: 8px;
   border-radius: 50%;
-  background: currentColor;
-  vertical-align: middle;
+  vertical-align: 0.15em;
+  background: var(--foreground-neutral-tertiary, #8897ae);
 }
 
-/* Dimmed, fixed-width, never wrapping — the message is the content, the time is context. */
-.time {
-  flex-shrink: 0;
-  font-size: 11px;
-  line-height: 18px;
-  color: var(--foreground-neutral-tertiary, #8897ae);
-  font-variant-numeric: tabular-nums;
+.timeCell {
+  display: flex;
+  gap: 8px;
   white-space: nowrap;
+  // Fixed-width digits so timestamps align down the column — the reason to
+  // reach for monospace, without the second typeface.
+  font-variant-numeric: tabular-nums;
+}
+
+.date {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.time {
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+/* Level accents — success needs none; a clean line is the expected case. */
+.warn {
+  .levelDot {
+    background: var(--foreground-warning-primary, #b45309);
+  }
+
+  .messageCell {
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+}
+
+.error {
+  td {
+    background: rgba(210, 26, 14, 0.04);
+  }
+
+  .levelDot {
+    background: var(--foreground-error-primary, #d21a0e);
+  }
+
+  .messageCell {
+    color: var(--foreground-neutral-primary, #0a0c11);
+    font-weight: 500;
+  }
 }
 
 .skeleton {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   min-height: 200px;
-  padding: 14px 12px;
-  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
-  border-radius: 8px;
+  margin: 0 -24px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
 }
 
 .skeletonRow {
@@ -281,9 +345,9 @@
   gap: 10px;
   min-height: 200px;
   justify-content: center;
-  padding: 24px;
-  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
-  border-radius: 8px;
+  margin: 0 -24px;
+  padding: 32px 24px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
   text-align: center;
 }
 
@@ -308,15 +372,19 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  margin-top: 12px;
-  padding: 16px 24px;
+  padding: 14px 24px;
   border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
 }
 
 .count {
-  font-size: 12px;
-  line-height: 18px;
+  font-size: 13px;
+  line-height: 20px;
   color: var(--foreground-neutral-tertiary, #8897ae);
+
+  strong {
+    font-weight: 600;
+    color: var(--foreground-neutral-secondary, #455468);
+  }
 }
 
 .srOnly {
@@ -341,6 +409,23 @@
   .panel,
   .footer {
     padding-inline: 16px;
+  }
+
+  // Full-bleed pieces track the panel's narrower mobile padding.
+  .tableWrap,
+  .skeleton,
+  .stateBlock {
+    margin: 0 -16px;
+  }
+
+  .table th,
+  .table td {
+    padding-inline: 16px;
+  }
+
+  .table th:last-child,
+  .table td:last-child {
+    width: auto;
   }
 
   .toolbar {

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
@@ -1,0 +1,359 @@
+.modal {
+  width: 100%;
+  max-width: 820px;
+}
+
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-height: 85vh;
+  overflow: hidden;
+  border: 1px solid rgba(27, 56, 96, 0.06);
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 4px 24px rgba(14, 15, 17, 0.08);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.appName {
+  overflow: hidden;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-secondary, #455468);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status {
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 16px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.statusLive {
+  color: var(--foreground-success-primary, #0a9952);
+  background: var(--background-success-subtle, rgba(10, 153, 82, 0.08));
+}
+
+.statusFailed {
+  color: var(--foreground-danger-primary, #d92d20);
+  background: var(--background-danger-subtle, rgba(217, 45, 32, 0.08));
+}
+
+.statusDeploying {
+  color: var(--foreground-brand-primary, #1b4dff);
+  background: var(--background-brand-subtle, rgba(27, 77, 255, 0.08));
+}
+
+.close {
+  display: flex;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 24px 0;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px 10px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
+
+  &[data-active='true'] {
+    border-bottom-color: var(--foreground-brand-primary, #1b4dff);
+    color: var(--foreground-neutral-primary, #0a0c11);
+    font-weight: 600;
+  }
+}
+
+.tabCount {
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  font-size: 11px;
+  line-height: 16px;
+  font-weight: 600;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.streamNote {
+  margin-left: auto;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.panel {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  padding: 12px 24px 0;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 12px;
+}
+
+.search {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 12px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+
+  &:focus-visible {
+    border-color: var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+    outline: none;
+  }
+}
+
+.toolBtn {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+  background: none;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.deployingNote {
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-brand-primary, #1b4dff);
+}
+
+.pane {
+  flex: 1;
+  min-height: 200px;
+  overflow-y: auto;
+  padding: 8px 12px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  font-family: 'SF Mono', 'Roboto Mono', ui-monospace, monospace;
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: -2px;
+  }
+}
+
+.line {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 2px 0;
+}
+
+.message {
+  min-width: 0;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+
+  &[data-level='error'] {
+    color: var(--foreground-danger-primary, #d92d20);
+  }
+
+  &[data-level='warn'] {
+    color: var(--foreground-warning-primary, #b54708);
+  }
+}
+
+.levelDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  vertical-align: middle;
+}
+
+/* Dimmed, fixed-width, never wrapping — the message is the content, the time is context. */
+.time {
+  flex-shrink: 0;
+  font-size: 11px;
+  line-height: 18px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 200px;
+  padding: 14px 12px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+}
+
+.skeletonRow {
+  height: 12px;
+  border-radius: 4px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+}
+
+.stateBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-height: 200px;
+  justify-content: center;
+  padding: 24px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 8px;
+  text-align: center;
+}
+
+.stateTitle {
+  margin: 0;
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: 600;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.stateText {
+  margin: 0;
+  max-width: 380px;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+}
+
+.count {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+@media (max-width: 639px) {
+  .modal {
+    max-width: 100%;
+  }
+
+  .header,
+  .tabs,
+  .panel,
+  .footer {
+    padding-inline: 16px;
+  }
+
+  .toolbar {
+    flex-wrap: wrap;
+  }
+
+  .search {
+    flex-basis: 100%;
+  }
+
+  .footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+    text-align: center;
+  }
+}

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.module.scss
@@ -296,6 +296,41 @@
   color: var(--foreground-neutral-primary, #0a0c11);
 }
 
+/* The infinite-scroll sentinel row: crossing it auto-loads the next page; the
+   button is the keyboard / no-IntersectionObserver fallback. */
+.loadMoreRow td {
+  padding: 12px 24px;
+  text-align: center;
+  border-bottom: none;
+}
+
+.loadMoreBtn {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  color: var(--foreground-brand-primary, #1b4dff);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.loadMoreHint {
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.loadMoreFailed {
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
 /* Level accents — success needs none; a clean line is the expected case. */
 .warn {
   .levelDot {

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -221,21 +221,25 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
 
   // The last row: InfiniteScroll auto-loads as the reader nears it; the
   // button is the keyboard fallback, and Retry takes over on a failed page.
+  // Against a backend that ignored order=desc (pagesNewestFirst false) the
+  // labels drop the "earlier" claim — forward pages actually bring newer
+  // lines — and only the manual button remains.
+  const loadMoreLabel = active.pagesNewestFirst ? 'Load earlier logs' : 'Load more logs';
   const loadMoreRow = active.hasMore && !query.trim() && (
     <tr className={s.loadMoreRow}>
       <td colSpan={2}>
         {active.loadMoreFailed ? (
           <span className={s.loadMoreFailed}>
-            Couldn’t load earlier lines.{' '}
+            Couldn’t load more lines.{' '}
             <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
               Retry
             </button>
           </span>
         ) : active.isLoadingMore ? (
-          <span className={s.loadMoreHint}>Loading earlier logs…</span>
+          <span className={s.loadMoreHint}>Loading…</span>
         ) : (
           <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
-            Load earlier logs
+            {loadMoreLabel}
           </button>
         )}
       </td>
@@ -295,7 +299,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <div className={s.stateBlock}>
           <p className={s.stateTitle}>No lines in this part of the log yet.</p>
           <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
-            {active.isLoadingMore ? 'Loading…' : 'Load earlier logs'}
+            {active.isLoadingMore ? 'Loading…' : loadMoreLabel}
           </Button>
         </div>
       );
@@ -328,7 +332,11 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <InfiniteScroll
           scrollableTarget="deployment-logs-scroll"
           dataLength={filtered.length}
-          hasMore={active.hasMore && !query.trim() && !active.loadMoreFailed}
+          // pagesNewestFirst guards against a backend without order=desc: it
+          // ignores the param and serves forward pages, where scroll-loading
+          // chain-fetches (appends land above the reader and the bottom
+          // trigger never releases). Manual paging only in that case.
+          hasMore={active.hasMore && active.pagesNewestFirst && !query.trim() && !active.loadMoreFailed}
           next={active.loadMore}
           loader={null}
           style={{ overflow: 'unset' }}
@@ -450,7 +458,8 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {active.hasMore && ' · newest first — scroll for earlier logs'}
+            {active.hasMore &&
+              (active.pagesNewestFirst ? ' · newest first — scroll for earlier logs' : ' · more lines available')}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -6,7 +6,7 @@ import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { Modal } from '@/components/common/Modal/Modal';
 import { Button } from '@/components/common/Button/Button';
 import { CloseIcon } from '@/components/icons';
-import { AiApp, AiAppLogStream, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+import { AiApp, AiAppLogEvent, AiAppLogStream } from '@/services/ai-apps/ai-apps.service';
 import {
   deriveLogLevel,
   formatLogTimestamp,
@@ -44,9 +44,9 @@ interface PreparedLine {
  * The CRI framing is stripped because the event's own timestamp already fills
  * the table's second column — keeping it would print every time twice.
  */
-function prepareLines(result: FetchAiAppLogsResult | null): PreparedLine[] {
-  if (!result) return [];
-  return result.events.map((event, i) => {
+function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
+  if (!events) return [];
+  return events.map((event, i) => {
     const text = stripLogControlSequences(stripCriLogPrefix(event.message));
     const time = formatLogTimestamp(event.timestamp);
     // formatLogTimestamp yields "MMM d HH:mm:ss" for anything parseable; a raw
@@ -67,10 +67,12 @@ function prepareLines(result: FetchAiAppLogsResult | null): PreparedLine[] {
 /**
  * Read-only troubleshooting view of an app's two log sources: Build (finite,
  * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
- * retention window). One scrollable chronological pane per stream — log lines
- * are never paginated — loaded bottom-anchored because failures live at the
- * end. Data changes only on open and on the explicit Refresh button; live
- * tailing is deliberately out of v1.
+ * retention window). One chronological table per stream, paged by the runner's
+ * nextToken: the first page loads on open, further pages load as the reader
+ * scrolls past the sentinel (infinite scroll, with a manual "Load more"
+ * fallback). When the whole log fits in one page the view bottom-anchors —
+ * failures live at the end; when more remains it starts at the top, reading
+ * oldest → newest. Refresh restarts from page 1; live tailing stays out of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -92,15 +94,16 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   );
   const [query, setQuery] = useState('');
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [announcement, setAnnouncement] = useState('');
 
-  // Both streams load on open — the tab counts need them; each is one request.
+  // Both streams load their first page on open — the tab counts need them.
   const build = useAiAppLogs(app.uid, 'build', { enabled: true });
   const runtime = useAiAppLogs(app.uid, 'runtime', { enabled: true });
   const active = stream === 'build' ? build : runtime;
 
-  const buildLines = useMemo(() => prepareLines(build.result), [build.result]);
-  const runtimeLines = useMemo(() => prepareLines(runtime.result), [runtime.result]);
+  const buildLines = useMemo(() => prepareLines(build.events), [build.events]);
+  const runtimeLines = useMemo(() => prepareLines(runtime.events), [runtime.events]);
   const lines = stream === 'build' ? buildLines : runtimeLines;
 
   const filtered = useMemo(() => {
@@ -110,16 +113,47 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   }, [lines, query]);
 
   const paneRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLTableRowElement>(null);
   const buildTabRef = useRef<HTMLButtonElement>(null);
   const runtimeTabRef = useRef<HTMLButtonElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Bottom-anchor whenever the visible snapshot changes (load, refresh, tab
-  // switch) — the newest lines are the reason the modal was opened.
+  // Anchor only while the FIRST page is showing: bottom when it's the whole
+  // log (failures live at the end), top when more pages remain (read oldest →
+  // newest, scroll to load). Appended pages never move the scroll position —
+  // re-anchoring after an append would pin the sentinel in view and turn it
+  // into a request loop.
   useEffect(() => {
     const pane = paneRef.current;
-    if (pane) pane.scrollTop = pane.scrollHeight;
-  }, [lines, stream]);
+    if (!pane || active.pageCount !== 1) return;
+    pane.scrollTop = active.hasMore ? 0 : pane.scrollHeight;
+    // `lines` is the render trigger: anchor once the first page's rows exist.
+  }, [lines, stream, active.pageCount, active.hasMore]);
+
+  // Auto-load when the sentinel row scrolls into view. The observer calls
+  // through a ref so it never holds a stale closure, and it stays inert when
+  // the hook says manual-only (canAutoLoad false — e.g. an empty page with a
+  // token, where auto-chaining could loop).
+  const autoLoadRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    autoLoadRef.current = active.canAutoLoad && !active.loadMoreFailed ? active.loadMore : null;
+  });
+
+  useEffect(() => {
+    const pane = paneRef.current;
+    const sentinel = sentinelRef.current;
+    if (!pane || !sentinel || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) autoLoadRef.current?.();
+      },
+      { root: pane, rootMargin: '120px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // Re-attach when the sentinel (re)mounts: tab switches and load-all both
+    // swap the table subtree.
+  }, [stream, lines, active.hasMore]);
 
   useEffect(
     () => () => {
@@ -144,8 +178,12 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     (next === 'build' ? buildTabRef : runtimeTabRef).current?.focus();
   };
 
+  // Refresh restarts both streams from page 1 — a plain refetch would replay
+  // every page the reader had scrolled through.
   const handleRefresh = () => {
-    Promise.allSettled([build.refetch(), runtime.refetch()]).then(() => {
+    setIsRefreshing(true);
+    Promise.allSettled([build.refresh(), runtime.refresh()]).then(() => {
+      setIsRefreshing(false);
       setAnnouncement('Logs refreshed');
     });
   };
@@ -171,10 +209,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     );
   };
 
-  const isRefreshing = build.isRefetching || runtime.isRefetching;
-  const failed = active.result?.termination.reason === 'failed' ? active.result.termination : null;
-  const truncated = active.result?.termination.reason === 'truncated';
-  const isEmpty = !!active.result && active.result.events.length === 0 && !failed;
+  const isEmpty = !!active.events && active.events.length === 0 && !active.hasMore && !active.errorKind;
 
   const statusChip =
     app.status === 'ERROR'
@@ -183,13 +218,45 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         ? { label: 'Deploying', className: s.statusDeploying }
         : { label: 'Live', className: s.statusLive };
 
-  const tabs: { key: AiAppLogStream; label: string; count: number | null; ref: typeof buildTabRef }[] = [
-    { key: 'build', label: 'Build', count: build.result ? buildLines.length : null, ref: buildTabRef },
-    { key: 'runtime', label: 'Runtime', count: runtime.result ? runtimeLines.length : null, ref: runtimeTabRef },
+  const tabs: { key: AiAppLogStream; label: string; count: string | null; ref: typeof buildTabRef }[] = [
+    // A trailing + marks "more pages remain" — the count is lines loaded, not the log's size.
+    {
+      key: 'build',
+      label: 'Build',
+      count: build.events ? `${buildLines.length}${build.hasMore ? '+' : ''}` : null,
+      ref: buildTabRef,
+    },
+    {
+      key: 'runtime',
+      label: 'Runtime',
+      count: runtime.events ? `${runtimeLines.length}${runtime.hasMore ? '+' : ''}` : null,
+      ref: runtimeTabRef,
+    },
   ];
 
+  const loadMoreRow = active.hasMore && !query.trim() && (
+    <tr ref={sentinelRef} className={s.loadMoreRow}>
+      <td colSpan={2}>
+        {active.loadMoreFailed ? (
+          <span className={s.loadMoreFailed}>
+            Couldn’t load more lines.{' '}
+            <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
+              Retry
+            </button>
+          </span>
+        ) : active.isLoadingMore ? (
+          <span className={s.loadMoreHint}>Loading more…</span>
+        ) : (
+          <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
+            Load more
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+
   const renderBody = () => {
-    if (active.isLoading) {
+    if (active.isLoading || isRefreshing) {
       return (
         <div className={s.skeleton} aria-hidden>
           {Array.from({ length: 8 }, (_, i) => (
@@ -199,19 +266,19 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
       );
     }
 
-    // Whole-stream failure (or an unexpected throw surfaced by React Query).
-    if ((failed && active.result?.events.length === 0) || (!active.result && active.isError)) {
-      const copy =
-        failed?.errorKind === 'forbidden'
-          ? { title: 'You don’t have access to logs for this app.', hint: null }
-          : failed?.errorKind === 'not-found'
-            ? { title: 'Logs for this app could not be found.', hint: null }
-            : { title: 'Unable to load logs. Please try again later.', hint: null };
+    // Whole-stream failure — nothing loaded at all.
+    if (active.errorKind) {
+      const title =
+        active.errorKind === 'forbidden'
+          ? 'You don’t have access to logs for this app.'
+          : active.errorKind === 'not-found'
+            ? 'Logs for this app could not be found.'
+            : 'Unable to load logs. Please try again later.';
       return (
         <div className={s.stateBlock}>
-          <p className={s.stateTitle}>{copy.title}</p>
-          {failed?.errorKind !== 'forbidden' && failed?.errorKind !== 'not-found' && (
-            <Button style="border" variant="neutral" size="s" onClick={() => active.refetch()}>
+          <p className={s.stateTitle}>{title}</p>
+          {active.errorKind === 'network' && (
+            <Button style="border" variant="neutral" size="s" onClick={() => active.refresh()}>
               Retry
             </Button>
           )}
@@ -230,6 +297,19 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
               ? 'Logs may have expired from retention, or no build has produced output yet.'
               : `Only the ${RUNTIME_WINDOW_LABEL} of runtime output is shown.`}
           </p>
+        </div>
+      );
+    }
+
+    // A step can come back empty while the log continues (sparse window) —
+    // offer the cursor to the reader instead of a dead end.
+    if (lines.length === 0 && active.hasMore) {
+      return (
+        <div className={s.stateBlock}>
+          <p className={s.stateTitle}>No lines in this part of the log yet.</p>
+          <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
+            {active.isLoadingMore ? 'Loading…' : 'Load more'}
+          </Button>
         </div>
       );
     }
@@ -282,6 +362,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 </td>
               </tr>
             ))}
+            {loadMoreRow}
           </tbody>
         </table>
       </div>
@@ -334,7 +415,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
               className={`${s.search} ph-no-capture`}
               type="search"
               value={query}
-              placeholder="Search logs"
+              placeholder={active.hasMore ? 'Search loaded logs' : 'Search logs'}
               aria-label="Search deployment logs"
               onChange={(e) => setQuery(e.target.value)}
             />
@@ -363,14 +444,14 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
           <span className={s.count}>
             {query.trim() ? (
               <>
-                Showing <strong>{filtered.length}</strong> of {lines.length} events
+                Showing <strong>{filtered.length}</strong> of {lines.length} loaded events
               </>
             ) : (
               <>
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {truncated && ' · log truncated to the 2,000-line limit'}
+            {active.hasMore && ' · scroll to load more'}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import InfiniteScroll from 'react-infinite-scroll-component';
 
 import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
 import { Modal } from '@/components/common/Modal/Modal';
@@ -72,15 +73,17 @@ function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
  * newest-first view server-side — the runner itself only pages forward), and
  * each further page walks EARLIER into history. The latest line is therefore
  * at the top on open, and scrolling toward the bottom auto-loads earlier
- * lines via an IntersectionObserver sentinel (manual "Load earlier logs"
- * button as the keyboard / no-IO fallback).
+ * lines via react-infinite-scroll-component (the house pattern — see
+ * JobsContent, TeamList, OutreachInvestorTable), with a manual "Load earlier
+ * logs" row as the keyboard / retry fallback.
  *
- * The sentinel is only safe BECAUSE pages arrive newest-to-oldest: an
- * appended page's older lines sort in BELOW the reader, pushing the sentinel
- * out of view until they scroll again. (With forward paging this exact
- * sentinel chain-fetched entire windows — appends landed above the reader and
- * it never un-triggered. Don't revisit without that history.) Refresh
- * restarts from page 1; live tailing stays out of v1.
+ * Scroll-triggered loading is only safe BECAUSE pages arrive newest-to-oldest:
+ * an appended page's older lines sort in BELOW the reader, so the bottom
+ * threshold un-triggers until they scroll again. (Under the old forward
+ * paging, bottom-triggered loaders chain-fetched entire windows — appends
+ * landed above the reader and the trigger never released. Don't revisit
+ * without that history.) Refresh restarts from page 1; live tailing stays out
+ * of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -121,7 +124,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   }, [lines, query]);
 
   const paneRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLTableRowElement>(null);
   const buildTabRef = useRef<HTMLButtonElement>(null);
   const runtimeTabRef = useRef<HTMLButtonElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -137,31 +139,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     pane.scrollTop = 0;
     // `lines` is the render trigger: anchor once the first page's rows exist.
   }, [lines, stream, active.pageCount]);
-
-  // Auto-load earlier history when the sentinel row scrolls into view. Calls
-  // through a ref so the observer never holds a stale closure; inert while a
-  // page fetch is failed (the inline Retry takes over) or a search is active
-  // (results only cover loaded lines).
-  const autoLoadRef = useRef<(() => void) | null>(null);
-  useEffect(() => {
-    autoLoadRef.current = !active.loadMoreFailed && !query.trim() ? active.loadMore : null;
-  });
-
-  useEffect(() => {
-    const pane = paneRef.current;
-    const sentinel = sentinelRef.current;
-    if (!pane || !sentinel || typeof IntersectionObserver === 'undefined') return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) autoLoadRef.current?.();
-      },
-      { root: pane, rootMargin: '120px' },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-    // Re-attach when the sentinel (re)mounts — tab switches and end-of-log
-    // both swap the table subtree.
-  }, [stream, lines, active.hasMore]);
 
   useEffect(
     () => () => {
@@ -242,10 +219,10 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     },
   ];
 
-  // The last row: crossing it auto-loads earlier history (which appends right
-  // below the reader); the button is the keyboard / no-IO fallback.
+  // The last row: InfiniteScroll auto-loads as the reader nears it; the
+  // button is the keyboard fallback, and Retry takes over on a failed page.
   const loadMoreRow = active.hasMore && !query.trim() && (
-    <tr ref={sentinelRef} className={s.loadMoreRow}>
+    <tr className={s.loadMoreRow}>
       <td colSpan={2}>
         {active.loadMoreFailed ? (
           <span className={s.loadMoreFailed}>
@@ -336,45 +313,57 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     }
 
     // The prototype's two-column table: message takes the slack, the timestamp
-    // is a fixed right rail split into a muted date and a dark clock.
+    // is a fixed right rail split into a muted date and a dark clock. The
+    // tableWrap div stays the scroll container; InfiniteScroll only watches it
+    // (style overflow:unset per house usage) and fires `next` near its bottom.
     return (
       <div
         ref={paneRef}
+        id="deployment-logs-scroll"
         className={`${s.tableWrap} ph-no-capture`}
         role="region"
         aria-label="Deployment logs"
         tabIndex={0}
       >
-        <table className={s.table}>
-          <thead>
-            <tr>
-              <th scope="col">Message</th>
-              <th scope="col">Timestamp</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((line) => (
-              <tr key={line.key} className={line.level ? s[line.level] : undefined}>
-                <td className={s.messageCell}>
-                  {line.level && (
-                    <>
-                      <span className={s.levelDot} aria-hidden />
-                      <span className={s.srOnly}>{line.level === 'error' ? 'Error: ' : 'Warning: '}</span>
-                    </>
-                  )}
-                  <span className={s.messageText}>{line.text}</span>
-                </td>
-                <td>
-                  <span className={s.timeCell}>
-                    {line.date && <span className={s.date}>{line.date}</span>}
-                    <span className={s.time}>{line.clock}</span>
-                  </span>
-                </td>
+        <InfiniteScroll
+          scrollableTarget="deployment-logs-scroll"
+          dataLength={filtered.length}
+          hasMore={active.hasMore && !query.trim() && !active.loadMoreFailed}
+          next={active.loadMore}
+          loader={null}
+          style={{ overflow: 'unset' }}
+        >
+          <table className={s.table}>
+            <thead>
+              <tr>
+                <th scope="col">Message</th>
+                <th scope="col">Timestamp</th>
               </tr>
-            ))}
-            {loadMoreRow}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filtered.map((line) => (
+                <tr key={line.key} className={line.level ? s[line.level] : undefined}>
+                  <td className={s.messageCell}>
+                    {line.level && (
+                      <>
+                        <span className={s.levelDot} aria-hidden />
+                        <span className={s.srOnly}>{line.level === 'error' ? 'Error: ' : 'Warning: '}</span>
+                      </>
+                    )}
+                    <span className={s.messageText}>{line.text}</span>
+                  </td>
+                  <td>
+                    <span className={s.timeCell}>
+                      {line.date && <span className={s.date}>{line.date}</span>}
+                      <span className={s.time}>{line.clock}</span>
+                    </span>
+                  </td>
+                </tr>
+              ))}
+              {loadMoreRow}
+            </tbody>
+          </table>
+        </InfiniteScroll>
       </div>
     );
   };

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -228,13 +228,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     }
 
     return (
-      <div
-        ref={paneRef}
-        className={`${s.pane} ph-no-capture`}
-        role="region"
-        aria-label="Deployment logs"
-        tabIndex={0}
-      >
+      <div ref={paneRef} className={`${s.pane} ph-no-capture`} role="region" aria-label="Deployment logs" tabIndex={0}>
         {filtered.map((line) => (
           <div key={line.key} className={s.line}>
             <span className={s.message} data-level={line.level ?? undefined}>
@@ -293,12 +287,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
           {stream === 'runtime' && <span className={s.streamNote}>{RUNTIME_WINDOW_LABEL}</span>}
         </div>
 
-        <div
-          className={s.panel}
-          role="tabpanel"
-          id={PANEL_ID}
-          aria-labelledby={`deployment-logs-tab-${stream}`}
-        >
+        <div className={s.panel} role="tabpanel" id={PANEL_ID} aria-labelledby={`deployment-logs-tab-${stream}`}>
           <div className={s.toolbar}>
             <input
               className={`${s.search} ph-no-capture`}

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -67,12 +67,14 @@ function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
 /**
  * Read-only troubleshooting view of an app's two log sources: Build (finite,
  * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
- * retention window). One chronological table per stream, paged by the runner's
- * nextToken: the first page loads on open, further pages load as the reader
- * scrolls past the sentinel (infinite scroll, with a manual "Load more"
- * fallback). When the whole log fits in one page the view bottom-anchors —
- * failures live at the end; when more remains it starts at the top, reading
- * oldest → newest. Refresh restarts from page 1; live tailing stays out of v1.
+ * retention window). One NEWEST-FIRST table per stream — the latest lines are
+ * why the modal was opened, so they're at the top on arrival — paged by the
+ * runner's nextToken: the first page loads on open, EARLIER history loads as
+ * the reader scrolls past the sentinel (with a manual "Load earlier" fallback).
+ * Assumes the runner reads CloudWatch from the tail (GetLogEvents' default);
+ * the hook's global re-sort keeps display coherent if it doesn't, but the
+ * "earlier below" promise then needs the backend ordering answer. Refresh
+ * restarts from page 1; live tailing stays out of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -118,17 +120,17 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   const runtimeTabRef = useRef<HTMLButtonElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Anchor only while the FIRST page is showing: bottom when it's the whole
-  // log (failures live at the end), top when more pages remain (read oldest →
-  // newest, scroll to load). Appended pages never move the scroll position —
+  // Newest-first: the top of the table IS the latest line, so the view always
+  // starts (and re-starts on tab switch / refresh) at the top. Only the first
+  // page anchors — appended history never moves the scroll position, because
   // re-anchoring after an append would pin the sentinel in view and turn it
   // into a request loop.
   useEffect(() => {
     const pane = paneRef.current;
     if (!pane || active.pageCount !== 1) return;
-    pane.scrollTop = active.hasMore ? 0 : pane.scrollHeight;
+    pane.scrollTop = 0;
     // `lines` is the render trigger: anchor once the first page's rows exist.
-  }, [lines, stream, active.pageCount, active.hasMore]);
+  }, [lines, stream, active.pageCount]);
 
   // Auto-load when the sentinel row scrolls into view. The observer calls
   // through a ref so it never holds a stale closure, and it stays inert when
@@ -239,16 +241,16 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
       <td colSpan={2}>
         {active.loadMoreFailed ? (
           <span className={s.loadMoreFailed}>
-            Couldn’t load more lines.{' '}
+            Couldn’t load earlier lines.{' '}
             <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
               Retry
             </button>
           </span>
         ) : active.isLoadingMore ? (
-          <span className={s.loadMoreHint}>Loading more…</span>
+          <span className={s.loadMoreHint}>Loading earlier logs…</span>
         ) : (
           <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
-            Load more
+            Load earlier logs
           </button>
         )}
       </td>
@@ -308,7 +310,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <div className={s.stateBlock}>
           <p className={s.stateTitle}>No lines in this part of the log yet.</p>
           <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
-            {active.isLoadingMore ? 'Loading…' : 'Load more'}
+            {active.isLoadingMore ? 'Loading…' : 'Load earlier logs'}
           </Button>
         </div>
       );
@@ -451,7 +453,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {active.hasMore && ' · scroll to load more'}
+            {active.hasMore && ' · newest first — scroll for earlier logs'}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAiAppsAnalytics } from '@/analytics/ai-apps.analytics';
+import { Modal } from '@/components/common/Modal/Modal';
+import { Button } from '@/components/common/Button/Button';
+import { CloseIcon } from '@/components/icons';
+import { AiApp, AiAppLogStream, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+import { deriveLogLevel, formatLogTimestamp, stripLogControlSequences } from '@/services/ai-apps/ai-apps-logs.utils';
+import { useAiAppLogs, RUNTIME_WINDOW_LABEL } from '@/services/ai-apps/hooks/useAiAppLogs';
+
+import s from './DeploymentLogsModal.module.scss';
+
+const TITLE_ID = 'deployment-logs-title';
+const PANEL_ID = 'deployment-logs-panel';
+
+interface Props {
+  app: AiApp;
+  onClose: () => void;
+}
+
+interface PreparedLine {
+  key: string;
+  text: string;
+  searchText: string;
+  level: 'error' | 'warn' | null;
+  time: string;
+}
+
+/**
+ * Prepared once per loaded snapshot: control-sequence stripping, level
+ * derivation, and timestamp formatting never run per keystroke or per render.
+ */
+function prepareLines(result: FetchAiAppLogsResult | null): PreparedLine[] {
+  if (!result) return [];
+  return result.events.map((event, i) => {
+    const text = stripLogControlSequences(event.message);
+    return {
+      key: `${event.timestamp}-${i}`,
+      text,
+      searchText: text.toLowerCase(),
+      level: deriveLogLevel(text),
+      time: formatLogTimestamp(event.timestamp),
+    };
+  });
+}
+
+/**
+ * Read-only troubleshooting view of an app's two log sources: Build (finite,
+ * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
+ * retention window). One scrollable chronological pane per stream — log lines
+ * are never paginated — loaded bottom-anchored because failures live at the
+ * end. Data changes only on open and on the explicit Refresh button; live
+ * tailing is deliberately out of v1.
+ *
+ * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
+ * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
+ * React Query's signal). Keeping it mounted behind `isOpen` would leak fetches.
+ *
+ * Log content can carry injected secrets and member PII, so the pane, search
+ * input, and export button are `ph-no-capture` (PostHog session replay /
+ * autocapture must never see log text), messages render as text nodes only,
+ * and analytics events carry counts — never content.
+ */
+export function DeploymentLogsModal({ app, onClose }: Props) {
+  const analytics = useAiAppsAnalytics();
+
+  // Mount-time default: a failed or in-flight deploy is a build-log story;
+  // a healthy app's interesting logs are runtime. Never switched by effects —
+  // the tab must not move under the reader when a status poll lands.
+  const [stream, setStream] = useState<AiAppLogStream>(() =>
+    app.status === 'ERROR' || app.status === 'DEPLOYING' ? 'build' : 'runtime',
+  );
+  const [query, setQuery] = useState('');
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [announcement, setAnnouncement] = useState('');
+
+  // Both streams load on open — the tab counts need them; each is one request.
+  const build = useAiAppLogs(app.uid, 'build', { enabled: true });
+  const runtime = useAiAppLogs(app.uid, 'runtime', { enabled: true });
+  const active = stream === 'build' ? build : runtime;
+
+  const buildLines = useMemo(() => prepareLines(build.result), [build.result]);
+  const runtimeLines = useMemo(() => prepareLines(runtime.result), [runtime.result]);
+  const lines = stream === 'build' ? buildLines : runtimeLines;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return lines;
+    return lines.filter((line) => line.searchText.includes(q));
+  }, [lines, query]);
+
+  const paneRef = useRef<HTMLDivElement>(null);
+  const buildTabRef = useRef<HTMLButtonElement>(null);
+  const runtimeTabRef = useRef<HTMLButtonElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Bottom-anchor whenever the visible snapshot changes (load, refresh, tab
+  // switch) — the newest lines are the reason the modal was opened.
+  useEffect(() => {
+    const pane = paneRef.current;
+    if (pane) pane.scrollTop = pane.scrollHeight;
+  }, [lines, stream]);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
+
+  const switchStream = (next: AiAppLogStream) => {
+    if (next === stream) return;
+    setStream(next);
+    setQuery('');
+    analytics.onDeploymentLogsTabSwitched(app.uid, next);
+  };
+
+  // WAI-ARIA tabs: arrow keys move and activate; roving tabindex below.
+  const handleTablistKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const next = stream === 'build' ? 'runtime' : 'build';
+    switchStream(next);
+    (next === 'build' ? buildTabRef : runtimeTabRef).current?.focus();
+  };
+
+  const handleRefresh = () => {
+    Promise.allSettled([build.refetch(), runtime.refetch()]).then(() => {
+      setAnnouncement('Logs refreshed');
+    });
+  };
+
+  const handleExport = () => {
+    const text = filtered.map((line) => `${line.time}  ${line.text}`).join('\n');
+    const setTransient = (state: 'copied' | 'failed') => {
+      setCopyState(state);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopyState('idle'), 1600);
+    };
+    if (!navigator.clipboard) {
+      setTransient('failed');
+      return;
+    }
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setTransient('copied');
+        setAnnouncement('Logs copied to clipboard');
+        analytics.onDeploymentLogsExported(app.uid, stream, filtered.length);
+      },
+      () => setTransient('failed'),
+    );
+  };
+
+  const isRefreshing = build.isRefetching || runtime.isRefetching;
+  const failed = active.result?.termination.reason === 'failed' ? active.result.termination : null;
+  const truncated = active.result?.termination.reason === 'truncated';
+  const isEmpty = !!active.result && active.result.events.length === 0 && !failed;
+
+  const statusChip =
+    app.status === 'ERROR'
+      ? { label: 'Deploy failed', className: s.statusFailed }
+      : app.status === 'DEPLOYING'
+        ? { label: 'Deploying', className: s.statusDeploying }
+        : { label: 'Live', className: s.statusLive };
+
+  const tabs: { key: AiAppLogStream; label: string; count: number | null; ref: typeof buildTabRef }[] = [
+    { key: 'build', label: 'Build', count: build.result ? buildLines.length : null, ref: buildTabRef },
+    { key: 'runtime', label: 'Runtime', count: runtime.result ? runtimeLines.length : null, ref: runtimeTabRef },
+  ];
+
+  const renderBody = () => {
+    if (active.isLoading) {
+      return (
+        <div className={s.skeleton} aria-hidden>
+          {Array.from({ length: 8 }, (_, i) => (
+            <div key={i} className={s.skeletonRow} style={{ width: `${55 + ((i * 17) % 40)}%` }} />
+          ))}
+        </div>
+      );
+    }
+
+    // Whole-stream failure (or an unexpected throw surfaced by React Query).
+    if ((failed && active.result?.events.length === 0) || (!active.result && active.isError)) {
+      const copy =
+        failed?.errorKind === 'forbidden'
+          ? { title: 'You don’t have access to logs for this app.', hint: null }
+          : failed?.errorKind === 'not-found'
+            ? { title: 'Logs for this app could not be found.', hint: null }
+            : { title: 'Unable to load logs. Please try again later.', hint: null };
+      return (
+        <div className={s.stateBlock}>
+          <p className={s.stateTitle}>{copy.title}</p>
+          {failed?.errorKind !== 'forbidden' && failed?.errorKind !== 'not-found' && (
+            <Button style="border" variant="neutral" size="s" onClick={() => active.refetch()}>
+              Retry
+            </Button>
+          )}
+        </div>
+      );
+    }
+
+    if (isEmpty) {
+      return (
+        <div className={s.stateBlock}>
+          <p className={s.stateTitle}>
+            {stream === 'build' ? 'No build logs available.' : 'No runtime logs in this window.'}
+          </p>
+          <p className={s.stateText}>
+            {stream === 'build'
+              ? 'Logs may have expired from retention, or no build has produced output yet.'
+              : `Only the ${RUNTIME_WINDOW_LABEL} of runtime output is shown.`}
+          </p>
+        </div>
+      );
+    }
+
+    if (filtered.length === 0) {
+      return (
+        <div className={s.stateBlock}>
+          <p className={s.stateTitle}>No lines match “{query.trim()}”.</p>
+          <Button style="border" variant="neutral" size="s" onClick={() => setQuery('')}>
+            Clear search
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={paneRef}
+        className={`${s.pane} ph-no-capture`}
+        role="region"
+        aria-label="Deployment logs"
+        tabIndex={0}
+      >
+        {filtered.map((line) => (
+          <div key={line.key} className={s.line}>
+            <span className={s.message} data-level={line.level ?? undefined}>
+              {line.level && (
+                <>
+                  <span className={s.levelDot} aria-hidden />
+                  <span className={s.srOnly}>{line.level === 'error' ? 'Error: ' : 'Warning: '}</span>
+                </>
+              )}
+              {line.text}
+            </span>
+            <span className={s.time}>{line.time}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} className={s.modal} ariaLabelledBy={TITLE_ID} lockScroll inertBackground>
+      <div className={s.content}>
+        <div className={s.header}>
+          <div className={s.titleBlock}>
+            <h2 className={s.title} id={TITLE_ID}>
+              Deployment logs
+            </h2>
+            <div className={s.metaRow}>
+              <span className={s.appName}>{app.name}</span>
+              <span className={`${s.status} ${statusChip.className}`}>{statusChip.label}</span>
+            </div>
+          </div>
+          <button type="button" className={s.close} onClick={onClose} aria-label="Close">
+            <CloseIcon width={20} height={20} />
+          </button>
+        </div>
+
+        <div className={s.tabs} role="tablist" aria-label="Log stream" onKeyDown={handleTablistKeyDown}>
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              ref={tab.ref}
+              type="button"
+              role="tab"
+              id={`deployment-logs-tab-${tab.key}`}
+              aria-selected={stream === tab.key}
+              aria-controls={PANEL_ID}
+              tabIndex={stream === tab.key ? 0 : -1}
+              className={s.tab}
+              data-active={stream === tab.key}
+              onClick={() => switchStream(tab.key)}
+            >
+              {tab.label}
+              {tab.count !== null && <span className={s.tabCount}>{tab.count}</span>}
+            </button>
+          ))}
+          {stream === 'runtime' && <span className={s.streamNote}>{RUNTIME_WINDOW_LABEL}</span>}
+        </div>
+
+        <div
+          className={s.panel}
+          role="tabpanel"
+          id={PANEL_ID}
+          aria-labelledby={`deployment-logs-tab-${stream}`}
+        >
+          <div className={s.toolbar}>
+            <input
+              className={`${s.search} ph-no-capture`}
+              type="search"
+              value={query}
+              placeholder="Search logs"
+              aria-label="Search deployment logs"
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <button type="button" className={s.toolBtn} onClick={handleRefresh} disabled={isRefreshing}>
+              {isRefreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+            <button
+              type="button"
+              className={`${s.toolBtn} ph-no-capture`}
+              onClick={handleExport}
+              disabled={filtered.length === 0}
+              title="Copy the lines currently shown (filtered) to the clipboard"
+            >
+              {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Export'}
+            </button>
+          </div>
+
+          {app.status === 'DEPLOYING' && (
+            <p className={s.deployingNote}>Deploy in progress — use Refresh to pull the latest lines.</p>
+          )}
+
+          {renderBody()}
+        </div>
+
+        <div className={s.footer}>
+          <span className={s.count}>
+            {query.trim() ? `${filtered.length} of ${lines.length} lines` : `${lines.length} lines`}
+            {truncated && ' · log truncated to the 2,000-line limit'}
+            {' · times in your local time'}
+          </span>
+          <Button style="border" variant="neutral" size="s" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+
+        <span className={s.srOnly} role="status" aria-live="polite">
+          {announcement}
+        </span>
+      </div>
+    </Modal>
+  );
+}

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -7,7 +7,12 @@ import { Modal } from '@/components/common/Modal/Modal';
 import { Button } from '@/components/common/Button/Button';
 import { CloseIcon } from '@/components/icons';
 import { AiApp, AiAppLogStream, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
-import { deriveLogLevel, formatLogTimestamp, stripLogControlSequences } from '@/services/ai-apps/ai-apps-logs.utils';
+import {
+  deriveLogLevel,
+  formatLogTimestamp,
+  stripCriLogPrefix,
+  stripLogControlSequences,
+} from '@/services/ai-apps/ai-apps-logs.utils';
 import { useAiAppLogs, RUNTIME_WINDOW_LABEL } from '@/services/ai-apps/hooks/useAiAppLogs';
 
 import s from './DeploymentLogsModal.module.scss';
@@ -25,23 +30,36 @@ interface PreparedLine {
   text: string;
   searchText: string;
   level: 'error' | 'warn' | null;
+  /** "Jul 23" — empty when the raw value didn't parse. */
+  date: string;
+  /** "14:24:24", or the raw value verbatim when unparseable. */
+  clock: string;
+  /** Full "Jul 23 14:24:24" (or raw) — the export line's prefix. */
   time: string;
 }
 
 /**
- * Prepared once per loaded snapshot: control-sequence stripping, level
+ * Prepared once per loaded snapshot: prefix/control-sequence stripping, level
  * derivation, and timestamp formatting never run per keystroke or per render.
+ * The CRI framing is stripped because the event's own timestamp already fills
+ * the table's second column — keeping it would print every time twice.
  */
 function prepareLines(result: FetchAiAppLogsResult | null): PreparedLine[] {
   if (!result) return [];
   return result.events.map((event, i) => {
-    const text = stripLogControlSequences(event.message);
+    const text = stripLogControlSequences(stripCriLogPrefix(event.message));
+    const time = formatLogTimestamp(event.timestamp);
+    // formatLogTimestamp yields "MMM d HH:mm:ss" for anything parseable; a raw
+    // fallback value stays whole and rides in the clock slot.
+    const parts = /^[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2}$/.test(time) ? time.split(' ') : null;
     return {
       key: `${event.timestamp}-${i}`,
       text,
       searchText: text.toLowerCase(),
       level: deriveLogLevel(text),
-      time: formatLogTimestamp(event.timestamp),
+      date: parts ? `${parts[0]} ${parts[1]}` : '',
+      clock: parts ? parts[2] : time,
+      time,
     };
   });
 }
@@ -227,22 +245,45 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
       );
     }
 
+    // The prototype's two-column table: message takes the slack, the timestamp
+    // is a fixed right rail split into a muted date and a dark clock.
     return (
-      <div ref={paneRef} className={`${s.pane} ph-no-capture`} role="region" aria-label="Deployment logs" tabIndex={0}>
-        {filtered.map((line) => (
-          <div key={line.key} className={s.line}>
-            <span className={s.message} data-level={line.level ?? undefined}>
-              {line.level && (
-                <>
-                  <span className={s.levelDot} aria-hidden />
-                  <span className={s.srOnly}>{line.level === 'error' ? 'Error: ' : 'Warning: '}</span>
-                </>
-              )}
-              {line.text}
-            </span>
-            <span className={s.time}>{line.time}</span>
-          </div>
-        ))}
+      <div
+        ref={paneRef}
+        className={`${s.tableWrap} ph-no-capture`}
+        role="region"
+        aria-label="Deployment logs"
+        tabIndex={0}
+      >
+        <table className={s.table}>
+          <thead>
+            <tr>
+              <th scope="col">Message</th>
+              <th scope="col">Timestamp</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((line) => (
+              <tr key={line.key} className={line.level ? s[line.level] : undefined}>
+                <td className={s.messageCell}>
+                  {line.level && (
+                    <>
+                      <span className={s.levelDot} aria-hidden />
+                      <span className={s.srOnly}>{line.level === 'error' ? 'Error: ' : 'Warning: '}</span>
+                    </>
+                  )}
+                  <span className={s.messageText}>{line.text}</span>
+                </td>
+                <td>
+                  <span className={s.timeCell}>
+                    {line.date && <span className={s.date}>{line.date}</span>}
+                    <span className={s.time}>{line.clock}</span>
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     );
   };
@@ -320,7 +361,15 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
 
         <div className={s.footer}>
           <span className={s.count}>
-            {query.trim() ? `${filtered.length} of ${lines.length} lines` : `${lines.length} lines`}
+            {query.trim() ? (
+              <>
+                Showing <strong>{filtered.length}</strong> of {lines.length} events
+              </>
+            ) : (
+              <>
+                <strong>{lines.length}</strong> events
+              </>
+            )}
             {truncated && ' · log truncated to the 2,000-line limit'}
             {' · times in your local time'}
           </span>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -69,17 +69,19 @@ function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
  * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
  * retention window). One NEWEST-FIRST table per stream — every loaded line is
  * sorted latest-on-top — paged by the runner's nextToken: the first page loads
- * on open, more load as the reader scrolls near the bottom (with a manual
- * "Load more" fallback).
+ * on open, further pages load ONLY via the explicit "Load newer logs" button.
  *
  * The runner pages FORWARD (observed: page 1 is the window's oldest chunk), so
  * later pages carry NEWER lines and the sort slots them in at the top; the top
  * row is the newest loaded line, and the log's true tail only once every page
  * is in. A backend `order=desc`/tail-read option is the real fix and is on the
- * asks list. Forward paging is also why auto-loading is armed by USER SCROLLS
- * only — an append re-triggering the loader (the sentinel never leaves the
- * viewport when new rows sort in above it) would chain-fetch the entire window.
- * Refresh restarts from page 1; live tailing stays out of v1.
+ * asks list. Forward paging is also why loading more is a MANUAL button (at
+ * the top, where the loaded lines appear) and never automatic: every
+ * scroll-position heuristic gets defeated when appends land above the reader —
+ * an IntersectionObserver sentinel never un-triggers, and browser scroll
+ * anchoring re-fires scroll events while preserving distance-to-bottom — and
+ * each false trigger chain-fetches the entire window. Refresh restarts from
+ * page 1; live tailing stays out of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -135,20 +137,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     pane.scrollTop = 0;
     // `lines` is the render trigger: anchor once the first page's rows exist.
   }, [lines, stream, active.pageCount]);
-
-  // Auto-load on USER scroll near the bottom — never on content changes.
-  // Scroll events only fire for real scrolling, so an appended page can't
-  // re-trigger the loader by itself (with forward paging, new rows sort in
-  // ABOVE the reader and the bottom of the pane stays the bottom — an
-  // intersection-observer sentinel here chain-fetches the whole window).
-  // Stays inert during search (results only cover loaded lines) and when the
-  // hook says manual-only (canAutoLoad false — an empty page with a token).
-  const handlePaneScroll = () => {
-    const pane = paneRef.current;
-    if (!pane || !active.canAutoLoad || active.loadMoreFailed || query.trim()) return;
-    const nearBottom = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 200;
-    if (nearBottom) active.loadMore(); // loadMore self-guards against re-entry
-  };
 
   useEffect(
     () => () => {
@@ -229,6 +217,9 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     },
   ];
 
+  // At the TOP of the table: with forward paging + newest-first sorting the
+  // loaded lines appear right here, so the affordance sits where its result
+  // shows up.
   const loadMoreRow = active.hasMore && !query.trim() && (
     <tr className={s.loadMoreRow}>
       <td colSpan={2}>
@@ -240,10 +231,10 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
             </button>
           </span>
         ) : active.isLoadingMore ? (
-          <span className={s.loadMoreHint}>Loading more logs…</span>
+          <span className={s.loadMoreHint}>Loading newer logs…</span>
         ) : (
           <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
-            Load more logs
+            Load newer logs
           </button>
         )}
       </td>
@@ -303,7 +294,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <div className={s.stateBlock}>
           <p className={s.stateTitle}>No lines in this part of the log yet.</p>
           <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
-            {active.isLoadingMore ? 'Loading…' : 'Load more logs'}
+            {active.isLoadingMore ? 'Loading…' : 'Load newer logs'}
           </Button>
         </div>
       );
@@ -329,7 +320,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         role="region"
         aria-label="Deployment logs"
         tabIndex={0}
-        onScroll={handlePaneScroll}
       >
         <table className={s.table}>
           <thead>
@@ -339,6 +329,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
             </tr>
           </thead>
           <tbody>
+            {loadMoreRow}
             {filtered.map((line) => (
               <tr key={line.key} className={line.level ? s[line.level] : undefined}>
                 <td className={s.messageCell}>
@@ -358,7 +349,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 </td>
               </tr>
             ))}
-            {loadMoreRow}
           </tbody>
         </table>
       </div>
@@ -447,7 +437,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {active.hasMore && ' · newest loaded first — scroll to load the rest'}
+            {active.hasMore && ' · newer lines available'}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -67,21 +67,20 @@ function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
 /**
  * Read-only troubleshooting view of an app's two log sources: Build (finite,
  * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
- * retention window). One NEWEST-FIRST table per stream — every loaded line is
- * sorted latest-on-top — paged by the runner's nextToken: the first page loads
- * on open, further pages load ONLY via the explicit "Load newer logs" button.
+ * retention window). One NEWEST-FIRST table per stream: the backend's
+ * `order=desc` mode serves the log's true tail as page 1 (it assembles the
+ * newest-first view server-side — the runner itself only pages forward), and
+ * each further page walks EARLIER into history. The latest line is therefore
+ * at the top on open, and scrolling toward the bottom auto-loads earlier
+ * lines via an IntersectionObserver sentinel (manual "Load earlier logs"
+ * button as the keyboard / no-IO fallback).
  *
- * The runner pages FORWARD (observed: page 1 is the window's oldest chunk), so
- * later pages carry NEWER lines and the sort slots them in at the top; the top
- * row is the newest loaded line, and the log's true tail only once every page
- * is in. A backend `order=desc`/tail-read option is the real fix and is on the
- * asks list. Forward paging is also why loading more is a MANUAL button (at
- * the top, where the loaded lines appear) and never automatic: every
- * scroll-position heuristic gets defeated when appends land above the reader —
- * an IntersectionObserver sentinel never un-triggers, and browser scroll
- * anchoring re-fires scroll events while preserving distance-to-bottom — and
- * each false trigger chain-fetches the entire window. Refresh restarts from
- * page 1; live tailing stays out of v1.
+ * The sentinel is only safe BECAUSE pages arrive newest-to-oldest: an
+ * appended page's older lines sort in BELOW the reader, pushing the sentinel
+ * out of view until they scroll again. (With forward paging this exact
+ * sentinel chain-fetched entire windows — appends landed above the reader and
+ * it never un-triggered. Don't revisit without that history.) Refresh
+ * restarts from page 1; live tailing stays out of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -122,6 +121,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   }, [lines, query]);
 
   const paneRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLTableRowElement>(null);
   const buildTabRef = useRef<HTMLButtonElement>(null);
   const runtimeTabRef = useRef<HTMLButtonElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -137,6 +137,31 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     pane.scrollTop = 0;
     // `lines` is the render trigger: anchor once the first page's rows exist.
   }, [lines, stream, active.pageCount]);
+
+  // Auto-load earlier history when the sentinel row scrolls into view. Calls
+  // through a ref so the observer never holds a stale closure; inert while a
+  // page fetch is failed (the inline Retry takes over) or a search is active
+  // (results only cover loaded lines).
+  const autoLoadRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    autoLoadRef.current = !active.loadMoreFailed && !query.trim() ? active.loadMore : null;
+  });
+
+  useEffect(() => {
+    const pane = paneRef.current;
+    const sentinel = sentinelRef.current;
+    if (!pane || !sentinel || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) autoLoadRef.current?.();
+      },
+      { root: pane, rootMargin: '120px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // Re-attach when the sentinel (re)mounts — tab switches and end-of-log
+    // both swap the table subtree.
+  }, [stream, lines, active.hasMore]);
 
   useEffect(
     () => () => {
@@ -217,24 +242,23 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     },
   ];
 
-  // At the TOP of the table: with forward paging + newest-first sorting the
-  // loaded lines appear right here, so the affordance sits where its result
-  // shows up.
+  // The last row: crossing it auto-loads earlier history (which appends right
+  // below the reader); the button is the keyboard / no-IO fallback.
   const loadMoreRow = active.hasMore && !query.trim() && (
-    <tr className={s.loadMoreRow}>
+    <tr ref={sentinelRef} className={s.loadMoreRow}>
       <td colSpan={2}>
         {active.loadMoreFailed ? (
           <span className={s.loadMoreFailed}>
-            Couldn’t load more lines.{' '}
+            Couldn’t load earlier lines.{' '}
             <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
               Retry
             </button>
           </span>
         ) : active.isLoadingMore ? (
-          <span className={s.loadMoreHint}>Loading newer logs…</span>
+          <span className={s.loadMoreHint}>Loading earlier logs…</span>
         ) : (
           <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
-            Load newer logs
+            Load earlier logs
           </button>
         )}
       </td>
@@ -294,7 +318,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <div className={s.stateBlock}>
           <p className={s.stateTitle}>No lines in this part of the log yet.</p>
           <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
-            {active.isLoadingMore ? 'Loading…' : 'Load newer logs'}
+            {active.isLoadingMore ? 'Loading…' : 'Load earlier logs'}
           </Button>
         </div>
       );
@@ -329,7 +353,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
             </tr>
           </thead>
           <tbody>
-            {loadMoreRow}
             {filtered.map((line) => (
               <tr key={line.key} className={line.level ? s[line.level] : undefined}>
                 <td className={s.messageCell}>
@@ -349,6 +372,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 </td>
               </tr>
             ))}
+            {loadMoreRow}
           </tbody>
         </table>
       </div>
@@ -437,7 +461,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {active.hasMore && ' · newer lines available'}
+            {active.hasMore && ' · newest first — scroll for earlier logs'}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/DeploymentLogsModal.tsx
@@ -67,14 +67,19 @@ function prepareLines(events: AiAppLogEvent[] | null): PreparedLine[] {
 /**
  * Read-only troubleshooting view of an app's two log sources: Build (finite,
  * one per deploy attempt) and Runtime (the pod's stdout/stderr over a
- * retention window). One NEWEST-FIRST table per stream — the latest lines are
- * why the modal was opened, so they're at the top on arrival — paged by the
- * runner's nextToken: the first page loads on open, EARLIER history loads as
- * the reader scrolls past the sentinel (with a manual "Load earlier" fallback).
- * Assumes the runner reads CloudWatch from the tail (GetLogEvents' default);
- * the hook's global re-sort keeps display coherent if it doesn't, but the
- * "earlier below" promise then needs the backend ordering answer. Refresh
- * restarts from page 1; live tailing stays out of v1.
+ * retention window). One NEWEST-FIRST table per stream — every loaded line is
+ * sorted latest-on-top — paged by the runner's nextToken: the first page loads
+ * on open, more load as the reader scrolls near the bottom (with a manual
+ * "Load more" fallback).
+ *
+ * The runner pages FORWARD (observed: page 1 is the window's oldest chunk), so
+ * later pages carry NEWER lines and the sort slots them in at the top; the top
+ * row is the newest loaded line, and the log's true tail only once every page
+ * is in. A backend `order=desc`/tail-read option is the real fix and is on the
+ * asks list. Forward paging is also why auto-loading is armed by USER SCROLLS
+ * only — an append re-triggering the loader (the sentinel never leaves the
+ * viewport when new rows sort in above it) would chain-fetch the entire window.
+ * Refresh restarts from page 1; live tailing stays out of v1.
  *
  * Must be conditionally rendered by the parent (`action && <Modal/>`): closing
  * unmounts it, which is what aborts an in-flight fetch (the queryFn consumes
@@ -115,7 +120,6 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   }, [lines, query]);
 
   const paneRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLTableRowElement>(null);
   const buildTabRef = useRef<HTMLButtonElement>(null);
   const runtimeTabRef = useRef<HTMLButtonElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -132,30 +136,19 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
     // `lines` is the render trigger: anchor once the first page's rows exist.
   }, [lines, stream, active.pageCount]);
 
-  // Auto-load when the sentinel row scrolls into view. The observer calls
-  // through a ref so it never holds a stale closure, and it stays inert when
-  // the hook says manual-only (canAutoLoad false — e.g. an empty page with a
-  // token, where auto-chaining could loop).
-  const autoLoadRef = useRef<(() => void) | null>(null);
-  useEffect(() => {
-    autoLoadRef.current = active.canAutoLoad && !active.loadMoreFailed ? active.loadMore : null;
-  });
-
-  useEffect(() => {
+  // Auto-load on USER scroll near the bottom — never on content changes.
+  // Scroll events only fire for real scrolling, so an appended page can't
+  // re-trigger the loader by itself (with forward paging, new rows sort in
+  // ABOVE the reader and the bottom of the pane stays the bottom — an
+  // intersection-observer sentinel here chain-fetches the whole window).
+  // Stays inert during search (results only cover loaded lines) and when the
+  // hook says manual-only (canAutoLoad false — an empty page with a token).
+  const handlePaneScroll = () => {
     const pane = paneRef.current;
-    const sentinel = sentinelRef.current;
-    if (!pane || !sentinel || typeof IntersectionObserver === 'undefined') return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) autoLoadRef.current?.();
-      },
-      { root: pane, rootMargin: '120px' },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-    // Re-attach when the sentinel (re)mounts: tab switches and load-all both
-    // swap the table subtree.
-  }, [stream, lines, active.hasMore]);
+    if (!pane || !active.canAutoLoad || active.loadMoreFailed || query.trim()) return;
+    const nearBottom = pane.scrollHeight - pane.scrollTop - pane.clientHeight < 200;
+    if (nearBottom) active.loadMore(); // loadMore self-guards against re-entry
+  };
 
   useEffect(
     () => () => {
@@ -237,20 +230,20 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
   ];
 
   const loadMoreRow = active.hasMore && !query.trim() && (
-    <tr ref={sentinelRef} className={s.loadMoreRow}>
+    <tr className={s.loadMoreRow}>
       <td colSpan={2}>
         {active.loadMoreFailed ? (
           <span className={s.loadMoreFailed}>
-            Couldn’t load earlier lines.{' '}
+            Couldn’t load more lines.{' '}
             <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
               Retry
             </button>
           </span>
         ) : active.isLoadingMore ? (
-          <span className={s.loadMoreHint}>Loading earlier logs…</span>
+          <span className={s.loadMoreHint}>Loading more logs…</span>
         ) : (
           <button type="button" className={s.loadMoreBtn} onClick={active.loadMore}>
-            Load earlier logs
+            Load more logs
           </button>
         )}
       </td>
@@ -310,7 +303,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         <div className={s.stateBlock}>
           <p className={s.stateTitle}>No lines in this part of the log yet.</p>
           <Button style="border" variant="neutral" size="s" onClick={active.loadMore}>
-            {active.isLoadingMore ? 'Loading…' : 'Load earlier logs'}
+            {active.isLoadingMore ? 'Loading…' : 'Load more logs'}
           </Button>
         </div>
       );
@@ -336,6 +329,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
         role="region"
         aria-label="Deployment logs"
         tabIndex={0}
+        onScroll={handlePaneScroll}
       >
         <table className={s.table}>
           <thead>
@@ -453,7 +447,7 @@ export function DeploymentLogsModal({ app, onClose }: Props) {
                 <strong>{lines.length}</strong> events
               </>
             )}
-            {active.hasMore && ' · newest first — scroll for earlier logs'}
+            {active.hasMore && ' · newest loaded first — scroll to load the rest'}
             {' · times in your local time'}
           </span>
           <Button style="border" variant="neutral" size="s" onClick={onClose}>

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/index.ts
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentLogsModal } from './DeploymentLogsModal';

--- a/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal/DeploymentSettingsModal.tsx
+++ b/components/page/ai-apps/AiAppsPage/components/DeploymentSettingsModal/DeploymentSettingsModal.tsx
@@ -169,6 +169,11 @@ export function DeploymentSettingsModal({ app, onClose, onDeployingChange }: Pro
     setReplacing({});
     // Refresh both caches right away — the list poll only starts once it can
     // see a DEPLOYING app, and the detail query drives this modal's phases.
+    // Logs are dropped (not just invalidated) so a reopened logs modal shows a
+    // loader for this deploy, never the previous deploy's lines under the new
+    // status chip. (Agent-triggered redeploys skip this path — the logs hook's
+    // staleTime: 0 refetch-on-open is the safety net there.)
+    queryClient.removeQueries({ queryKey: [AiAppsQueryKeys.AI_APP_LOGS, app.uid] });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: [AiAppsQueryKeys.AI_APP_DETAIL, app.uid] }),
       queryClient.invalidateQueries({ queryKey: [AiAppsQueryKeys.AI_APPS_LIST] }),

--- a/components/page/ai-apps/dynamicActionModals.ts
+++ b/components/page/ai-apps/dynamicActionModals.ts
@@ -15,6 +15,11 @@ export const DeploymentSettingsModal = dynamic(
     ),
   { ssr: false },
 );
+export const DeploymentLogsModal = dynamic(
+  () =>
+    import('@/components/page/ai-apps/AiAppsPage/components/DeploymentLogsModal').then((m) => m.DeploymentLogsModal),
+  { ssr: false },
+);
 export const DeleteAiAppDialog = dynamic(
   () => import('@/components/page/ai-apps/AiAppsPage/components/DeleteAiAppDialog').then((m) => m.DeleteAiAppDialog),
   { ssr: false },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -103,6 +103,7 @@ jest.mock('@tanstack/react-query', () => ({
     setQueriesData: jest.fn(),
     cancelQueries: jest.fn(() => Promise.resolve()),
     invalidateQueries: jest.fn(() => Promise.resolve()),
+    removeQueries: jest.fn(),
     isMutating: jest.fn(() => 1),
   }),
 }));

--- a/services/ai-apps/ai-apps-logs.utils.ts
+++ b/services/ai-apps/ai-apps-logs.utils.ts
@@ -25,6 +25,25 @@ const LOG_TIME_FORMAT = new Intl.DateTimeFormat('en-GB', {
 });
 
 /**
+ * Sortable epoch-ms for a log event's timestamp. The contract says number, but
+ * the runner envelope passes through verbatim and has been seen delivering
+ * strings — which the display formatter tolerates while a numbers-only sort
+ * silently no-ops (every value compares as 0 and server order leaks through).
+ * Handles finite numbers, ISO strings, and numeric strings; anything else
+ * sorts as 0.
+ */
+export function logTimestampSortValue(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value !== '') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return 0;
+}
+
+/**
  * Epoch-ms → viewer-local "Jul 23 14:02:05". Anything unparseable renders as
  * its raw value — never "Invalid Date" (the contract promises numbers, but the
  * runner envelope is passed through verbatim and is not to be trusted).

--- a/services/ai-apps/ai-apps-logs.utils.ts
+++ b/services/ai-apps/ai-apps-logs.utils.ts
@@ -1,0 +1,59 @@
+export type AiAppLogLevel = 'error' | 'warn';
+
+/**
+ * Canonical v1 heuristic for a line's severity — the backend contract carries
+ * no `level` field yet (raised with backend; delete this when it lands). Whole
+ * words only, so "0 errors" / "3 warnings" (plural) stay unmarked. Any other
+ * surface (agent-facing included) must reuse this rather than reinvent it, so
+ * humans and agents count the same errors.
+ */
+const ERROR_PATTERN = /\b(error|fatal|exception|panic)\b/i;
+const WARN_PATTERN = /\bwarn(ing)?\b/i;
+
+export function deriveLogLevel(message: string): AiAppLogLevel | null {
+  if (ERROR_PATTERN.test(message)) return 'error';
+  if (WARN_PATTERN.test(message)) return 'warn';
+  return null;
+}
+
+const LOG_DATE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+const LOG_TIME_FORMAT = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+/**
+ * Epoch-ms → viewer-local "Jul 23 14:02:05". Anything unparseable renders as
+ * its raw value — never "Invalid Date" (the contract promises numbers, but the
+ * runner envelope is passed through verbatim and is not to be trusted).
+ */
+export function formatLogTimestamp(value: unknown): string {
+  const ms =
+    typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : typeof value === 'string' && value !== '' && Number.isFinite(Date.parse(value))
+        ? Date.parse(value)
+        : null;
+  if (ms === null) {
+    return value === null || value === undefined ? '' : String(value);
+  }
+  const date = new Date(ms);
+  return `${LOG_DATE_FORMAT.format(date)} ${LOG_TIME_FORMAT.format(date)}`;
+}
+
+// ANSI escape sequences (CSI + other ESC-prefixed forms), C0 controls other
+// than tab, and the bidi/zero-width characters that can visually reorder or
+// hide copied text. Log messages are author-controlled input; they get to be
+// text, not terminal instructions.
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\u001B\[[0-9;?]*[ -/]*[@-~]|\u001B[@-_]/g;
+// eslint-disable-next-line no-control-regex
+const CONTROL_PATTERN = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
+const BIDI_PATTERN = /[\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g;
+
+/** Applied before both render and export — the two places a spoofed line could mislead. */
+export function stripLogControlSequences(message: string): string {
+  return message.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, '').replace(BIDI_PATTERN, '');
+}

--- a/services/ai-apps/ai-apps-logs.utils.ts
+++ b/services/ai-apps/ai-apps-logs.utils.ts
@@ -55,3 +55,14 @@ const BIDI_PATTERN = /[\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g;
 export function stripLogControlSequences(message: string): string {
   return message.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, '').replace(BIDI_PATTERN, '');
 }
+
+// Kubernetes CRI log framing: "<RFC3339Nano> <stdout|stderr> <F|P> <payload>".
+// The runner passes pod lines through with this prefix intact; the event's own
+// `timestamp` already carries the moment, so rendering the prefix would print
+// every timestamp twice. Only the exact framing shape is stripped — anything
+// else stays untouched.
+const CRI_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}T\S+ (stdout|stderr) [FP] /;
+
+export function stripCriLogPrefix(message: string): string {
+  return message.replace(CRI_PREFIX_PATTERN, '');
+}

--- a/services/ai-apps/ai-apps-logs.utils.ts
+++ b/services/ai-apps/ai-apps-logs.utils.ts
@@ -47,9 +47,7 @@ export function formatLogTimestamp(value: unknown): string {
 // than tab, and the bidi/zero-width characters that can visually reorder or
 // hide copied text. Log messages are author-controlled input; they get to be
 // text, not terminal instructions.
-// eslint-disable-next-line no-control-regex
 const ANSI_PATTERN = /\u001B\[[0-9;?]*[ -/]*[@-~]|\u001B[@-_]/g;
-// eslint-disable-next-line no-control-regex
 const CONTROL_PATTERN = /[\u0000-\u0008\u000B-\u001F\u007F]/g;
 const BIDI_PATTERN = /[\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g;
 

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -1,4 +1,5 @@
 import { customFetch } from '@/utils/fetch-wrapper';
+import { logTimestampSortValue } from '@/services/ai-apps/ai-apps-logs.utils';
 
 const AI_APPS_API_URL = `${process.env.DIRECTORY_API_URL}/v1/ai-apps`;
 
@@ -181,13 +182,11 @@ const AI_APP_LOGS_TIME_BUDGET_MS = 8_000;
  * DESCENDING by timestamp (stable, so equal/unparseable stamps keep arrival
  * order). The log table reads newest-first — the latest lines are why the
  * modal was opened — and scrolling down loads earlier history.
+ * logTimestampSortValue does the comparing: the runner has been seen sending
+ * string timestamps, and a numbers-only comparator silently no-ops on those.
  */
 function sortLogEvents(events: AiAppLogEvent[]): AiAppLogEvent[] {
-  return [...events].sort((a, b) => {
-    const ta = Number.isFinite(a.timestamp) ? a.timestamp : 0;
-    const tb = Number.isFinite(b.timestamp) ? b.timestamp : 0;
-    return tb - ta;
-  });
+  return [...events].sort((a, b) => logTimestampSortValue(b.timestamp) - logTimestampSortValue(a.timestamp));
 }
 
 /**

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -216,7 +216,11 @@ export async function fetchAiAppLogsPage(
   let sentToken = opts.nextToken;
 
   for (let skip = 0; skip < AI_APP_LOGS_MAX_SKIPS; skip++) {
-    const params = new URLSearchParams({ limit: String(AI_APP_LOGS_PAGE_SIZE) });
+    // order=desc: the web-api assembles the newest-first view (the runner only
+    // pages forward) — page 1 is the log's true tail and nextToken walks
+    // EARLIER into history. Desc responses are allowlisted {events, nextToken}
+    // with numeric timestamps.
+    const params = new URLSearchParams({ order: 'desc', limit: String(AI_APP_LOGS_PAGE_SIZE) });
     if (sinceMinutes !== undefined) params.set('sinceMinutes', String(sinceMinutes));
     if (sentToken !== undefined) params.set('nextToken', sentToken);
 

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -145,34 +145,41 @@ export interface AiAppLogEvent {
 }
 
 /**
- * Why the fetch stopped — a discriminated union so "truncated" and "failed"
- * can never both be claimed for one result. `failed` with a non-empty `events`
- * means a later page broke: render what loaded, offer a retry.
+ * One scroll-step of a stream's log. `nextToken` present = more log remains
+ * (feeds useInfiniteQuery's getNextPageParam); absent = end of stream.
  */
-export type AiAppLogsTermination =
-  | { reason: 'complete' }
-  | { reason: 'truncated' }
-  | { reason: 'failed'; errorKind: AiAppFetchErrorKind };
-
-export interface FetchAiAppLogsResult {
+export interface AiAppLogsPage {
   events: AiAppLogEvent[];
-  termination: AiAppLogsTermination;
+  nextToken?: string;
 }
 
-/** One request's worth is also the whole v1 budget — the modal shows at most one non-empty page. */
-const AI_APP_LOGS_MAX_LINES = 2000;
 /**
- * CloudWatch can return empty pages WITH a nextToken over sparse windows, so a
- * few follow-ups exist purely to skip those. These bounds are the exit for
- * that quirk — never a mechanism to accumulate more pages.
+ * Typed failure for a logs page fetch, thrown (not returned) so React Query
+ * owns the error state per page — an initial-load failure surfaces on the
+ * query, a failed fetchNextPage keeps the already-loaded pages rendered.
  */
-const AI_APP_LOGS_MAX_PAGES = 5;
+export class AiAppLogsError extends Error {
+  constructor(public readonly errorKind: AiAppFetchErrorKind) {
+    super(`ai-app-logs: ${errorKind}`);
+    this.name = 'AiAppLogsError';
+  }
+}
+
+/** Lines requested per scroll-step. Typical logs land in 1–3 pages. */
+const AI_APP_LOGS_PAGE_SIZE = 500;
+/**
+ * CloudWatch can return empty pages WITH a nextToken over sparse windows, so
+ * each scroll-step skips a few of those before giving up its turn. These
+ * bounds end the step, not the log — a returned token lets the next step
+ * (user keeps scrolling) resume where this one stopped.
+ */
+const AI_APP_LOGS_MAX_SKIPS = 5;
 const AI_APP_LOGS_TIME_BUDGET_MS = 8_000;
 
 /**
- * Server ordering is not documented, so display order is enforced here:
+ * Server ordering is not documented, so display order is enforced per page:
  * ascending by timestamp (stable, so equal/unparseable stamps keep arrival
- * order). Chronological top-to-bottom is what the bottom-anchored pane expects.
+ * order). Chronological top-to-bottom is what the log table expects.
  */
 function sortLogEvents(events: AiAppLogEvent[]): AiAppLogEvent[] {
   return [...events].sort((a, b) => {
@@ -183,36 +190,33 @@ function sortLogEvents(events: AiAppLogEvent[]): AiAppLogEvent[] {
 }
 
 /**
- * Fetch one stream's logs: a single capped request, plus a bounded follow-up
- * loop that exists only to skip CloudWatch's empty-page-with-token responses.
+ * Fetch ONE page of a stream's logs, resuming from `nextToken` when given.
+ * A bounded follow-up loop exists only to skip CloudWatch's
+ * empty-page-with-token responses inside a single step.
  *
  * Termination rules (unit-tested):
- * - first NON-EMPTY page → done; `truncated` iff it came with a fresh nextToken
- *   (more log remains) or the page itself overflowed the cap.
- * - empty page with no token, or a token equal to the one we sent → `complete`
- *   (CloudWatch never nulls the token at end-of-stream; a repeated token is the
- *   real end signal).
- * - page/time budget exhausted while skipping empties → `truncated`.
- * - AbortError is RETHROWN, never converted to a result — a cancelled fetch
- *   must not cache a partial snapshot as success. Any other failure resolves to
- *   `failed` (with whatever loaded) so the modal never renders blank.
+ * - first NON-EMPTY page → done; `nextToken` returned iff it advanced (more
+ *   log remains).
+ * - empty page with no token, or a token equal to the one we sent →
+ *   end-of-stream, no nextToken (CloudWatch never nulls the token; a repeated
+ *   token is the real end signal).
+ * - skip/time budget exhausted while skipping empties → empty page WITH the
+ *   last token, so the next scroll-step resumes instead of losing the cursor.
+ * - AbortError is RETHROWN as-is — a cancelled fetch must not cache anything.
+ *   Any other failure throws AiAppLogsError so the modal can discriminate
+ *   forbidden/not-found from transient trouble.
  */
-export async function fetchAiAppLogs(
+export async function fetchAiAppLogsPage(
   uid: string,
   stream: AiAppLogStream,
-  opts: { signal?: AbortSignal; sinceMinutes?: number } = {},
-): Promise<FetchAiAppLogsResult> {
+  opts: { signal?: AbortSignal; sinceMinutes?: number; nextToken?: string } = {},
+): Promise<AiAppLogsPage> {
   const { signal, sinceMinutes } = opts;
   const startedAt = Date.now();
-  let sentToken: string | undefined;
+  let sentToken = opts.nextToken;
 
-  const failed = (errorKind: AiAppFetchErrorKind): FetchAiAppLogsResult => ({
-    events: [],
-    termination: { reason: 'failed', errorKind },
-  });
-
-  for (let page = 0; page < AI_APP_LOGS_MAX_PAGES; page++) {
-    const params = new URLSearchParams({ limit: String(AI_APP_LOGS_MAX_LINES) });
+  for (let skip = 0; skip < AI_APP_LOGS_MAX_SKIPS; skip++) {
+    const params = new URLSearchParams({ limit: String(AI_APP_LOGS_PAGE_SIZE) });
     if (sinceMinutes !== undefined) params.set('sinceMinutes', String(sinceMinutes));
     if (sentToken !== undefined) params.set('nextToken', sentToken);
 
@@ -231,17 +235,17 @@ export async function fetchAiAppLogs(
       if ((error as { name?: string } | null)?.name === 'AbortError') {
         throw error;
       }
-      return failed('network');
+      throw new AiAppLogsError('network');
     }
 
     // customFetch resolves undefined only on its logout/refresh-failure paths.
     if (!response) {
-      return failed('network');
+      throw new AiAppLogsError('network');
     }
     if (!response.ok) {
-      const errorKind: AiAppFetchErrorKind =
-        response.status === 403 ? 'forbidden' : response.status === 404 ? 'not-found' : 'network';
-      return failed(errorKind);
+      throw new AiAppLogsError(
+        response.status === 403 ? 'forbidden' : response.status === 404 ? 'not-found' : 'network',
+      );
     }
 
     const body = await response.json().catch(() => null);
@@ -252,23 +256,19 @@ export async function fetchAiAppLogs(
     const tokenAdvanced = !!nextToken && nextToken !== sentToken;
 
     if (pageEvents.length > 0) {
-      const overflow = pageEvents.length > AI_APP_LOGS_MAX_LINES;
-      return {
-        events: sortLogEvents(overflow ? pageEvents.slice(0, AI_APP_LOGS_MAX_LINES) : pageEvents),
-        termination: tokenAdvanced || overflow ? { reason: 'truncated' } : { reason: 'complete' },
-      };
+      return { events: sortLogEvents(pageEvents), nextToken: tokenAdvanced ? nextToken : undefined };
     }
 
     if (!tokenAdvanced) {
-      return { events: [], termination: { reason: 'complete' } };
-    }
-    if (Date.now() - startedAt > AI_APP_LOGS_TIME_BUDGET_MS) {
-      return { events: [], termination: { reason: 'truncated' } };
+      return { events: [] };
     }
     sentToken = nextToken;
+    if (Date.now() - startedAt > AI_APP_LOGS_TIME_BUDGET_MS) {
+      return { events: [], nextToken: sentToken };
+    }
   }
 
-  return { events: [], termination: { reason: 'truncated' } };
+  return { events: [], nextToken: sentToken };
 }
 
 export interface UpdateAiAppPatch {

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -339,7 +339,11 @@ export async function updateAiAppFile(uid: string, input: UpdateAiAppFileInput):
   if (input.description !== undefined) formData.append('description', input.description);
   formData.append('file', input.file);
 
-  const response = await customFetch(`${AI_APPS_API_URL}/${encodeURIComponent(uid)}`, { method: 'PATCH', body: formData }, true);
+  const response = await customFetch(
+    `${AI_APPS_API_URL}/${encodeURIComponent(uid)}`,
+    { method: 'PATCH', body: formData },
+    true,
+  );
 
   return parseUpdateResponse(response);
 }

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -218,8 +218,10 @@ export async function fetchAiAppLogs(
 
     let response: Response | undefined;
     try {
+      // Member-JWT routes (creator-or-directory-admin, enforced server-side).
+      // The agent's deploy-token routes live at /logs/{stream} — not these.
       response = await customFetch(
-        `${AI_APPS_API_URL}/${encodeURIComponent(uid)}/logs/${stream}?${params.toString()}`,
+        `${AI_APPS_API_URL}/${encodeURIComponent(uid)}/${stream}-logs?${params.toString()}`,
         { method: 'GET', signal },
         true,
       );

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -178,14 +178,15 @@ const AI_APP_LOGS_TIME_BUDGET_MS = 8_000;
 
 /**
  * Server ordering is not documented, so display order is enforced per page:
- * ascending by timestamp (stable, so equal/unparseable stamps keep arrival
- * order). Chronological top-to-bottom is what the log table expects.
+ * DESCENDING by timestamp (stable, so equal/unparseable stamps keep arrival
+ * order). The log table reads newest-first — the latest lines are why the
+ * modal was opened — and scrolling down loads earlier history.
  */
 function sortLogEvents(events: AiAppLogEvent[]): AiAppLogEvent[] {
   return [...events].sort((a, b) => {
     const ta = Number.isFinite(a.timestamp) ? a.timestamp : 0;
     const tb = Number.isFinite(b.timestamp) ? b.timestamp : 0;
-    return ta - tb;
+    return tb - ta;
   });
 }
 

--- a/services/ai-apps/ai-apps.service.ts
+++ b/services/ai-apps/ai-apps.service.ts
@@ -134,6 +134,141 @@ export async function fetchAiApp(uid: string): Promise<FetchAiAppResult> {
   return { app: await response.json(), errorKind: null };
 }
 
+/** The two log sources the platform produces: the image build (Kaniko) vs the running app pod. */
+export type AiAppLogStream = 'build' | 'runtime';
+
+/** One CloudWatch log line, proxied verbatim from the sandbox runner. */
+export interface AiAppLogEvent {
+  /** Epoch milliseconds per the contract; treated as unparseable-safe by the UI formatter. */
+  timestamp: number;
+  message: string;
+}
+
+/**
+ * Why the fetch stopped — a discriminated union so "truncated" and "failed"
+ * can never both be claimed for one result. `failed` with a non-empty `events`
+ * means a later page broke: render what loaded, offer a retry.
+ */
+export type AiAppLogsTermination =
+  | { reason: 'complete' }
+  | { reason: 'truncated' }
+  | { reason: 'failed'; errorKind: AiAppFetchErrorKind };
+
+export interface FetchAiAppLogsResult {
+  events: AiAppLogEvent[];
+  termination: AiAppLogsTermination;
+}
+
+/** One request's worth is also the whole v1 budget — the modal shows at most one non-empty page. */
+const AI_APP_LOGS_MAX_LINES = 2000;
+/**
+ * CloudWatch can return empty pages WITH a nextToken over sparse windows, so a
+ * few follow-ups exist purely to skip those. These bounds are the exit for
+ * that quirk — never a mechanism to accumulate more pages.
+ */
+const AI_APP_LOGS_MAX_PAGES = 5;
+const AI_APP_LOGS_TIME_BUDGET_MS = 8_000;
+
+/**
+ * Server ordering is not documented, so display order is enforced here:
+ * ascending by timestamp (stable, so equal/unparseable stamps keep arrival
+ * order). Chronological top-to-bottom is what the bottom-anchored pane expects.
+ */
+function sortLogEvents(events: AiAppLogEvent[]): AiAppLogEvent[] {
+  return [...events].sort((a, b) => {
+    const ta = Number.isFinite(a.timestamp) ? a.timestamp : 0;
+    const tb = Number.isFinite(b.timestamp) ? b.timestamp : 0;
+    return ta - tb;
+  });
+}
+
+/**
+ * Fetch one stream's logs: a single capped request, plus a bounded follow-up
+ * loop that exists only to skip CloudWatch's empty-page-with-token responses.
+ *
+ * Termination rules (unit-tested):
+ * - first NON-EMPTY page → done; `truncated` iff it came with a fresh nextToken
+ *   (more log remains) or the page itself overflowed the cap.
+ * - empty page with no token, or a token equal to the one we sent → `complete`
+ *   (CloudWatch never nulls the token at end-of-stream; a repeated token is the
+ *   real end signal).
+ * - page/time budget exhausted while skipping empties → `truncated`.
+ * - AbortError is RETHROWN, never converted to a result — a cancelled fetch
+ *   must not cache a partial snapshot as success. Any other failure resolves to
+ *   `failed` (with whatever loaded) so the modal never renders blank.
+ */
+export async function fetchAiAppLogs(
+  uid: string,
+  stream: AiAppLogStream,
+  opts: { signal?: AbortSignal; sinceMinutes?: number } = {},
+): Promise<FetchAiAppLogsResult> {
+  const { signal, sinceMinutes } = opts;
+  const startedAt = Date.now();
+  let sentToken: string | undefined;
+
+  const failed = (errorKind: AiAppFetchErrorKind): FetchAiAppLogsResult => ({
+    events: [],
+    termination: { reason: 'failed', errorKind },
+  });
+
+  for (let page = 0; page < AI_APP_LOGS_MAX_PAGES; page++) {
+    const params = new URLSearchParams({ limit: String(AI_APP_LOGS_MAX_LINES) });
+    if (sinceMinutes !== undefined) params.set('sinceMinutes', String(sinceMinutes));
+    if (sentToken !== undefined) params.set('nextToken', sentToken);
+
+    let response: Response | undefined;
+    try {
+      response = await customFetch(
+        `${AI_APPS_API_URL}/${encodeURIComponent(uid)}/logs/${stream}?${params.toString()}`,
+        { method: 'GET', signal },
+        true,
+      );
+    } catch (error) {
+      // Name check, not instanceof: fetch aborts reject with a DOMException,
+      // which is not `instanceof Error` in browsers.
+      if ((error as { name?: string } | null)?.name === 'AbortError') {
+        throw error;
+      }
+      return failed('network');
+    }
+
+    // customFetch resolves undefined only on its logout/refresh-failure paths.
+    if (!response) {
+      return failed('network');
+    }
+    if (!response.ok) {
+      const errorKind: AiAppFetchErrorKind =
+        response.status === 403 ? 'forbidden' : response.status === 404 ? 'not-found' : 'network';
+      return failed(errorKind);
+    }
+
+    const body = await response.json().catch(() => null);
+    const pageEvents: AiAppLogEvent[] = Array.isArray(body?.events)
+      ? body.events.filter((e: unknown): e is AiAppLogEvent => typeof (e as AiAppLogEvent)?.message === 'string')
+      : [];
+    const nextToken: string | undefined = typeof body?.nextToken === 'string' ? body.nextToken : undefined;
+    const tokenAdvanced = !!nextToken && nextToken !== sentToken;
+
+    if (pageEvents.length > 0) {
+      const overflow = pageEvents.length > AI_APP_LOGS_MAX_LINES;
+      return {
+        events: sortLogEvents(overflow ? pageEvents.slice(0, AI_APP_LOGS_MAX_LINES) : pageEvents),
+        termination: tokenAdvanced || overflow ? { reason: 'truncated' } : { reason: 'complete' },
+      };
+    }
+
+    if (!tokenAdvanced) {
+      return { events: [], termination: { reason: 'complete' } };
+    }
+    if (Date.now() - startedAt > AI_APP_LOGS_TIME_BUDGET_MS) {
+      return { events: [], termination: { reason: 'truncated' } };
+    }
+    sentToken = nextToken;
+  }
+
+  return { events: [], termination: { reason: 'truncated' } };
+}
+
 export interface UpdateAiAppPatch {
   name?: string;
   description?: string;

--- a/services/ai-apps/constants.ts
+++ b/services/ai-apps/constants.ts
@@ -3,6 +3,9 @@ export enum AiAppsQueryKeys {
   AI_APP_DETAIL = 'ai-app-detail',
   AI_APP_PRD_CONTENT = 'ai-app-prd-content',
   AI_APP_PRD_SIZE = 'ai-app-prd-size',
+  // Key shape is [AI_APP_LOGS, uid, stream]; if a time-window selector ever
+  // ships, sinceMinutes must join the key or windows cross-contaminate the cache.
+  AI_APP_LOGS = 'ai-app-logs',
 }
 
 /** Keep in sync with `AI_APPS_STARTER_KIT_VERSION` in pln-directory-portal web-api. */

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -22,12 +22,11 @@ const RUNTIME_WINDOW_MINUTES = 24 * 60;
 export const RUNTIME_WINDOW_LABEL = 'last 24 hours';
 
 /**
- * One stream's logs for the deployment-logs modal, paged by the runner's
- * `nextToken`: the first page loads on open, further pages load via the
- * modal's explicit "Load newer logs" button (`loadMore` — MANUAL by design:
- * the runner pages forward, so appended lines sort in above the reader and
- * every scroll-based auto-load heuristic turns into a request loop). `hasMore`
- * doubles as the "log continues" signal.
+ * One stream's logs for the deployment-logs modal, requested with
+ * `order=desc`: page 1 is the log's true tail (the web-api assembles the
+ * newest-first view — the runner itself only pages forward) and each
+ * `loadMore` walks EARLIER into history via the server's offset cursor.
+ * `hasMore` doubles as the "history continues" signal.
  *
  * The modal must be conditionally rendered (`action && <Modal/>`), never kept
  * mounted behind an isOpen prop: abort-on-close works because unmounting drops
@@ -61,15 +60,22 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
     refetchOnWindowFocus: false,
   });
 
-  // Newest-first across ALL loaded pages. Each page arrives pre-sorted; the
-  // global re-sort is a cheap idempotent no-op when the runner reads from the
-  // tail (CloudWatch GetLogEvents' default — later pages are strictly older),
-  // and it keeps the display coherent if the runner turns out to page forward
-  // instead (the open ordering question with backend).
+  // Newest-first across ALL loaded pages. With order=desc, later pages are
+  // strictly older, so the global re-sort is a cheap idempotent safety net.
+  // The dedupe guards against cursor drift: the server's offset cursor is
+  // relative to the newest line, so lines arriving between two page requests
+  // (after its 15s walk cache expires) can shift the window and repeat a line.
   const events = useMemo<AiAppLogEvent[] | null>(() => {
     if (!query.data) return null;
+    const seen = new Set<string>();
     return query.data.pages
       .flatMap((page) => page.events)
+      .filter((event) => {
+        const key = `${event.timestamp}|${event.message}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
       .sort((a, b) => logTimestampSortValue(b.timestamp) - logTimestampSortValue(a.timestamp));
   }, [query.data]);
 

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -57,10 +57,21 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
     refetchOnWindowFocus: false,
   });
 
-  const events = useMemo<AiAppLogEvent[] | null>(
-    () => (query.data ? query.data.pages.flatMap((page) => page.events) : null),
-    [query.data],
-  );
+  // Newest-first across ALL loaded pages. Each page arrives pre-sorted; the
+  // global re-sort is a cheap idempotent no-op when the runner reads from the
+  // tail (CloudWatch GetLogEvents' default — later pages are strictly older),
+  // and it keeps the display coherent if the runner turns out to page forward
+  // instead (the open ordering question with backend).
+  const events = useMemo<AiAppLogEvent[] | null>(() => {
+    if (!query.data) return null;
+    return query.data.pages
+      .flatMap((page) => page.events)
+      .sort((a, b) => {
+        const ta = Number.isFinite(a.timestamp) ? a.timestamp : 0;
+        const tb = Number.isFinite(b.timestamp) ? b.timestamp : 0;
+        return tb - ta;
+      });
+  }, [query.data]);
 
   // A step can legitimately return zero events WITH a token (skip budget spent
   // on CloudWatch's sparse-window quirk). The modal must not auto-chain off

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 
 import { AiAppsQueryKeys } from '@/services/ai-apps/constants';
+import { logTimestampSortValue } from '@/services/ai-apps/ai-apps-logs.utils';
 import {
   fetchAiAppLogsPage,
   AiAppFetchErrorKind,
@@ -66,11 +67,7 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
     if (!query.data) return null;
     return query.data.pages
       .flatMap((page) => page.events)
-      .sort((a, b) => {
-        const ta = Number.isFinite(a.timestamp) ? a.timestamp : 0;
-        const tb = Number.isFinite(b.timestamp) ? b.timestamp : 0;
-        return tb - ta;
-      });
+      .sort((a, b) => logTimestampSortValue(b.timestamp) - logTimestampSortValue(a.timestamp));
   }, [query.data]);
 
   // A step can legitimately return zero events WITH a token (skip budget spent

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -1,9 +1,17 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 
 import { AiAppsQueryKeys } from '@/services/ai-apps/constants';
-import { fetchAiAppLogs, AiAppLogStream, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+import {
+  fetchAiAppLogsPage,
+  AiAppFetchErrorKind,
+  AiAppLogEvent,
+  AiAppLogsError,
+  AiAppLogsPage,
+  AiAppLogStream,
+} from '@/services/ai-apps/ai-apps.service';
 
 /**
  * Runtime is a continuous stream, so it gets a window; build logs are finite
@@ -13,8 +21,9 @@ const RUNTIME_WINDOW_MINUTES = 24 * 60;
 export const RUNTIME_WINDOW_LABEL = 'last 24 hours';
 
 /**
- * One stream's logs for the deployment-logs modal. No polling — data changes
- * only on open and on the modal's explicit Refresh (live tail is a v2 story).
+ * One stream's logs for the deployment-logs modal, paged by the runner's
+ * `nextToken`: the first page loads on open, further pages load as the reader
+ * scrolls (`loadMore`), and `hasMore` doubles as the "log continues" signal.
  *
  * The modal must be conditionally rendered (`action && <Modal/>`), never kept
  * mounted behind an isOpen prop: abort-on-close works because unmounting drops
@@ -28,13 +37,19 @@ export const RUNTIME_WINDOW_LABEL = 'last 24 hours';
  * exactly when the runner is unhealthy, and the user has Refresh.
  */
 export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { enabled: boolean }) {
-  const { data, isLoading, isRefetching, isError, refetch } = useQuery<FetchAiAppLogsResult>({
-    queryKey: [AiAppsQueryKeys.AI_APP_LOGS, uid, stream],
-    queryFn: ({ signal }) =>
-      fetchAiAppLogs(uid, stream, {
+  const queryClient = useQueryClient();
+  const queryKey = [AiAppsQueryKeys.AI_APP_LOGS, uid, stream];
+
+  const query = useInfiniteQuery<AiAppLogsPage, Error>({
+    queryKey,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ signal, pageParam }) =>
+      fetchAiAppLogsPage(uid, stream, {
         signal,
+        nextToken: pageParam as string | undefined,
         sinceMinutes: stream === 'runtime' ? RUNTIME_WINDOW_MINUTES : undefined,
       }),
+    getNextPageParam: (lastPage) => lastPage.nextToken,
     enabled: options.enabled,
     staleTime: 0,
     gcTime: 30_000,
@@ -42,5 +57,38 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
     refetchOnWindowFocus: false,
   });
 
-  return { result: data ?? null, isLoading, isRefetching, isError, refetch };
+  const events = useMemo<AiAppLogEvent[] | null>(
+    () => (query.data ? query.data.pages.flatMap((page) => page.events) : null),
+    [query.data],
+  );
+
+  // A step can legitimately return zero events WITH a token (skip budget spent
+  // on CloudWatch's sparse-window quirk). The modal must not auto-chain off
+  // that — it downgrades to the manual "Load more" button so a pathological
+  // stream of empty pages can't turn the scroll sentinel into a request loop.
+  const pages = query.data?.pages;
+  const lastPageHadEvents = !!pages && pages.length > 0 && pages[pages.length - 1].events.length > 0;
+
+  return {
+    events,
+    pageCount: pages?.length ?? 0,
+    /** Set only when the query has no data at all — the whole-body error states. */
+    errorKind:
+      !query.data && query.isError
+        ? query.error instanceof AiAppLogsError
+          ? query.error.errorKind
+          : ('network' as AiAppFetchErrorKind)
+        : null,
+    /** A later page failed while earlier pages render — inline retry, not a blank body. */
+    loadMoreFailed: !!query.data && query.isError,
+    isLoading: query.isLoading,
+    hasMore: !!query.hasNextPage,
+    canAutoLoad: !!query.hasNextPage && lastPageHadEvents,
+    isLoadingMore: query.isFetchingNextPage,
+    loadMore: () => {
+      if (query.hasNextPage && !query.isFetchingNextPage) void query.fetchNextPage();
+    },
+    /** Refresh = start over from page 1 (a plain refetch would replay every loaded page). */
+    refresh: () => queryClient.resetQueries({ queryKey }),
+  };
 }

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -23,8 +23,11 @@ export const RUNTIME_WINDOW_LABEL = 'last 24 hours';
 
 /**
  * One stream's logs for the deployment-logs modal, paged by the runner's
- * `nextToken`: the first page loads on open, further pages load as the reader
- * scrolls (`loadMore`), and `hasMore` doubles as the "log continues" signal.
+ * `nextToken`: the first page loads on open, further pages load via the
+ * modal's explicit "Load newer logs" button (`loadMore` — MANUAL by design:
+ * the runner pages forward, so appended lines sort in above the reader and
+ * every scroll-based auto-load heuristic turns into a request loop). `hasMore`
+ * doubles as the "log continues" signal.
  *
  * The modal must be conditionally rendered (`action && <Modal/>`), never kept
  * mounted behind an isOpen prop: abort-on-close works because unmounting drops
@@ -70,12 +73,7 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
       .sort((a, b) => logTimestampSortValue(b.timestamp) - logTimestampSortValue(a.timestamp));
   }, [query.data]);
 
-  // A step can legitimately return zero events WITH a token (skip budget spent
-  // on CloudWatch's sparse-window quirk). The modal must not auto-chain off
-  // that — it downgrades to the manual "Load more" button so a pathological
-  // stream of empty pages can't turn the scroll sentinel into a request loop.
   const pages = query.data?.pages;
-  const lastPageHadEvents = !!pages && pages.length > 0 && pages[pages.length - 1].events.length > 0;
 
   return {
     events,
@@ -91,7 +89,6 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
     loadMoreFailed: !!query.data && query.isError,
     isLoading: query.isLoading,
     hasMore: !!query.hasNextPage,
-    canAutoLoad: !!query.hasNextPage && lastPageHadEvents,
     isLoadingMore: query.isFetchingNextPage,
     loadMore: () => {
       if (query.hasNextPage && !query.isFetchingNextPage) void query.fetchNextPage();

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { AiAppsQueryKeys } from '@/services/ai-apps/constants';
+import { fetchAiAppLogs, AiAppLogStream, FetchAiAppLogsResult } from '@/services/ai-apps/ai-apps.service';
+
+/**
+ * Runtime is a continuous stream, so it gets a window; build logs are finite
+ * per deploy and fetch unwindowed (the fetcher's own bounds still apply).
+ */
+const RUNTIME_WINDOW_MINUTES = 24 * 60;
+export const RUNTIME_WINDOW_LABEL = 'last 24 hours';
+
+/**
+ * One stream's logs for the deployment-logs modal. No polling — data changes
+ * only on open and on the modal's explicit Refresh (live tail is a v2 story).
+ *
+ * The modal must be conditionally rendered (`action && <Modal/>`), never kept
+ * mounted behind an isOpen prop: abort-on-close works because unmounting drops
+ * the query's last observer while the queryFn consumes the signal. `enabled:
+ * false` alone never cancels an in-flight fetch.
+ *
+ * staleTime 0 → every open refetches (also the safety net for redeploys
+ * triggered outside this tab, e.g. by the agent). gcTime is short and only
+ * controls whether a quick reopen flashes the previous snapshot while the
+ * refetch runs — accepted. retry 0: a retry would hit the CloudWatch proxy
+ * exactly when the runner is unhealthy, and the user has Refresh.
+ */
+export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { enabled: boolean }) {
+  const { data, isLoading, isRefetching, isError, refetch } = useQuery<FetchAiAppLogsResult>({
+    queryKey: [AiAppsQueryKeys.AI_APP_LOGS, uid, stream],
+    queryFn: ({ signal }) =>
+      fetchAiAppLogs(uid, stream, {
+        signal,
+        sinceMinutes: stream === 'runtime' ? RUNTIME_WINDOW_MINUTES : undefined,
+      }),
+    enabled: options.enabled,
+    staleTime: 0,
+    gcTime: 30_000,
+    retry: 0,
+    refetchOnWindowFocus: false,
+  });
+
+  return { result: data ?? null, isLoading, isRefetching, isError, refetch };
+}

--- a/services/ai-apps/hooks/useAiAppLogs.ts
+++ b/services/ai-apps/hooks/useAiAppLogs.ts
@@ -81,9 +81,39 @@ export function useAiAppLogs(uid: string, stream: AiAppLogStream, options: { ena
 
   const pages = query.data?.pages;
 
+  // Did the server actually honor order=desc? A backend without the desc
+  // feature silently ignores the param and serves FORWARD pages — each later
+  // page then carries NEWER lines, which makes scroll-triggered loading
+  // unsafe (appends land above the reader and the bottom trigger never
+  // releases, chain-fetching the window). Descending pages are strictly
+  // older: every line of page N must be <= the oldest line of page N-1.
+  const pagesNewestFirst = useMemo(() => {
+    if (!pages) return true;
+    let previousOldest = Infinity;
+    for (const page of pages) {
+      if (page.events.length === 0) continue;
+      let pageNewest = -Infinity;
+      let pageOldest = Infinity;
+      for (const event of page.events) {
+        const value = logTimestampSortValue(event.timestamp);
+        if (value > pageNewest) pageNewest = value;
+        if (value < pageOldest) pageOldest = value;
+      }
+      if (pageNewest > previousOldest) return false;
+      previousOldest = pageOldest;
+    }
+    return true;
+  }, [pages]);
+
   return {
     events,
     pageCount: pages?.length ?? 0,
+    /**
+     * False = the backend ignored order=desc (feature not deployed there yet).
+     * The modal must not auto-load on scroll then — manual paging only — and
+     * the loaded lines are the window's OLDEST chunk, not the true tail.
+     */
+    pagesNewestFirst,
     /** Set only when the query has no data at all — the whole-body error states. */
     errorKind:
       !query.data && query.isError

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2381,4 +2381,7 @@ export const AI_APPS_ANALYTICS = {
   APP_DETAILS_OPENED: 'ai_apps_app_details_opened',
   PRD_OPEN_IN_NEW_TAB_CLICKED: 'ai_apps_prd_open_in_new_tab_clicked',
   PRD_PAGE_VIEWED: 'ai_apps_prd_page_viewed',
+  DEPLOYMENT_LOGS_OPENED: 'ai_apps_deployment_logs_opened',
+  DEPLOYMENT_LOGS_TAB_SWITCHED: 'ai_apps_deployment_logs_tab_switched',
+  DEPLOYMENT_LOGS_EXPORTED: 'ai_apps_deployment_logs_exported',
 };

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,15 +1,6 @@
 export const USE_ACCESS_CONTROL_V2 = process.env.NEXT_PUBLIC_USE_ACCESS_CONTROL_V2 === 'true';
 
 /**
- * AI Apps "Deployment logs" UI (kebab item + card failure-strip link). The
- * backend logs endpoints are agent-token-only until the owner/admin auth
- * change lands — flip this only after a non-owner 403 has been verified
- * against the target environment, or every open is a 403. UX gate only; the
- * server enforces access regardless. Inlined at build time (flip = redeploy).
- */
-export const AI_APPS_LOGS_ENABLED = process.env.NEXT_PUBLIC_AI_APPS_LOGS_ENABLED === 'true';
-
-/**
  * Per-objective rating rows in the boost popover ("Break it down by goal"). UI + payload
  * plumbing are built; flip to true once the backend accepts `objectiveImpacts` on the pin
  * POST/PATCH and returns per-objective aggregates. Code-level (not env) on purpose — it

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,6 +1,15 @@
 export const USE_ACCESS_CONTROL_V2 = process.env.NEXT_PUBLIC_USE_ACCESS_CONTROL_V2 === 'true';
 
 /**
+ * AI Apps "Deployment logs" UI (kebab item + card failure-strip link). The
+ * backend logs endpoints are agent-token-only until the owner/admin auth
+ * change lands — flip this only after a non-owner 403 has been verified
+ * against the target environment, or every open is a 403. UX gate only; the
+ * server enforces access regardless. Inlined at build time (flip = redeploy).
+ */
+export const AI_APPS_LOGS_ENABLED = process.env.NEXT_PUBLIC_AI_APPS_LOGS_ENABLED === 'true';
+
+/**
  * Per-objective rating rows in the boost popover ("Break it down by goal"). UI + payload
  * plumbing are built; flip to true once the backend accepts `objectiveImpacts` on the pin
  * POST/PATCH and returns per-objective aggregates. Code-level (not env) on purpose — it


### PR DESCRIPTION
## Summary

Productionizes the AI Apps deployment-logs prototype (#2683): app owners and directory admins can open **build and runtime logs** from the UI.

**Entry points:**
- **"Deployment logs"** item in the manage kebab (grid card + detail page; hidden for DRAFT apps, disabled until `canManage` verification like its siblings)
- **"See logs"** link in a new failure strip across the top of ERROR cards — the strip replaces the inline "Deploy failed" badge; the strip shows for every viewer, the link renders only for managers and sits as a sibling overlay (never nested inside the card's link/button)

**Modal** — Build/Runtime tabs with loaded-line counts (`N+` when more history remains), a **newest-first** log table: page 1 is the log's true tail, and scrolling toward the bottom auto-loads earlier history via `react-infinite-scroll-component` (house pattern), with a manual "Load earlier logs" row as the keyboard/retry fallback. Client-side search over loaded lines, **Refresh** (restarts from page 1), clipboard **Export** of the filtered lines, level dots derived from message text, viewer-local timestamps, and explicit states for loading / forbidden / not-found / network-failure / empty / no-matches, plus inline Retry when a later page fails (loaded lines never blank).

**Data layer** — `fetchAiAppLogsPage` + `useAiAppLogs` (`useInfiniteQuery`) against the member-JWT endpoints `GET /v1/ai-apps/:uid/{build,runtime}-logs` (route-level RBAC + creator-or-directory-admin check server-side), requested with **`order=desc`** (memser-spaceport/pln-directory-portal#3284, deployed): the web-api assembles the newest-first view server-side and `nextToken` walks earlier into history:
- `limit=500` per page; runtime windowed to 24h; a bounded skip loop absorbs CloudWatch's empty-page-with-token quirk (terminates on empty page / repeated token / 5 pages / 8s)
- **fallback**: the hook verifies pages actually arrive newest-first; against a backend that silently ignores `order=desc` it disarms scroll auto-load (forward pages would chain-fetch the whole window) and degrades to a manual "Load more logs" button
- pages are deduped and re-sorted globally (offset-cursor drift; runner sends string timestamps despite the number contract)
- `AbortError` is rethrown so a closed modal never caches a partial snapshot; conditional rendering aborts in-flight fetches
- logs cache dropped at both deploy call sites so a reopened modal never shows the previous deploy's lines

**Security/privacy** — log pane, search, and Export are `ph-no-capture` (PostHog replay/autocapture never sees log text); messages render as text nodes only with ANSI/control/bidi sequences stripped; analytics events carry counts, never log or search content.

## Testing

- 67 tests across 4 suites: page fetcher termination/abort/error mapping, hook ordering detection, derivation utils, modal states/search/export/analytics hygiene, card failure strip (manager gating, no nested interactive)
- Full ai-apps Jest sweep green (22 suites / 211 tests); `next build`, ESLint and Prettier clean on touched files
- Manual against the deployed backend: newest-first page 1, scroll loads earlier history, Refresh restarts, tab switch, search, export

## Remaining backend asks (non-blocking)

- **Timestamps arrive as strings** — the contract documents `timestamp: number`, but the runner delivers strings on the asc path (FE normalizes for sorting/formatting; worth fixing at the source)
- Allowlist the asc logs response to `{events, nextToken}` (runner envelope currently passes through verbatim, incl. `logGroup`; the desc path is already allowlisted)
- Optional: `filterPattern` pass-through for server-side search (FE search covers loaded lines only); secret-value redaction in log lines; `eventId` pass-through
- Distinguish "live app whose latest redeploy failed" from plain ERROR (single flat status today) — needed for the prototype's amber "Latest deploy didn't ship" card variant

## Design

Prototype: https://directoryv2.dev.plnetwork.io/prototypes/ai-apps (PR #2683). Deviations from the prototype, agreed during planning: newest-first infinite scroll instead of a 25-row paginated table, manual Refresh instead of auto-polling, neutral empty-runtime copy instead of the "never ran" claim (unverifiable under a windowed fetch), and exit-code/attempt/retention metadata omitted until the backend provides the fields.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
