### PR TITLE
feat(prototypes): warm intros v2 UX fixes

### DIFF
--- a/prototypes/AUTH-COPY-AUDIT.md
+++ b/prototypes/AUTH-COPY-AUDIT.md
@@ -1,0 +1,143 @@
+# Auth copy audit — "Log in" → "Sign in"
+
+Every visible string in the app that needs to change, with file, line, current text
+and replacement. Swept 2026-07-28 against `consistency-audit`.
+
+## The standard
+
+- **Sign in · Sign up · Sign out** — always these verbs, never *log in / login / logout*.
+- **Sentence case** — "Sign in", not "Sign In". Applies mid-sentence too:
+  "Sign in to view updates", not "Sign In to View Updates".
+- **Visible strings only.** Identifiers, routes, events and analytics names are
+  explicitly out of scope — see the exclusion list at the bottom. Renaming those
+  breaks deep links and analytics dashboards without changing a single pixel.
+
+Total: **25 strings across 15 files.** None of it is behavioural — every change is
+a string literal or a JSX text node.
+
+---
+
+## A. Wrong verb — buttons, links, menu items
+
+These say *log in / login / logout* where they should say *sign in / sign out*.
+
+| # | Location | Current | Replace with |
+|---|---|---|---|
+| 1 | [AccountMenu.tsx:111](../components/core/navbar/components/AccountMenu/AccountMenu.tsx#L111) | `Logout` | `Sign out` |
+| 2 | [MemberDetailsLoginStrip.tsx:46](../components/page/member-details/member-details-login-strip/MemberDetailsLoginStrip.tsx#L46) | `Login` | `Sign in` |
+| 3 | [team-login-info.tsx:25](../components/page/team-form-info/team-login-info.tsx#L25) | `Proceed to Login` | `Sign in` |
+| 4 | [IrlGatheringModal.tsx:478](../components/core/UpdatesPanel/IrlGatheringModal/IrlGatheringModal.tsx#L478) | `Log in to Respond` | `Sign in to respond` |
+| 5 | [AccountCreatedSuccessModal.tsx:186](../components/page/demo-day/ApplyForDemoDayModal/AccountCreatedSuccessModal.tsx#L186) | `Log In To Set Up Investor Profile` | `Sign in to set up investor profile` |
+| 6 | [AccountCreatedSuccessModal.tsx:189](../components/page/demo-day/ApplyForDemoDayModal/AccountCreatedSuccessModal.tsx#L189) | `Log In To Review Investor Profile` | `Sign in to review investor profile` |
+| 7 | [AppliedInvestorSteps.tsx:93](../components/page/demo-day/AppliedInvestorSteps/AppliedInvestorSteps.tsx#L93) | `Log In To ` (prefix concatenated onto "Set Up / Review Investor Profile") | `Sign in to ` |
+| 8 | [stories/Header.tsx:34](../stories/Header.tsx#L34) | `label="Log out"` | `label="Sign out"` |
+
+**#7 is the one to read carefully.** It builds the label by concatenation:
+`` `${!isLoggedIn ? 'Log In To ' : ''}${isNew ? 'Set Up Investor Profile' : 'Review Investor Profile'}` ``.
+Fixing the prefix alone yields "Sign in to Set Up Investor Profile" — the tail is
+title-case too. Sentence-casing the whole label means changing both halves, and the
+tail is also used standalone when signed in. Decide whether the signed-in label
+becomes sentence case as well, or keep the two cases divergent on purpose.
+
+**#8 is Storybook only** — a demo header, not product surface. Include it for
+consistency or skip it; it ships to no user.
+
+---
+
+## B. Right verb, wrong case
+
+Already "Sign in/up", but title-cased.
+
+| # | Location | Current | Replace with |
+|---|---|---|---|
+| 9 | [SessionExpiredModal.tsx:46](../components/core/login/components/modals/SessionExpiredModal/SessionExpiredModal.tsx#L46) | `label: 'Sign In'` | `label: 'Sign in'` |
+| 10 | [NotLoggedInState.tsx:40](../components/core/UpdatesPanel/NotLoggedInState.tsx#L40) | `Sign In to View Updates` | `Sign in to view updates` |
+| 11 | [NotLoggedInState.tsx:45](../components/core/UpdatesPanel/NotLoggedInState.tsx#L45) | `Sign Up` | `Sign up` |
+| 12 | [Welcome.tsx:18](../components/page/home/Welcome/Welcome.tsx#L18) | `Sign In` | `Sign in` |
+| 13 | [AuthSection.tsx:45](../components/page/member-details/ForumActivity/components/ForumActivityCardsList/components/AuthSection/AuthSection.tsx#L45) | `Sign In` | `Sign in` |
+| 14 | [AuthSection.tsx:56](../components/page/member-details/ForumActivity/components/ForumActivityCardsList/components/AuthSection/AuthSection.tsx#L56) | `Sign Up` | `Sign up` |
+| 15 | [LoggedOutView.tsx:130](../components/page/forum/LoggedOutView/LoggedOutView.tsx#L130) | `Sign Up` | `Sign up` |
+| 16 | [GuestAccessModal.tsx:61](../components/page/aligement-assets/guest-access-modal/GuestAccessModal.tsx#L61) | `Sign Up` | `Sign up` |
+| 17 | [overview-page.tsx:343](../components/page/aligement-assets/overview/overview-page.tsx#L343) | `Sign Up to Join the Private Beta` | `Sign up to join the private beta` |
+
+**#9 sits next to already-correct copy.** The same modal's description reads
+"Please sign in again to continue" — so the button contradicts the sentence above it.
+Good one to fix first; it's the clearest evidence the standard is real.
+
+**#17 is a marketing section title** on the alignment-assets overview, where
+surrounding titles may be title-case by design. Check its neighbours before
+sentence-casing it alone.
+
+---
+
+## C. Body copy
+
+| # | Location | Current | Replace with |
+|---|---|---|---|
+| 18 | [constants.ts:293](../utils/constants.ts#L293) `LOGOUT_MSG` | `You have been logged out successfully` | `You have been signed out successfully` |
+| 19 | [constants.ts:295](../utils/constants.ts#L295) `LOGGED_IN_MSG` | `You are already logged in` | `You are already signed in` |
+| 20 | [constants.ts:753, 755, 757, 759, 761, 763, 765](../utils/constants.ts#L753) | `…to all logged in members` (×7: email, GitHub, Telegram, LinkedIn, Discord, office hours, Twitter) | `…to all signed-in members` |
+| 21 | [constants.ts:1754](../utils/constants.ts#L1754) | `link your directory membership email to a login method of your choice` | `…to a sign-in method of your choice` |
+| 22 | [team-login-info.tsx:19](../components/page/team-form-info/team-login-info.tsx#L19) | `You need to sign in to submit a team.Please login to proceed.` | `You need to sign in to submit a team.` |
+| 23 | [faqs.tsx:41](../components/page/aligement-assets/faqs/faqs.tsx#L41) | `including login problems or wallet access` | `including sign-in problems or wallet access` |
+
+**#20 is one find-and-replace** — seven help-text strings sharing the same phrasing.
+Note the hyphen: "signed-in members" is attributive, so it hyphenates, unlike the
+verb form in #18/#19.
+
+**#22 carries a real bug**, not just wrong copy: there's a missing space after the
+full stop (`team.Please`), and the sentence says the same thing twice. The proposed
+replacement drops the second clause entirely — the button right below it already
+says what to do.
+
+**#21 is transactional email HTML**, so it ships outside the app. Worth confirming
+whether the template is also duplicated server-side before calling it done.
+
+---
+
+## D. Assistive text
+
+| # | Location | Current | Note |
+|---|---|---|---|
+| 24 | [userProfile.tsx:86](../components/core/navbar/userProfile.tsx#L86) | `alt="logout"` | Screen-reader text on the icon inside the sign-out control |
+| 25 | [AccountMenu.tsx:111](../components/core/navbar/components/AccountMenu/AccountMenu.tsx#L111) | `<LogoutIcon /> Logout` | Same control as #1 — the icon component name stays, only the text changes |
+
+For #24 the icon sits inside a labelled control, so the better fix is `alt=""` —
+decorative — rather than translating the word. Announcing "logout" *and* the button
+label is a duplicate announcement.
+
+---
+
+## Explicitly out of scope — do not rename
+
+A future sweep will match these; they are deliberate exclusions.
+
+| What | Where | Why |
+|---|---|---|
+| `#login` hash route | ~25 files (`router.push(…#login)`, `redirect(…#login)`, `proxy.ts:54`) | Deep links and email links point at it; renaming breaks them |
+| `auth:init-login`, `auth:login-success`, `auth:logout`, `auth:logout-success` | [authEvents.ts](../components/core/login/utils/authEvents.ts) | Internal event contract |
+| PostHog event names | `analytics/*.analytics.ts`, `utils/constants.ts` (e.g. `session-expired-popup-login-btn-clicked`, `on-login-button-clicked`) | Renaming silently breaks historical dashboards |
+| Component + file names | `LoginBtn`, `LoginFlowTrigger`, `NotLoggedInState`, `MemberDetailsLoginStrip`, `team-login-info.tsx`, `LoggedOutView` | Identifiers, not copy |
+| CSS class names | `.login-info`, `.loginButton`, `.signInButton`, `.triggerLoginButton` | Identifiers |
+| `localStorage` key | `directory-logout` in [PrivyModals.tsx:387](../components/core/login/components/PrivyModals/PrivyModals.tsx#L387) | Changing it signs everyone out mid-session |
+| API path | `/v1/auth/login-token/redeem` in [auth.service.ts:147](../services/auth.service.ts#L147) | Backend contract |
+| Asset URLs | `login-banner.png`, `/icons/logout.svg` | Hosted filenames |
+| Test assertions on `#login` | `__tests__/page/home/*`, `__tests__/core/login/*` | Follow the route, not the copy |
+| Changelog entry | [product-versions.tsx:46](../components/page/aligement-assets/product-versions/product-versions.tsx#L46) — "Removed the strict login gate" | Historical record of what shipped; rewriting it falsifies it |
+
+---
+
+## Suggested order
+
+1. **#9** — the button contradicting its own modal description.
+2. **Section B** — pure casing, no wording judgement, 9 strings.
+3. **Section A** minus #7 — straightforward verb swaps.
+4. **#20** — the seven-way help-text replace.
+5. **#7, #17, #22** — each needs a decision, not just a replacement.
+6. **#24** — an a11y fix that happens to touch the same word.
+
+After the sweep, this regex should return only excluded matches:
+
+```
+rg -n "Log ?[Ii]n|Log ?[Oo]ut|Sign In|Sign Up|Sign Out" --glob '!**/node_modules/**'
+```

--- a/prototypes/entries/auth-copy-audit/AuthCopyAudit.module.scss
+++ b/prototypes/entries/auth-copy-audit/AuthCopyAudit.module.scss
@@ -1,0 +1,301 @@
+/**
+ * Auth copy audit page. New UI, so every color is a token + fallback pair per
+ * prototypes/CLAUDE.md §3–4, and type sizes stay on the scale (§5).
+ */
+
+.page {
+  min-height: 100%;
+  background: var(--background-neutral-subtle, #f1f5f9);
+  font-family: 'Inter', sans-serif;
+}
+
+@media (min-width: 1024px) {
+  .page {
+    padding: 30px 24px 40px;
+  }
+}
+
+.sheet {
+  max-width: 1040px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 12px;
+  padding: 20px 24px;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────── */
+
+.title {
+  margin: 0 0 6px;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+  letter-spacing: -0.4px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.lead {
+  margin: 0;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.statNum {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+/* ── The standard ───────────────────────────────────────────────────── */
+
+.ruleList {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.ruleList strong {
+  color: var(--foreground-neutral-primary, #0a0c11);
+  font-weight: 600;
+}
+
+.sectionTitle {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--foreground-brand-primary, #1b4dff);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.countPill {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.blurb {
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/* ── Findings ───────────────────────────────────────────────────────── */
+
+.findings {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.finding {
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.findingHead {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.num {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  flex-shrink: 0;
+}
+
+.where {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.path {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+.swap {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.from,
+.to {
+  font-size: 14px;
+  line-height: 22px;
+  padding: 3px 10px;
+  border-radius: 6px;
+}
+
+.from {
+  background: var(--background-error-subtle, #fef2f2);
+  color: var(--foreground-error-primary, #b91c1c);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+.to {
+  background: var(--background-success-subtle, #f0fdf4);
+  color: var(--foreground-success-primary, #0a9952);
+  font-weight: 500;
+}
+
+.arrow {
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  flex-shrink: 0;
+}
+
+.note {
+  margin: 10px 0 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/* ── Exclusions ─────────────────────────────────────────────────────── */
+
+.exclusionIntro {
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.tableWrap {
+  margin-top: 14px;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 14px;
+}
+
+.th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  border-bottom: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  white-space: nowrap;
+}
+
+.td {
+  padding: 10px 12px;
+  vertical-align: top;
+  line-height: 20px;
+  border-bottom: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.tdWhat {
+  color: var(--foreground-neutral-primary, #0a0c11);
+  font-weight: 500;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+/* ── Order + verify ─────────────────────────────────────────────────── */
+
+.orderList {
+  margin: 12px 0 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.verify {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 20px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/prototypes/entries/auth-copy-audit/AuthCopyAuditPrototype.tsx
+++ b/prototypes/entries/auth-copy-audit/AuthCopyAuditPrototype.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * Auth copy audit — a shareable read-only page listing every visible string that
+ * needs "log in" → "sign in", plus the identifiers that must NOT be renamed.
+ *
+ * Content lives in findings.ts and mirrors prototypes/AUTH-COPY-AUDIT.md.
+ * No mock product UI here: this is a document, so it is plain semantic markup
+ * rather than a reconstruction of any production screen.
+ */
+
+import { BRANCH, EXCLUSIONS, FILE_COUNT, ORDER, SECTIONS, SWEPT_ON, TOTAL, type Finding } from './findings';
+import s from './AuthCopyAudit.module.scss';
+
+const VERIFY_COMMAND = `rg -n "Log ?[Ii]n|Log ?[Oo]ut|Sign In|Sign Up|Sign Out" --glob '!**/node_modules/**'`;
+
+function FindingRow({ finding }: { finding: Finding }) {
+  return (
+    <li className={s.finding}>
+      <div className={s.findingHead}>
+        <span className={s.num}>#{finding.id}</span>
+        <span className={s.where}>{finding.where}</span>
+        <span className={s.path}>{finding.path}</span>
+      </div>
+
+      <div className={s.swap}>
+        <span className={s.from}>{finding.current}</span>
+        <span className={s.arrow} aria-label="becomes">
+          →
+        </span>
+        <span className={s.to}>{finding.replacement}</span>
+      </div>
+
+      {finding.note ? <p className={s.note}>{finding.note}</p> : null}
+    </li>
+  );
+}
+
+export default function AuthCopyAuditPrototype() {
+  return (
+    <div className={s.page}>
+      <div className={s.sheet}>
+        <header className={s.card}>
+          <h1 className={s.title}>Auth copy audit — “Log in” → “Sign in”</h1>
+          <p className={s.lead}>
+            Every visible string in the app that needs to change, with file, line, current text and replacement. Nothing
+            here is behavioural — each change is a string literal or a JSX text node.
+          </p>
+          <div className={s.metaRow}>
+            <span className={s.stat}>
+              <span className={s.statNum}>{TOTAL}</span> strings
+            </span>
+            <span className={s.stat}>
+              <span className={s.statNum}>{FILE_COUNT}</span> files
+            </span>
+            <span className={s.stat}>Swept {SWEPT_ON}</span>
+            <span className={s.stat}>
+              branch <span className={s.mono}>{BRANCH}</span>
+            </span>
+          </div>
+        </header>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>The standard</h2>
+          <ul className={s.ruleList}>
+            <li>
+              <strong>Sign in · Sign up · Sign out</strong> — always these verbs, never <em>log in / login / logout</em>
+              .
+            </li>
+            <li>
+              <strong>Sentence case</strong> — “Sign in”, not “Sign In”. Applies mid-sentence too: “Sign in to view
+              updates”, not “Sign In to View Updates”.
+            </li>
+            <li>
+              <strong>Visible strings only.</strong> Identifiers, routes, events and analytics names are out of scope —
+              renaming those breaks deep links and dashboards without changing a single pixel.
+            </li>
+          </ul>
+        </section>
+
+        {SECTIONS.map((section) => (
+          <section key={section.key} className={s.card}>
+            <h2 className={s.sectionTitle}>
+              <span className={s.letter} aria-hidden>
+                {section.letter}
+              </span>
+              {section.title}
+              <span className={s.countPill}>
+                {section.findings.length} {section.findings.length === 1 ? 'string' : 'strings'}
+              </span>
+            </h2>
+            <p className={s.blurb}>{section.blurb}</p>
+            <ul className={s.findings}>
+              {section.findings.map((finding) => (
+                <FindingRow key={finding.id} finding={finding} />
+              ))}
+            </ul>
+          </section>
+        ))}
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Out of scope — do not rename</h2>
+          <p className={s.exclusionIntro}>
+            A future sweep will match all of these. They are deliberate exclusions, not misses.
+          </p>
+          <div className={s.tableWrap}>
+            <table className={s.table}>
+              <thead>
+                <tr>
+                  <th className={s.th} scope="col">
+                    What
+                  </th>
+                  <th className={s.th} scope="col">
+                    Where
+                  </th>
+                  <th className={s.th} scope="col">
+                    Why
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {EXCLUSIONS.map((ex) => (
+                  <tr key={ex.what}>
+                    <td className={`${s.td} ${s.tdWhat}`}>{ex.what}</td>
+                    <td className={`${s.td} ${s.mono}`}>{ex.where}</td>
+                    <td className={s.td}>{ex.why}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Suggested order</h2>
+          <ol className={s.orderList}>
+            {ORDER.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+          <p className={s.blurb} style={{ marginTop: 16 }}>
+            After the sweep, this should return only excluded matches:
+          </p>
+          <div className={s.verify}>{VERIFY_COMMAND}</div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/prototypes/entries/auth-copy-audit/findings.ts
+++ b/prototypes/entries/auth-copy-audit/findings.ts
@@ -1,0 +1,313 @@
+/**
+ * The auth copy audit as data. Mirrors prototypes/AUTH-COPY-AUDIT.md — when one
+ * changes, change the other. Line numbers were swept 2026-07-28 against
+ * `consistency-audit`; they drift as the files move.
+ */
+
+export type Finding = {
+  id: number;
+  /** Display label, e.g. "AccountMenu.tsx:111". */
+  where: string;
+  /** Repo-relative path, for the GitHub-style hint under the label. */
+  path: string;
+  current: string;
+  replacement: string;
+  /** Shown when the fix needs a decision rather than a find-and-replace. */
+  note?: string;
+};
+
+export type Section = {
+  key: string;
+  letter: string;
+  title: string;
+  blurb: string;
+  findings: Finding[];
+};
+
+export const SECTIONS: Section[] = [
+  {
+    key: 'verb',
+    letter: 'A',
+    title: 'Wrong verb',
+    blurb: 'Buttons, links and menu items that say log in / login / logout where they should say sign in / sign out.',
+    findings: [
+      {
+        id: 1,
+        where: 'AccountMenu.tsx:111',
+        path: 'components/core/navbar/components/AccountMenu',
+        current: 'Logout',
+        replacement: 'Sign out',
+      },
+      {
+        id: 2,
+        where: 'MemberDetailsLoginStrip.tsx:46',
+        path: 'components/page/member-details/member-details-login-strip',
+        current: 'Login',
+        replacement: 'Sign in',
+      },
+      {
+        id: 3,
+        where: 'team-login-info.tsx:25',
+        path: 'components/page/team-form-info',
+        current: 'Proceed to Login',
+        replacement: 'Sign in',
+      },
+      {
+        id: 4,
+        where: 'IrlGatheringModal.tsx:478',
+        path: 'components/core/UpdatesPanel/IrlGatheringModal',
+        current: 'Log in to Respond',
+        replacement: 'Sign in to respond',
+      },
+      {
+        id: 5,
+        where: 'AccountCreatedSuccessModal.tsx:186',
+        path: 'components/page/demo-day/ApplyForDemoDayModal',
+        current: 'Log In To Set Up Investor Profile',
+        replacement: 'Sign in to set up investor profile',
+      },
+      {
+        id: 6,
+        where: 'AccountCreatedSuccessModal.tsx:189',
+        path: 'components/page/demo-day/ApplyForDemoDayModal',
+        current: 'Log In To Review Investor Profile',
+        replacement: 'Sign in to review investor profile',
+      },
+      {
+        id: 7,
+        where: 'AppliedInvestorSteps.tsx:93',
+        path: 'components/page/demo-day/AppliedInvestorSteps',
+        current: "'Log In To ' prefix, concatenated onto “Set Up / Review Investor Profile”",
+        replacement: "'Sign in to '",
+        note: 'Fixing the prefix alone yields “Sign in to Set Up Investor Profile” — the tail is title-case too, and is used standalone when signed in. Decide whether that signed-in label also becomes sentence case, or whether the two stay divergent on purpose.',
+      },
+      {
+        id: 8,
+        where: 'stories/Header.tsx:34',
+        path: 'stories',
+        current: 'label="Log out"',
+        replacement: 'label="Sign out"',
+        note: 'Storybook demo header — ships to no user. Include for consistency or skip.',
+      },
+    ],
+  },
+  {
+    key: 'case',
+    letter: 'B',
+    title: 'Right verb, wrong case',
+    blurb: 'Already “Sign in / Sign up”, but title-cased. Sentence case applies mid-sentence too.',
+    findings: [
+      {
+        id: 9,
+        where: 'SessionExpiredModal.tsx:46',
+        path: 'components/core/login/components/modals/SessionExpiredModal',
+        current: "label: 'Sign In'",
+        replacement: "label: 'Sign in'",
+        note: 'The same modal’s description already reads “Please sign in again to continue” — the button contradicts the sentence above it. Clearest first fix.',
+      },
+      {
+        id: 10,
+        where: 'NotLoggedInState.tsx:40',
+        path: 'components/core/UpdatesPanel',
+        current: 'Sign In to View Updates',
+        replacement: 'Sign in to view updates',
+      },
+      {
+        id: 11,
+        where: 'NotLoggedInState.tsx:45',
+        path: 'components/core/UpdatesPanel',
+        current: 'Sign Up',
+        replacement: 'Sign up',
+      },
+      {
+        id: 12,
+        where: 'Welcome.tsx:18',
+        path: 'components/page/home/Welcome',
+        current: 'Sign In',
+        replacement: 'Sign in',
+      },
+      {
+        id: 13,
+        where: 'AuthSection.tsx:45',
+        path: 'components/page/member-details/ForumActivity/…/AuthSection',
+        current: 'Sign In',
+        replacement: 'Sign in',
+      },
+      {
+        id: 14,
+        where: 'AuthSection.tsx:56',
+        path: 'components/page/member-details/ForumActivity/…/AuthSection',
+        current: 'Sign Up',
+        replacement: 'Sign up',
+      },
+      {
+        id: 15,
+        where: 'LoggedOutView.tsx:130',
+        path: 'components/page/forum/LoggedOutView',
+        current: 'Sign Up',
+        replacement: 'Sign up',
+      },
+      {
+        id: 16,
+        where: 'GuestAccessModal.tsx:61',
+        path: 'components/page/aligement-assets/guest-access-modal',
+        current: 'Sign Up',
+        replacement: 'Sign up',
+      },
+      {
+        id: 17,
+        where: 'overview-page.tsx:343',
+        path: 'components/page/aligement-assets/overview',
+        current: 'Sign Up to Join the Private Beta',
+        replacement: 'Sign up to join the private beta',
+        note: 'A marketing section title, where neighbouring titles may be title-case by design. Check them before sentence-casing this one alone.',
+      },
+    ],
+  },
+  {
+    key: 'body',
+    letter: 'C',
+    title: 'Body copy',
+    blurb: 'Toasts, help text and transactional email.',
+    findings: [
+      {
+        id: 18,
+        where: 'constants.ts:293 — LOGOUT_MSG',
+        path: 'utils',
+        current: 'You have been logged out successfully',
+        replacement: 'You have been signed out successfully',
+      },
+      {
+        id: 19,
+        where: 'constants.ts:295 — LOGGED_IN_MSG',
+        path: 'utils',
+        current: 'You are already logged in',
+        replacement: 'You are already signed in',
+      },
+      {
+        id: 20,
+        where: 'constants.ts:753–765',
+        path: 'utils',
+        current: '…to all logged in members (×7: email, GitHub, Telegram, LinkedIn, Discord, office hours, Twitter)',
+        replacement: '…to all signed-in members',
+        note: 'One find-and-replace across seven help strings. Note the hyphen: “signed-in members” is attributive, unlike the verb form in #18 and #19.',
+      },
+      {
+        id: 21,
+        where: 'constants.ts:1754',
+        path: 'utils',
+        current: 'link your directory membership email to a login method of your choice',
+        replacement: '…to a sign-in method of your choice',
+        note: 'Transactional email HTML — ships outside the app. Confirm the template isn’t duplicated server-side before calling it done.',
+      },
+      {
+        id: 22,
+        where: 'team-login-info.tsx:19',
+        path: 'components/page/team-form-info',
+        current: 'You need to sign in to submit a team.Please login to proceed.',
+        replacement: 'You need to sign in to submit a team.',
+        note: 'Carries a real bug, not just wrong copy: missing space after the full stop, and the sentence says the same thing twice. The button directly below already says what to do.',
+      },
+      {
+        id: 23,
+        where: 'faqs.tsx:41',
+        path: 'components/page/aligement-assets/faqs',
+        current: 'including login problems or wallet access',
+        replacement: 'including sign-in problems or wallet access',
+      },
+    ],
+  },
+  {
+    key: 'a11y',
+    letter: 'D',
+    title: 'Assistive text',
+    blurb: 'Not visible, but read aloud.',
+    findings: [
+      {
+        id: 24,
+        where: 'userProfile.tsx:86',
+        path: 'components/core/navbar',
+        current: 'alt="logout"',
+        replacement: 'alt=""',
+        note: 'The icon sits inside an already-labelled control, so the fix is to make it decorative rather than translate the word — otherwise it announces twice.',
+      },
+      {
+        id: 25,
+        where: 'AccountMenu.tsx:111',
+        path: 'components/core/navbar/components/AccountMenu',
+        current: '<LogoutIcon /> Logout',
+        replacement: '<LogoutIcon /> Sign out',
+        note: 'Same control as #1 — the icon component name stays, only the text changes.',
+      },
+    ],
+  },
+];
+
+export type Exclusion = { what: string; where: string; why: string };
+
+export const EXCLUSIONS: Exclusion[] = [
+  {
+    what: '#login hash route',
+    where: '~25 files — router.push(…#login), redirect(…#login), proxy.ts:54',
+    why: 'Deep links and email links point at it; renaming breaks them',
+  },
+  {
+    what: 'auth:init-login, auth:login-success, auth:logout, auth:logout-success',
+    where: 'components/core/login/utils/authEvents.ts',
+    why: 'Internal event contract',
+  },
+  {
+    what: 'PostHog event names',
+    where: 'analytics/*.analytics.ts, utils/constants.ts',
+    why: 'Renaming silently breaks historical dashboards',
+  },
+  {
+    what: 'Component and file names',
+    where: 'LoginBtn, LoginFlowTrigger, NotLoggedInState, MemberDetailsLoginStrip, team-login-info.tsx, LoggedOutView',
+    why: 'Identifiers, not copy',
+  },
+  {
+    what: 'CSS class names',
+    where: '.login-info, .loginButton, .signInButton, .triggerLoginButton',
+    why: 'Identifiers',
+  },
+  {
+    what: 'localStorage key directory-logout',
+    where: 'components/core/login/components/PrivyModals/PrivyModals.tsx:387',
+    why: 'Changing it signs everyone out mid-session',
+  },
+  {
+    what: 'API path /v1/auth/login-token/redeem',
+    where: 'services/auth.service.ts:147',
+    why: 'Backend contract',
+  },
+  {
+    what: 'Asset URLs',
+    where: 'login-banner.png, /icons/logout.svg',
+    why: 'Hosted filenames',
+  },
+  {
+    what: 'Test assertions on #login',
+    where: '__tests__/page/home/*, __tests__/core/login/*',
+    why: 'They follow the route, not the copy',
+  },
+  {
+    what: 'Changelog entry “Removed the strict login gate”',
+    where: 'components/page/aligement-assets/product-versions/product-versions.tsx:46',
+    why: 'Historical record of what shipped; rewriting it falsifies it',
+  },
+];
+
+export const ORDER: string[] = [
+  '#9 — the button contradicting its own modal description.',
+  'Section B — pure casing, no wording judgement, 9 strings.',
+  'Section A minus #7 — straightforward verb swaps.',
+  '#20 — the seven-way help-text replace.',
+  '#7, #17, #22 — each needs a decision, not just a replacement.',
+  '#24 — an a11y fix that happens to touch the same word.',
+];
+
+export const TOTAL = SECTIONS.reduce((n, s) => n + s.findings.length, 0);
+export const FILE_COUNT = 15;
+export const SWEPT_ON = '28 July 2026';
+export const BRANCH = 'consistency-audit';

--- a/prototypes/entries/warm-intros-v2/COMPONENTS.md
+++ b/prototypes/entries/warm-intros-v2/COMPONENTS.md
@@ -1,0 +1,90 @@
+# warm-intros-v2 — reuse map
+
+Clone of the production **Warm Intros v2** workspace
+(`components/page/investors/WarmIntrosV2Workspace/`) running on mocked data.
+
+The rule here: **nothing about the visual layer is re-created.** Every class name and
+every `.module.scss` comes from production, so the prototype drifts only when
+production drifts.
+
+## Imported straight from production (do not copy into this folder)
+
+| What | Path |
+| --- | --- |
+| Results table **styles** | `@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss` |
+| Glossary drawer | `…/WarmIntrosV2GlossaryDrawer` |
+| Score % pill | `…/ScorePercentPill` |
+| Person chip | `…/PathProfileChip` |
+| CSV export | `…/exportWarmIntrosV2Csv` |
+| hopChain parsing + proximity derivation | `…/parseWarmPathHopChain` |
+| MasterProfile display helpers | `…/masterProfileDisplay.util` |
+| Workspace / drawer / modal styles | `…/WarmIntrosV2Workspace.module.scss`, `…/WarmIntrosV2InvestorDrawer.module.scss`, `…/MasterProfileModal.module.scss` |
+| Proximity badge | `@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge` |
+| Sector chips | `@/components/page/investors/SectorTagsList/SectorTagsList` |
+| Filter dropdowns | `@/components/common/filters/FilterSelect/FilterSelect` |
+| Drawer / Modal / CopyButton | `@/components/common/Drawer/Drawer`, `@/components/common/Modal`, `@/components/ui/CopyButton` |
+| Avatar fallback | `@/hooks/useDefaultAvatar` → `getDefaultAvatar` |
+| Types + target-set constants | `@/services/investors/warm-intros-v2.types` |
+
+## Transcribed here (only because production calls the API)
+
+| File | Production source | What changed |
+| --- | --- | --- |
+| `WarmIntrosV2Prototype.tsx` | `WarmIntrosV2Workspace.tsx` | `useQueryStates` (nuqs) → `useState`; `useWarmIntrosV2Paths` / `useWarmIntrosV2Facets` / `useGetInvestorLists` → mock selectors; infinite scroll dropped (14 rows fit one page); PostHog analytics dropped |
+| `InvestorDrawerMock.tsx` | `WarmIntrosV2InvestorDrawer.tsx` | `useWarmIntrosV2PathsForInvestor` + `useMasterProfile` → mock lookups |
+| `MasterProfileModalMock.tsx` | `MasterProfileModal.tsx` | `useMasterProfile` → `MOCK_MASTER_PROFILES[uid]`; loading / error branches are inert |
+| `WarmIntrosV2TableMock.tsx` | `WarmIntrosV2Table.tsx` | **Team** and **Industry / Sector** columns removed (a design change, not a data one); firm · role folded under the investor name; column widths re-balanced in `TableColumns.module.scss` |
+
+## New UI (no production counterpart)
+
+| File | What it is |
+| --- | --- |
+| `PathFeedback.tsx` | The action strip at the foot of every grey path card (`.pathItem`): `Can you refer?` → inline Yes / No, an answered state with Undo, and the `Give feedback` link |
+| `PathFeedbackModal.tsx` | The feedback modal — the path restated as avatar chips, and one free-text box with a 600-char counter |
+| `PathFeedback.module.scss` | Styling for both. New UI, so every color is a `var(--token, #fallback)` pair per `prototypes/CLAUDE.md` §3–4 |
+
+Design intent, so it doesn't get re-litigated:
+
+- **No pencil.** Nothing on the card is editable — you're reporting that the graph
+  is wrong — so the affordance is a labelled `Give feedback` link, not an edit icon.
+  It stays a quiet text button because the card repeats for every alternate.
+- **At rest the strip is two text links in the card's right corner.** Neither action
+  gets clicked often, so neither gets a bordered button. Clicking `Can you refer?`
+  promotes the question to the left of the row, where Yes / No do get real button
+  affordance; `Give feedback` stays pinned right so it never changes position.
+- **The modal restates the path with the drawer's own avatar chips** (`PathProfileChip.module.scss`
+  + the drawer's `.chain` / `.node` / `.arrow`), rendered as spans. `pointer-events: none`
+  drops the affordance without touching production's chip colors — mid-report is no
+  place to navigate off to a profile.
+- **Free text only.** The modal is one box. Nothing is pre-categorised, so whatever
+  is wrong gets said in the reporter's own words rather than squeezed into a chip.
+- **`No` asks no follow-up.** The verdict is the signal. A "Why not?" chip row was
+  a second question competing with `Give feedback` — the affordance already sitting
+  on the same row and built to answer it.
+- **Answers replace the question.** Answering shows the answer plus Undo rather than
+  resetting, so the same path doesn't get answered twice. `FEEDBACK_STORE` (a module
+  Map standing in for the mutation) keeps that across drawer open/close.
+- Chrome is the shared content-modal pattern (`SubmitDealModal.module.scss` + `Modal`),
+  the same one `MasterProfileModalMock` uses. `Modal` binds Escape in the capture phase
+  with `stopImmediatePropagation`, so Esc closes the modal and leaves the drawer open.
+
+Markup inside those three is a verbatim transcription — if you change the shape of a
+row or a section, change it here on purpose, not by accident.
+
+## Mock data (`mocks.ts`)
+
+- 14 investors across the two real target sets (`neuro-fund-i`, `gold-co-investors`)
+- 6 PL connectors, mirroring the "six connectors" the glossary describes
+- `derivePathProximity()` (production) generates every `proximityCode`, `caliber`,
+  `scorePercent` and `scoreBand`, so band colors match production rules exactly
+- `hopChain` uses the real `pl_direct` shape: `hops` / `reasons` / `alternates`
+- A `MasterProfileDetail` exists for every investor **and** connector, so every chip
+  in the table and drawer opens a populated modal
+- All names, firms, emails and Affinity ids are invented
+
+## Local CSS
+
+`TableColumns.module.scss` only — three column widths and the table's `min-width`,
+needed because production's 22/18/18/14/28 split assumed five columns. Layout values
+only, no colors, so there is nothing to token-swap. Any *new* styling beyond this
+must use `var(--token, #fallback)` pairs per `prototypes/CLAUDE.md` §3.

--- a/prototypes/entries/warm-intros-v2/ContactRow.module.scss
+++ b/prototypes/entries/warm-intros-v2/ContactRow.module.scss
@@ -1,0 +1,33 @@
+/**
+ * Inline social icons for the MasterProfile modal's contact row.
+ *
+ * The modal shipped socials as labeled pills in a separate row below the
+ * contact box. Everywhere else — v1 InvestorDrawer, member details — LinkedIn
+ * and website sit inline with the email as bare 20px logos after a divider.
+ * Both classes are copied literally from InvestorDrawer.module.scss (the
+ * canonical version of this row); only the divider color is translated to a
+ * token + fallback pair, keeping the same rendered #e2e8f0.
+ */
+
+.contactIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  opacity: 0.8;
+  transition: opacity 0.1s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.channelDivider {
+  width: 1px;
+  align-self: stretch;
+  min-height: 16px;
+  margin: 0 4px;
+  background: var(--border-neutral-secondary, #e2e8f0);
+}

--- a/prototypes/entries/warm-intros-v2/InvestorDrawerMock.tsx
+++ b/prototypes/entries/warm-intros-v2/InvestorDrawerMock.tsx
@@ -1,0 +1,412 @@
+'use client';
+
+/**
+ * Transcription of `WarmIntrosV2InvestorDrawer` with the two data hooks
+ * (`useWarmIntrosV2PathsForInvestor`, `useMasterProfile`) swapped for mock lookups.
+ * Markup, class names and the production SCSS module are unchanged — this is a
+ * copy, not a re-interpretation.
+ */
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import clsx from 'clsx';
+import { Drawer } from '@/components/common/Drawer/Drawer';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import { SectorTagsList } from '@/components/page/investors/SectorTagsList/SectorTagsList';
+import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import type { SectorTag } from '@/services/investors/types';
+import type { WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
+import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
+import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
+import {
+  affinityPersonUrl,
+  allReasonDescriptions,
+  derivePathProximity,
+  explanationFromHopChain,
+  parseWarmPathHopChain,
+  reasonDescription,
+  type WarmPathV2HopNode,
+} from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2InvestorDrawer.module.scss';
+import { PathActions } from './PathFeedback';
+import { MOCK_MASTER_PROFILES, pathsForInvestor } from './mocks';
+
+interface Props {
+  row: WarmIntrosV2PathListItem | null;
+  open: boolean;
+  onClose: () => void;
+  onOpenMasterProfile: (profileUid: string) => void;
+}
+
+function PathHopRow({
+  hops,
+  imageByUid,
+  onOpen,
+}: {
+  hops: WarmPathV2HopNode[];
+  imageByUid: Map<string, string | null | undefined>;
+  onOpen: (uid: string) => void;
+}) {
+  if (hops.length === 0) return null;
+  return (
+    <div className={s.chain}>
+      {hops.map((hop, i) => (
+        <span key={`${hop.profileUid}-${i}`} className={s.node}>
+          {i > 0 && <span className={s.arrow}>→</span>}
+          <PathProfileChip
+            name={hop.name}
+            profileUid={hop.profileUid}
+            imageUrl={imageByUid.get(hop.profileUid)}
+            onOpen={onOpen}
+          />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: Props) {
+  const investor = row?.investor;
+  const profileUid = investor?.profileUid ?? row?.targetProfileUid ?? null;
+  const targetSet = row?.targetSet;
+
+  // Mocked stand-ins for the two react-query hooks in production.
+  const detail = useMemo(
+    () => (open && profileUid ? { paths: pathsForInvestor(profileUid, targetSet) } : undefined),
+    [open, profileUid, targetSet],
+  );
+  const pathsLoading = false;
+  const masterProfile = open && profileUid ? MOCK_MASTER_PROFILES[profileUid] : undefined;
+
+  const [showAlternates, setShowAlternates] = useState(true);
+
+  const bestPath = useMemo(() => {
+    const paths = detail?.paths ?? [];
+    if (paths.length === 0) return row;
+    const forSet = targetSet ? paths.filter((p) => p.targetSet === targetSet) : paths;
+    const pool = forSet.length > 0 ? forSet : paths;
+    return pool.find((p) => p.rank === 1) ?? pool[0] ?? row;
+  }, [detail?.paths, row, targetSet]);
+
+  const hopChain = useMemo(() => parseWarmPathHopChain(bestPath?.hopChain), [bestPath?.hopChain]);
+  const reasonLines = useMemo(
+    () => (hopChain?.reasons?.length ? allReasonDescriptions(hopChain.reasons) : []),
+    [hopChain],
+  );
+  const explanation =
+    reasonLines[0] || bestPath?.pathSummary?.explanation?.trim() || explanationFromHopChain(bestPath?.hopChain) || null;
+
+  const hops: WarmPathV2HopNode[] = useMemo(() => {
+    if (hopChain?.hops?.length) return hopChain.hops;
+    const out: WarmPathV2HopNode[] = [];
+    if (bestPath?.bestConnector) {
+      out.push({
+        profileUid: bestPath.bestConnector.profileUid,
+        name: bestPath.bestConnector.name,
+        role: 'pl_connector',
+      });
+    }
+    if (investor) {
+      out.push({
+        profileUid: investor.profileUid,
+        name: investor.name,
+        role: 'investor',
+      });
+    }
+    return out;
+  }, [hopChain, bestPath?.bestConnector, investor]);
+
+  const alternates = hopChain?.alternates ?? [];
+  const email = investor?.email?.trim() || null;
+  const name = investor?.name?.trim() || profileUid || 'Investor';
+  const org = investor?.currentOrg?.trim() || null;
+  const title = investor?.currentTitle?.trim() || null;
+  const sectors = (investor?.sectors ?? []) as SectorTag[];
+  const affinityId = investor?.affinityPersonId?.trim() || null;
+  const bio = typeof masterProfile?.bio === 'string' && masterProfile.bio.trim() ? masterProfile.bio.trim() : null;
+
+  const imageByUid = useMemo(() => {
+    const map = new Map<string, string | null | undefined>();
+
+    const put = (
+      uid: string | undefined | null,
+      personName: string | undefined | null,
+      memberUid?: string | null,
+      imageUrl?: string | null,
+    ) => {
+      if (!uid) return;
+      const trimmed = imageUrl?.trim() || null;
+      if (memberUid) {
+        map.set(uid, trimmed || getDefaultAvatar(personName || uid));
+      } else if (trimmed) {
+        map.set(uid, trimmed);
+      } else if (!map.has(uid)) {
+        map.set(uid, null);
+      }
+    };
+
+    if (investor) {
+      put(investor.profileUid, investor.name, investor.memberUid, investor.imageUrl);
+    }
+    if (bestPath?.bestConnector) {
+      const c = bestPath.bestConnector;
+      put(c.profileUid, c.name, c.memberUid, c.imageUrl);
+    }
+    for (const hop of hopChain?.hops ?? []) {
+      put(hop.profileUid, hop.name, hop.memberUid, hop.imageUrl);
+    }
+    for (const alt of alternates) {
+      put(alt.profileUid, alt.name, alt.memberUid, alt.imageUrl);
+    }
+    return map;
+  }, [investor, bestPath?.bestConnector, hopChain?.hops, alternates]);
+
+  const investorAvatarSrc = investor?.memberUid
+    ? investor.imageUrl?.trim() || getDefaultAvatar(name)
+    : investor?.imageUrl?.trim() || null;
+
+  return (
+    <Drawer isOpen={open} onClose={onClose} width={720}>
+      {!row || !investor ? (
+        <div className={s.loading}>No investor selected.</div>
+      ) : (
+        <>
+          <div className={s.header}>
+            <button type="button" className={s.backBtn} onClick={onClose} aria-label="Close">
+              ← Back
+            </button>
+          </div>
+
+          <div className={s.content}>
+            <div className={s.section}>
+              <div className={s.headerTop}>
+                <div className={s.headerWho}>
+                  <div className={s.nameRow}>
+                    {investorAvatarSrc ? (
+                      <Image
+                        className={s.headerAvatar}
+                        src={investorAvatarSrc}
+                        alt=""
+                        width={40}
+                        height={40}
+                        unoptimized
+                      />
+                    ) : null}
+                    <button
+                      type="button"
+                      className={s.nameBtn}
+                      onClick={() => onOpenMasterProfile(investor.profileUid)}
+                    >
+                      <h2 id="wi2-investor-drawer-title" className={s.name}>
+                        {name}
+                      </h2>
+                    </button>
+                  </div>
+                  <div className={s.meta}>
+                    {org ? <span>{org}</span> : null}
+                    {org && title ? <span className={s.metaVDivider} aria-hidden /> : null}
+                    {title ? <span>{title}</span> : null}
+                    {!org && !title ? <span className={s.muted}>—</span> : null}
+                  </div>
+                  {affinityId ? <div className={s.metaSub}>Affinity id: {affinityId}</div> : null}
+                  {sectors.length > 0 ? (
+                    <div className={s.pillRow}>
+                      <SectorTagsList tags={sectors} max={12} />
+                    </div>
+                  ) : null}
+                </div>
+                <button type="button" className={s.closeBtn} onClick={onClose} aria-label="Close drawer">
+                  ✕
+                </button>
+              </div>
+
+              {email ? (
+                <div className={s.channelsBox}>
+                  <div className={s.socialEmailGroup}>
+                    <Image src={getContactLogoByProvider('email')} alt="" aria-hidden width={20} height={20} />
+                    <a href={`mailto:${email}`} className={s.socialEmailAddr}>
+                      {email}
+                    </a>
+                    <CopyButton text={email} className={s.contactIconCopy} />
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <div className={s.section}>
+              <h3 className={s.sectionTitle}>Investor profile</h3>
+              {bio ? <p className={s.enrichBio}>{bio}</p> : null}
+              <dl className={s.kv}>
+                <dt>Current org</dt>
+                <dd>{org || <span className={s.muted}>—</span>}</dd>
+                <dt>Title</dt>
+                <dd>{title || <span className={s.muted}>—</span>}</dd>
+                <dt>Industry / Sector</dt>
+                <dd>
+                  <SectorTagsList tags={sectors} max={20} />
+                </dd>
+              </dl>
+              <button type="button" className={s.linkBtn} onClick={() => onOpenMasterProfile(investor.profileUid)}>
+                View full profile
+              </button>
+            </div>
+
+            <div className={s.section}>
+              <h3 className={s.sectionTitle}>
+                Path
+                {alternates.length > 0 ? <span className={s.count}>{alternates.length + 1}</span> : null}
+              </h3>
+
+              {pathsLoading && !bestPath ? (
+                <div className={s.state}>Loading paths…</div>
+              ) : !bestPath ? (
+                <div className={s.state}>No warm paths for this investor yet.</div>
+              ) : (
+                <>
+                  <div className={s.pathItem}>
+                    <div className={s.pathMeta}>
+                      {bestPath.proximityCode ? <ProximityCodeBadge code={bestPath.proximityCode} /> : null}
+                      <ScorePercentPill scorePercent={bestPath.scorePercent} scoreBand={bestPath.scoreBand} />
+                      <span className={s.warmth}>Best path</span>
+                    </div>
+                    <p className={s.warmthSubtitle}>How strong this intro route is</p>
+                    {reasonLines.length > 0 ? (
+                      <ul className={s.reasonList}>
+                        {reasonLines.map((line) => (
+                          <li key={line}>{line}</li>
+                        ))}
+                      </ul>
+                    ) : explanation ? (
+                      <div className={s.explanation}>{explanation}</div>
+                    ) : null}
+                    <div className={s.chainRow}>
+                      <PathHopRow hops={hops} imageByUid={imageByUid} onOpen={onOpenMasterProfile} />
+                    </div>
+                    {/* Design change: the card ends in a referral answer + a
+                        feedback escape hatch. Keyed by path so re-opening the
+                        drawer shows what was already answered. */}
+                    <PathActions
+                      key={bestPath.uid}
+                      pathKey={bestPath.uid}
+                      context={{
+                        nodes: hops.map((hop) => ({
+                          profileUid: hop.profileUid,
+                          name: hop.name,
+                          imageUrl: imageByUid.get(hop.profileUid),
+                        })),
+                        connectorName: bestPath.bestConnector?.name ?? hops[0]?.name ?? null,
+                        proximityCode: bestPath.proximityCode,
+                        scorePercent: bestPath.scorePercent,
+                        scoreBand: bestPath.scoreBand,
+                      }}
+                    />
+                  </div>
+
+                  {alternates.length > 0 ? (
+                    <div className={s.alternatesBlock}>
+                      <button
+                        type="button"
+                        className={s.alternatesToggle}
+                        aria-expanded={showAlternates}
+                        onClick={() => setShowAlternates((v) => !v)}
+                      >
+                        {showAlternates ? 'Hide' : 'Show'} alternate connectors ({alternates.length})
+                      </button>
+                      {showAlternates ? (
+                        <ul className={s.altList}>
+                          {alternates.map((alt) => {
+                            const derived = derivePathProximity(alt.score, bestPath.hopCount ?? 1);
+                            const proximityCode = alt.proximityCode ?? derived?.proximityCode ?? null;
+                            const pct = alt.scorePercent ?? derived?.scorePercent ?? null;
+                            const scoreBand = alt.scoreBand ?? derived?.scoreBand;
+                            const altReason = Array.isArray(alt.reasons)
+                              ? alt.reasons.map(reasonDescription).find(Boolean)
+                              : null;
+                            return (
+                              <li key={alt.profileUid} className={s.pathItem}>
+                                <div className={s.pathMeta}>
+                                  {proximityCode ? <ProximityCodeBadge code={proximityCode} /> : null}
+                                  {pct != null ? <ScorePercentPill scorePercent={pct} scoreBand={scoreBand} /> : null}
+                                </div>
+                                {altReason ? <div className={s.explanation}>{altReason}</div> : null}
+                                <div className={s.chainRow}>
+                                  <PathHopRow
+                                    hops={[
+                                      {
+                                        profileUid: alt.profileUid,
+                                        name: alt.name,
+                                        role: 'pl_connector',
+                                      },
+                                      {
+                                        profileUid: investor.profileUid,
+                                        name: investor.name,
+                                        role: 'investor',
+                                      },
+                                    ]}
+                                    imageByUid={imageByUid}
+                                    onOpen={onOpenMasterProfile}
+                                  />
+                                </div>
+                                {/* Alternates carry the same strip — the whole
+                                    point is a per-path answer, and an alternate
+                                    is often the one you'd actually use. */}
+                                <PathActions
+                                  key={`${bestPath.uid}:${alt.profileUid}`}
+                                  pathKey={`${bestPath.uid}:${alt.profileUid}`}
+                                  context={{
+                                    nodes: [
+                                      {
+                                        profileUid: alt.profileUid,
+                                        name: alt.name,
+                                        imageUrl: imageByUid.get(alt.profileUid),
+                                      },
+                                      {
+                                        profileUid: investor.profileUid,
+                                        name: investor.name,
+                                        imageUrl: imageByUid.get(investor.profileUid),
+                                      },
+                                    ],
+                                    connectorName: alt.name,
+                                    proximityCode,
+                                    scorePercent: pct,
+                                    scoreBand,
+                                  }}
+                                />
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className={s.footer}>
+            {affinityId ? (
+              <a
+                className={clsx(s.btn, s.btnPrimary)}
+                href={affinityPersonUrl(affinityId)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open in Affinity ↗
+              </a>
+            ) : null}
+            {email ? (
+              <CopyButton text={email} label="Copy email" className={s.btn} />
+            ) : (
+              <button type="button" className={s.btn} disabled>
+                Copy email
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
+++ b/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+/**
+ * Transcription of `MasterProfileModal` with `useMasterProfile` swapped for a
+ * lookup in MOCK_MASTER_PROFILES. Section markup and class names are unchanged.
+ *
+ * Design changes on top of production:
+ *   - modal chrome swapped to the shared content-modal pattern (SubmitDealModal
+ *     styles + CloseIcon button + Modal's own dialog/scroll-lock/inert props),
+ *     the same one the Gantry item modal uses, replacing a bespoke micro-label
+ *     header and a text "✕"
+ *   - LinkedIn / website render inline with the email as icons, not pills below
+ *   - type tags (Investor, PL internal) sit next to the name
+ */
+
+import { useMemo } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import clsx from 'clsx';
+import { Modal } from '@/components/common/Modal';
+import { CloseIcon } from '@/components/icons';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvider';
+import { affinityPersonUrl } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import {
+  eventsFromProfile,
+  parseEducation,
+  parseExperience,
+  parseInvestorMetaFields,
+  parseListMemberships,
+  parseLocationLabels,
+  parseOrganizationLabels,
+  projectsFromProfile,
+  summarizeSourceSnapshots,
+  typeLabel,
+  unwrapSocials,
+  unwrapSourcedArray,
+} from '@/components/page/investors/WarmIntrosV2Workspace/masterProfileDisplay.util';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/MasterProfileModal.module.scss';
+// Shared content-modal chrome — the same module the Gantry item modal imports.
+import m from '@/components/page/deals/SubmitDealModal/SubmitDealModal.module.scss';
+import c from './ContactRow.module.scss';
+import chrome from './ModalChrome.module.scss';
+import { MOCK_MASTER_PROFILES } from './mocks';
+
+interface Props {
+  profileUid: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MasterProfileModalMock({ profileUid, open, onClose }: Props) {
+  const data = open && profileUid ? MOCK_MASTER_PROFILES[profileUid] : undefined;
+  const isLoading = false;
+  const isError = false;
+
+  const emails = useMemo(() => unwrapSourcedArray(data?.emails), [data?.emails]);
+  const phones = useMemo(() => unwrapSourcedArray(data?.phones), [data?.phones]);
+  const socials = useMemo(() => unwrapSocials(data?.socials), [data?.socials]);
+  const experience = useMemo(() => parseExperience(data?.experience), [data?.experience]);
+  const education = useMemo(() => parseEducation(data?.education), [data?.education]);
+  const orgs = useMemo(() => parseOrganizationLabels(data?.organizations), [data?.organizations]);
+  const locations = useMemo(() => parseLocationLabels(data?.locations), [data?.locations]);
+  const lists = useMemo(() => parseListMemberships(data?.listMemberships), [data?.listMemberships]);
+  const investorFields = useMemo(() => parseInvestorMetaFields(data?.investorMeta), [data?.investorMeta]);
+  const projects = useMemo(() => (data ? projectsFromProfile(data) : []), [data]);
+  const events = useMemo(() => (data ? eventsFromProfile(data) : []), [data]);
+  const snapshots = useMemo(() => summarizeSourceSnapshots(data?.sourceSnapshots), [data?.sourceSnapshots]);
+
+  const name = data?.canonicalName?.trim() || profileUid || 'Profile';
+  const types = Array.isArray(data?.types) ? data.types.filter((t): t is string => !!t) : [];
+  const org = data?.currentOrg?.trim() || null;
+  const title = data?.currentTitle?.trim() || null;
+  const bio = typeof data?.bio === 'string' && data.bio.trim() ? data.bio.trim() : null;
+  const memberUid = data?.memberUid?.trim() || null;
+  const affinityId = data?.affinityPersonId?.trim() || null;
+  const hasProjectsOrEvents = projects.length > 0 || events.length > 0;
+  const hasProvenance = snapshots.length > 0 || !!data?.raw || !!data?.enrichedAt;
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      className={chrome.modal}
+      closeOnEscape
+      // Deliberate dismissal only — the close icon or Escape, never a stray
+      // backdrop click. Nothing is at stake in a read-only profile, but two
+      // modals opening off the same drawer with different dismissal rules is
+      // worse than either rule on its own.
+      closeOnBackdropClick={false}
+      // Dialog semantics, scroll lock and background inerting come from Modal
+      // itself rather than being hand-rolled on an inner div.
+      ariaLabelledBy="wi2-master-profile-title"
+      lockScroll
+      inertBackground
+    >
+      <div className={clsx(m.root, chrome.root)}>
+        <div className={clsx(m.header, chrome.header)}>
+          <div className={m.headerText}>
+            {/* One line only — the subtitle restated what the sections below
+                already show, and cost the header a second row. */}
+            <h2 id="wi2-master-profile-title" className={clsx(m.title, chrome.title)}>
+              Master profile
+            </h2>
+          </div>
+          <button type="button" className={m.closeButton} onClick={onClose} aria-label="Close">
+            <CloseIcon width={20} height={20} color="#0a0c11" />
+          </button>
+        </div>
+
+        <div className={clsx(m.content, chrome.stack)}>
+          {isLoading && <div className={s.state}>Loading profile…</div>}
+
+          {!isLoading && !isError && !data && <div className={s.state}>Profile not found.</div>}
+
+          {!isLoading && !isError && data ? (
+            <>
+              <section className={s.hero}>
+                {/* Investor / PL internal / Founder qualify the name, so they sit
+                    inline with it rather than in their own row underneath. */}
+                <div className={s.nameRow}>
+                  <h3 className={s.name}>{name}</h3>
+                  {types.map((t) => (
+                    <span key={t} className={clsx(s.typePill, typePillClass(t))}>
+                      {typeLabel(t)}
+                    </span>
+                  ))}
+                </div>
+
+                <div className={s.meta}>
+                  {org ? <span>{org}</span> : null}
+                  {org && title ? <span className={s.metaVDivider} aria-hidden /> : null}
+                  {title ? <span>{title}</span> : null}
+                  {!org && !title ? <span className={s.muted}>—</span> : null}
+                </div>
+
+                {(emails.length > 0 || phones.length > 0 || socials.length > 0) && (
+                  <div className={s.channelsBox}>
+                    {emails.map((email) => (
+                      <div key={email} className={s.socialEmailGroup}>
+                        <Image src={getContactLogoByProvider('email')} alt="" aria-hidden width={18} height={18} />
+                        <a href={`mailto:${email}`} className={s.socialEmailAddr}>
+                          {email}
+                        </a>
+                        <CopyButton text={email} className={s.contactIconCopy} />
+                      </div>
+                    ))}
+                    {phones.map((phone) => (
+                      <div key={phone} className={s.socialEmailGroup}>
+                        <span className={s.phoneLabel}>Phone</span>
+                        <a href={`tel:${phone}`} className={s.socialEmailAddr}>
+                          {phone}
+                        </a>
+                        <CopyButton text={phone} className={s.contactIconCopy} />
+                      </div>
+                    ))}
+
+                    {/* Socials sit inline after the email/phone, icon-only, the way
+                        v1 InvestorDrawer and member details render this row. */}
+                    {socials.length > 0 && (emails.length > 0 || phones.length > 0) ? (
+                      <span className={c.channelDivider} />
+                    ) : null}
+                    {socials.map(({ provider, url }) => (
+                      <a
+                        key={`${provider}-${url}`}
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={c.contactIcon}
+                        title={provider}
+                      >
+                        <Image src={getContactLogoByProvider(provider)} alt={provider} width={20} height={20} />
+                      </a>
+                    ))}
+                  </div>
+                )}
+
+                <div className={s.extLinks}>
+                  {memberUid ? (
+                    <Link
+                      href={`/members/${encodeURIComponent(memberUid)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={s.extLink}
+                    >
+                      Directory member ↗
+                    </Link>
+                  ) : null}
+                  {affinityId ? (
+                    <a
+                      href={affinityPersonUrl(affinityId)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={s.extLink}
+                    >
+                      Open in Affinity ↗
+                    </a>
+                  ) : null}
+                </div>
+              </section>
+
+              {bio ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Bio</h4>
+                  <p className={s.bio}>{bio}</p>
+                </section>
+              ) : null}
+
+              {investorFields.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Investor profile</h4>
+                  <dl className={s.kv}>
+                    {investorFields.map((f) => (
+                      <div key={f.label} className={s.kvRow}>
+                        <dt>{f.label}</dt>
+                        <dd>{f.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </section>
+              ) : null}
+
+              {experience.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>
+                    Experience <span className={s.count}>{experience.length}</span>
+                  </h4>
+                  <ul className={s.itemList}>
+                    {experience.map((item, i) => (
+                      <li key={`${item.company}-${item.title}-${i}`} className={s.item}>
+                        <div className={s.itemPrimary}>
+                          {item.title || <span className={s.muted}>Role</span>}
+                          {item.company ? (
+                            <>
+                              <span className={s.itemSep}>·</span>
+                              <span>{item.company}</span>
+                            </>
+                          ) : null}
+                        </div>
+                        {item.years ? <div className={s.itemSecondary}>{item.years}</div> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+
+              {education.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>
+                    Education <span className={s.count}>{education.length}</span>
+                  </h4>
+                  <ul className={s.itemList}>
+                    {education.map((item, i) => (
+                      <li key={`${item.school}-${item.degree}-${i}`} className={s.item}>
+                        <div className={s.itemPrimary}>
+                          {item.school || <span className={s.muted}>School</span>}
+                          {item.degree ? (
+                            <>
+                              <span className={s.itemSep}>·</span>
+                              <span>{item.degree}</span>
+                            </>
+                          ) : null}
+                        </div>
+                        {item.year ? <div className={s.itemSecondary}>{item.year}</div> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+
+              {orgs.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Organizations</h4>
+                  <div className={s.pillRow}>
+                    {orgs.map((o) => (
+                      <span key={o} className={s.tag}>
+                        {o}
+                      </span>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {locations.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Locations</h4>
+                  <div className={s.pillRow}>
+                    {locations.map((loc) => (
+                      <span key={loc} className={s.tag}>
+                        {loc}
+                      </span>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {lists.length > 0 ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Lists</h4>
+                  <div className={s.pillRow}>
+                    {lists.map((list) => (
+                      <span key={list.slug} className={clsx(s.listPill, listPillClass(list.slug))}>
+                        {list.label}
+                      </span>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {hasProjectsOrEvents ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Projects / events</h4>
+                  {projects.length > 0 ? (
+                    <div className={s.subBlock}>
+                      <div className={s.subLabel}>Projects</div>
+                      <div className={s.pillRow}>
+                        {projects.map((p) => (
+                          <span key={p} className={s.tag}>
+                            {p}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {events.length > 0 ? (
+                    <div className={s.subBlock}>
+                      <div className={s.subLabel}>Events</div>
+                      <div className={s.pillRow}>
+                        {events.map((e) => (
+                          <span key={e} className={s.tag}>
+                            {e}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </section>
+              ) : null}
+
+              {hasProvenance ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>Provenance / sources</h4>
+                  {data.enrichedAt ? (
+                    <div className={s.metaSub}>
+                      Enriched {typeof data.enrichedAt === 'string' ? data.enrichedAt : String(data.enrichedAt)}
+                    </div>
+                  ) : null}
+                  {snapshots.length > 0 ? (
+                    <ul className={s.snapshotList}>
+                      {snapshots.map((snap) => (
+                        <li key={snap.key}>
+                          <code className={s.code}>{snap.key}</code>
+                          {snap.type ? <span className={s.muted}> · {snap.type}</span> : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  {data.raw ? (
+                    <details className={s.details}>
+                      <summary>Show raw JSON</summary>
+                      <pre className={s.rawJson}>{safeJson(data.raw)}</pre>
+                    </details>
+                  ) : null}
+                </section>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function typePillClass(type: string): string | undefined {
+  if (type === 'pl_internal') return s.typePl;
+  if (type === 'investor') return s.typeInvestor;
+  if (type === 'founder') return s.typeFounder;
+  return undefined;
+}
+
+function listPillClass(slug: string): string | undefined {
+  if (slug === 'neuro-fund-i') return s.listNeuro;
+  if (slug === 'gold-co-investors') return s.listGold;
+  return undefined;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/prototypes/entries/warm-intros-v2/ModalChrome.module.scss
+++ b/prototypes/entries/warm-intros-v2/ModalChrome.module.scss
@@ -1,0 +1,44 @@
+/**
+ * Width overrides for the shared content-modal chrome.
+ *
+ * The modal now borrows SubmitDealModal.module.scss — the same chrome the Gantry
+ * item modal imports — for its header, close button and scroll body. That root is
+ * a fixed 600px, which is right for a form but cramped for a profile's key/value
+ * rows and experience lists, so the width goes back to this modal's own 800px.
+ * Everything else (radius, shadow, header, close button) stays canonical.
+ *
+ * Layout only, no colors.
+ */
+
+.modal {
+  width: 100%;
+  max-width: 800px;
+}
+
+.root {
+  width: 100%;
+}
+
+/* The shared .content gives padding + scroll; sections still need their column gap. */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/**
+ * Slimmer header. The shared chrome sizes its header for a form modal, where the
+ * title is the main thing on screen; here the person's name right below it is,
+ * so the chrome title recedes to a label. 20px/27 → 16px/24 (both on the type
+ * scale) and the block padding tightens 20px → 12px.
+ */
+.header {
+  padding: 12px 16px;
+  align-items: center;
+}
+
+.title {
+  font-size: 16px;
+  line-height: 24px;
+  letter-spacing: -0.2px;
+}

--- a/prototypes/entries/warm-intros-v2/PageShell.module.scss
+++ b/prototypes/entries/warm-intros-v2/PageShell.module.scss
@@ -1,0 +1,21 @@
+/**
+ * Reproduces the page padding production gives the workspace.
+ *
+ * On /investors the workspace itself has no padding — it inherits it from
+ * DashboardPagesLayout's content column (`padding: 30px 24px 40px` at ≥1024px,
+ * on a #f1f5f9 gutter). The prototype route has no dashboard shell, so the
+ * workspace was rendering flush to the viewport edge. Values are copied
+ * literally from DashboardPagesLayout.module.css, incl. its 1024px breakpoint;
+ * only the color is translated to a token + fallback pair.
+ */
+
+.page {
+  min-height: 100%;
+  background: var(--background-neutral-subtle, #f1f5f9);
+}
+
+@media (min-width: 1024px) {
+  .page {
+    padding: 30px 24px 40px;
+  }
+}

--- a/prototypes/entries/warm-intros-v2/PathFeedback.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathFeedback.module.scss
@@ -1,0 +1,128 @@
+/**
+ * Per-path referral answer + feedback strip that sits inside the grey warm-path
+ * card (`.pathItem` in WarmIntrosV2InvestorDrawer.module.scss), plus the form
+ * pieces used inside the feedback modal.
+ *
+ * This is NEW UI, not a transcription — so every color is a
+ * `var(--token, #fallback)` pair (prototypes/CLAUDE.md §3–4) and sizes stay on
+ * the PL type scale (12/18 and 14/20).
+ */
+
+/* ---------------------------------------------------------------- card strip */
+
+/**
+ * One quiet row at the foot of the card, divided from the path content above.
+ * The referral answer sits left (it's the action), feedback sits right (it's
+ * the escape hatch) — so the eye lands on the thing people actually do.
+ */
+.strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+}
+
+.stripLeft,
+.stripRight {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* At rest the left half holds nothing. Collapse it, and keep the link cluster
+   pinned right either way — otherwise `Give feedback` jumps across the card the
+   moment the question expands. */
+.stripLeft:empty {
+  display: none;
+}
+
+.stripRight {
+  margin-left: auto;
+}
+
+.linkDivider {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+/* The question, once the "Can you refer?" button has opened it. Naming the
+   connector is what makes Yes/No answerable — "can you refer" alone doesn't
+   say through whom. */
+.askLabel {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.askName {
+  font-weight: 600;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+/* ------------------------------------------------------------ answered state */
+
+/**
+ * Answering replaces the question rather than resetting it — otherwise people
+ * re-answer the same path and the signal arrives duplicated. Undo is the way
+ * back.
+ */
+.answered {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-success-primary, #0a9952);
+}
+
+.answeredNo {
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.checkMark {
+  flex-shrink: 0;
+  color: currentColor;
+}
+
+/* ------------------------------------------------------------- modal content */
+
+/**
+ * Read-only restatement of which path is being reported, so nobody has to
+ * describe it in prose and no report lands ambiguous.
+ */
+.context {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  background: var(--background-neutral-subtle, #f9fafb);
+}
+
+.contextMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/**
+ * The drawer's person chip is a button; here the chain only restates which path
+ * is being reported. Killing pointer events is enough to drop the affordance —
+ * it takes the hover state with it, so production's chip colors stay untouched.
+ */
+.chipStatic {
+  cursor: default;
+  pointer-events: none;
+}

--- a/prototypes/entries/warm-intros-v2/PathFeedback.tsx
+++ b/prototypes/entries/warm-intros-v2/PathFeedback.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+/**
+ * The action strip at the foot of a grey warm-path card.
+ *
+ * Design changes on top of production (which has no feedback affordance on the
+ * path card at all, and whose older sibling prototypes carry a pencil icon):
+ *
+ *   - The pencil is gone. Nothing on the card is editable — you're reporting
+ *     that the graph is wrong — so the affordance is labelled `Give feedback`
+ *     and opens a modal with room for a real description. It's a quiet text
+ *     button, not a filled one: the card repeats for every alternate connector,
+ *     and a rarely-used action shouldn't compete with the path itself.
+ *
+ *   - `Can you refer?` collapses the referral question until someone engages
+ *     with it, then reveals Yes / No inline. Expanding costs a click, and buys
+ *     a card that stays calm while you're reading paths.
+ *
+ *   - Answering replaces the question with the answer plus Undo, rather than
+ *     resetting it — otherwise the same path gets answered repeatedly and the
+ *     signal arrives duplicated.
+ *
+ *   - `No` asks no follow-up. The verdict is the signal; anyone with more to say
+ *     already has `Give feedback` sitting on the same row, so a "Why not?" chip
+ *     row was a second question competing with the affordance built to answer it.
+ */
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { Button } from '@/components/common/Button/Button';
+import { CheckIcon } from '@/components/icons';
+import { PathFeedbackModal, type PathContext, type PathFeedbackSubmission } from './PathFeedbackModal';
+import f from './PathFeedback.module.scss';
+
+type ReferVerdict = 'yes' | 'no';
+
+type PathFeedbackRecord = {
+  refer?: ReferVerdict;
+  feedback?: PathFeedbackSubmission;
+};
+
+/**
+ * Stands in for the mutation production would fire. Module-level so an answer
+ * survives closing and re-opening the drawer within one session — the same
+ * persistence the real thing would have, without a store.
+ */
+const FEEDBACK_STORE = new Map<string, PathFeedbackRecord>();
+
+interface Props {
+  /** Stable per-path id — also the key the caller should mount this under. */
+  pathKey: string;
+  context: PathContext;
+}
+
+export function PathActions({ pathKey, context }: Props) {
+  const [record, setRecord] = useState<PathFeedbackRecord>(() => FEEDBACK_STORE.get(pathKey) ?? {});
+  const [asking, setAsking] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const save = (next: PathFeedbackRecord) => {
+    FEEDBACK_STORE.set(pathKey, next);
+    setRecord(next);
+  };
+
+  // Undo clears the referral answer only — a filed report is a separate thing
+  // and shouldn't vanish with it.
+  const reset = () => {
+    save(record.feedback ? { feedback: record.feedback } : {});
+    setAsking(false);
+  };
+
+  const connector = context.connectorName;
+  const answered = record.refer;
+  // Untouched, the strip is nothing but two text links in the corner. It only
+  // claims real estate once someone has engaged with it.
+  const resting = !answered && !asking;
+
+  return (
+    <>
+      <div className={f.strip}>
+        <div className={f.stripLeft}>
+          {asking && !answered ? (
+            <>
+              <span className={f.askLabel}>
+                Can you refer
+                {connector ? (
+                  <>
+                    {' via '}
+                    <span className={f.askName}>{connector}</span>
+                  </>
+                ) : null}
+                ?
+              </span>
+              <Button style="border" variant="secondary" size="xxs" onClick={() => save({ ...record, refer: 'yes' })}>
+                Yes
+              </Button>
+              <Button style="border" variant="secondary" size="xxs" onClick={() => save({ ...record, refer: 'no' })}>
+                No
+              </Button>
+            </>
+          ) : null}
+
+          {answered ? (
+            <>
+              <span className={clsx(f.answered, answered === 'no' && f.answeredNo)}>
+                <CheckIcon className={f.checkMark} width={11} height={11} />
+                {answered === 'yes'
+                  ? `You can refer${connector ? ` via ${connector}` : ''}`
+                  : 'You can’t refer on this path'}
+              </span>
+              <Button style="link" variant="secondary" size="xxs" underline onClick={reset}>
+                Undo
+              </Button>
+            </>
+          ) : null}
+        </div>
+
+        <div className={f.stripRight}>
+          {/* At rest this sits with `Give feedback` as a second quiet link —
+              it's the rarer action of the two, so it gets no more weight than
+              the escape hatch beside it. Clicking promotes the question to the
+              left of the row, where Yes / No get real button affordance. */}
+          {resting ? (
+            <>
+              <Button
+                style="link"
+                variant="secondary"
+                size="xxs"
+                underline
+                aria-expanded={false}
+                onClick={() => setAsking(true)}
+              >
+                Can you refer?
+              </Button>
+              <span className={f.linkDivider} aria-hidden>
+                ·
+              </span>
+            </>
+          ) : null}
+
+          {record.feedback ? (
+            <span className={f.answered}>
+              <CheckIcon className={f.checkMark} width={11} height={11} />
+              Feedback sent
+            </span>
+          ) : null}
+          <Button style="link" variant="secondary" size="xxs" underline onClick={() => setModalOpen(true)}>
+            {record.feedback ? 'Edit' : 'Give feedback'}
+          </Button>
+        </div>
+      </div>
+
+      <PathFeedbackModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        context={context}
+        initial={record.feedback}
+        onSubmit={(value) => {
+          save({ ...record, feedback: value });
+          setModalOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/PathFeedbackModal.tsx
+++ b/prototypes/entries/warm-intros-v2/PathFeedbackModal.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/**
+ * Feedback modal for one warm path — the "broader description" escape hatch
+ * behind the card's `Give feedback` link.
+ *
+ * One field: a free-text box. No reason chips — nothing gets pre-categorised, so
+ * whatever's wrong can be said in the reporter's own words.
+ *
+ * The one thing it does add is a read-only restatement of the path at the top, so
+ * nobody has to describe which of an investor's paths they mean.
+ *
+ * Chrome is the shared content-modal pattern (SubmitDealModal styles + Modal's
+ * own dialog / scroll-lock / inert props) — the same one MasterProfileModalMock
+ * and the Gantry item modal use.
+ *
+ * Dismissal is deliberate only: the close icon or Cancel. A stray backdrop click
+ * would throw away everything typed, and the modal has no draft to fall back on.
+ * Escape stays wired — it's the keyboard equivalent of the close icon, and a
+ * dialog you can't leave from the keyboard is a trap. Modal binds it in the
+ * capture phase with stopImmediatePropagation, so Esc closes this and leaves the
+ * drawer underneath open.
+ */
+
+import { useState } from 'react';
+import Image from 'next/image';
+import clsx from 'clsx';
+import { Modal } from '@/components/common/Modal';
+import { Button } from '@/components/common/Button/Button';
+import { CloseIcon } from '@/components/icons';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
+import type { ScoreBand } from '@/services/investors/warm-intros-v2.types';
+// Shared content-modal chrome — the same module the Gantry item modal imports.
+import m from '@/components/page/deals/SubmitDealModal/SubmitDealModal.module.scss';
+// Hop-chain layout and person-chip visuals, straight from the drawer that opened
+// this modal — so the path reads identically in both places.
+import d from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2InvestorDrawer.module.scss';
+import chip from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip.module.scss';
+// Textarea visuals reused from FormTextArea; the component itself needs a
+// react-hook-form context this prototype has no reason to stand up.
+import t from '@/components/form/FormTextArea/FormTextArea.module.scss';
+import f from './PathFeedback.module.scss';
+
+export type PathFeedbackSubmission = {
+  note: string;
+};
+
+const NOTE_MAX = 600;
+
+export type PathNode = {
+  profileUid: string;
+  name: string;
+  imageUrl?: string | null;
+};
+
+export interface PathContext {
+  /** The hop chain, in order — same nodes the drawer's card renders. */
+  nodes: PathNode[];
+  /** Who'd make the intro, for the card's "Can you refer via …?" label. */
+  connectorName: string | null;
+  proximityCode?: string | null;
+  scorePercent?: number | null;
+  scoreBand?: ScoreBand;
+}
+
+/** Mirrors the private helper inside PathProfileChip. */
+function initialsFromName(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (value: PathFeedbackSubmission) => void;
+  context: PathContext;
+  /** Existing report, when someone re-opens the modal to amend it. */
+  initial?: PathFeedbackSubmission;
+}
+
+export function PathFeedbackModal({ open, onClose, onSubmit, context, initial }: Props) {
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      closeOnEscape
+      closeOnBackdropClick={false}
+      ariaLabelledBy="wi2-path-feedback-title"
+      lockScroll
+      inertBackground
+    >
+      {/* The form is its own component so Modal mounting it is what seeds the
+          fields — re-opening shows what was already sent without an effect that
+          writes state on every open. */}
+      <FeedbackForm onClose={onClose} onSubmit={onSubmit} context={context} initial={initial} />
+    </Modal>
+  );
+}
+
+function FeedbackForm({ onClose, onSubmit, context, initial }: Omit<Props, 'open'>) {
+  const [note, setNote] = useState(initial?.note ?? '');
+
+  // The box is the whole form, so an empty one is an empty report.
+  const canSubmit = note.trim().length > 0;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit({ note: note.trim() });
+  };
+
+  return (
+    <div className={m.root}>
+      <div className={m.header}>
+        <div className={m.headerText}>
+          <h2 id="wi2-path-feedback-title" className={m.title}>
+            Give feedback
+          </h2>
+          <p className={m.subtitle}>Tell us what&rsquo;s wrong with this path so we can correct the graph.</p>
+        </div>
+        <button type="button" className={m.closeButton} onClick={onClose} aria-label="Close">
+          <CloseIcon width={20} height={20} color="#0a0c11" />
+        </button>
+      </div>
+
+      <div className={m.content}>
+        <div className={m.form}>
+          {/* Which path this is about — stated, not typed. */}
+          <div className={f.context}>
+            <div className={f.contextMeta}>
+              {context.proximityCode ? <ProximityCodeBadge code={context.proximityCode} /> : null}
+              {context.scorePercent != null ? (
+                <ScorePercentPill scorePercent={context.scorePercent} scoreBand={context.scoreBand} />
+              ) : null}
+            </div>
+            {/* The same avatar chips the card shows, rendered as spans — inside
+                the modal the chain is a restatement, not a way to navigate off
+                to a profile mid-report. */}
+            <div className={d.chain}>
+              {context.nodes.map((node, i) => (
+                <span key={`${node.profileUid}-${i}`} className={d.node}>
+                  {i > 0 && (
+                    <span className={d.arrow} aria-hidden>
+                      →
+                    </span>
+                  )}
+                  <span className={clsx(chip.chip, f.chipStatic)}>
+                    {node.imageUrl?.trim() ? (
+                      <Image className={chip.avatarImg} src={node.imageUrl} alt="" width={20} height={20} unoptimized />
+                    ) : (
+                      <span className={chip.avatar} aria-hidden>
+                        {initialsFromName(node.name) || '?'}
+                      </span>
+                    )}
+                    <span className={chip.label}>{node.name}</span>
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className={m.fieldGroup}>
+            <div className={t.labelWrapper}>
+              <label className={t.label} htmlFor="wi2-path-feedback-note">
+                What&rsquo;s wrong with this path?
+              </label>
+            </div>
+            <div className={t.input}>
+              <div className={t.inputContent}>
+                <textarea
+                  id="wi2-path-feedback-note"
+                  className={t.inputElement}
+                  rows={7}
+                  maxLength={NOTE_MAX}
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  autoFocus
+                  placeholder="Wrong connector, caliber too high or low, not a real path, investor details out of date — whatever it is, in your own words."
+                />
+              </div>
+            </div>
+            <div className={t.descriptionRow}>
+              <span className={m.helperText}>The more specific, the more we can fix.</span>
+              <span className={t.counter}>
+                {note.length} / {NOTE_MAX}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={m.footer}>
+        <p className={m.footerNote}>Goes to the Investor DB team.</p>
+        <div className={m.footerActions}>
+          <Button style="border" variant="secondary" size="s" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button style="fill" variant="primary" size="s" onClick={submit} disabled={!canSubmit}>
+            Send feedback
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/TableColumns.module.scss
+++ b/prototypes/entries/warm-intros-v2/TableColumns.module.scss
@@ -16,6 +16,26 @@
   width: 34%;
 }
 
+/* Name and its list badge share a line; wraps rather than squeezing the name. */
+.nameLine {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/**
+ * The shared listPill is already 12px — its bulk comes from weight 600 and
+ * 2px 10px padding, sized for the MasterProfile modal where it sits in a row of
+ * its own. Beside a 14px name in a table row it needs to recede, so the size
+ * stays and the weight and padding come down.
+ */
+.listBadge {
+  font-weight: 500;
+  line-height: 16px;
+  padding: 1px 8px;
+}
+
 .colProximity {
   width: 18%;
 }

--- a/prototypes/entries/warm-intros-v2/TableColumns.module.scss
+++ b/prototypes/entries/warm-intros-v2/TableColumns.module.scss
@@ -1,0 +1,25 @@
+/**
+ * Column widths for the 3-column table fork (Investor · Path · Proximity).
+ * Production apportions 22/18/18/14/28 across five columns; with Team and
+ * Industry / Sector gone, the remaining three are re-balanced here.
+ *
+ * Layout only — no colors, so nothing to token-swap. Everything else still
+ * comes from the production WarmIntrosV2Table.module.scss.
+ */
+
+.table {
+  /* Production's 960px floor was sized for five columns. */
+  min-width: 620px;
+}
+
+.colInvestor {
+  width: 34%;
+}
+
+.colProximity {
+  width: 18%;
+}
+
+.colPath {
+  width: 48%;
+}

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
@@ -17,6 +17,7 @@
  *
  * Design changes on top of production:
  *   - the list picker gains an "All investor lists" option, and opens on it
+ *   - under that scope each row carries a list badge, so mixed results stay readable
  *
  * Deliberate simplifications, all data-layer only:
  *   - filters live in component state instead of the URL (no nuqs in prototypes)
@@ -246,6 +247,9 @@ export default function WarmIntrosV2Prototype() {
               onOpenProfileUid={onOpenProfileUid}
               onViewAllPaths={onViewAllPaths}
               onRowClick={onRowClick}
+              // Only under "All investor lists" — inside a single list every
+              // badge would just repeat the picker.
+              showListName={targetSet === ALL_LISTS}
             />
           </div>
         )}

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+/**
+ * Warm Intros v2 — mocked clone of the production workspace.
+ *
+ * Reused from production (imported, not copied):
+ *   WarmIntrosV2GlossaryDrawer, ScorePercentPill, PathProfileChip,
+ *   ProximityCodeBadge, SectorTagsList, FilterSelect, Drawer, Modal, CopyButton,
+ *   exportWarmIntrosV2Csv, parseWarmPathHopChain, masterProfileDisplay.util,
+ *   and every WarmIntrosV2Workspace `.module.scss` — so this tracks production 1:1.
+ *
+ * Copied + simplified here (they call the API in production):
+ *   WarmIntrosV2Workspace  → this file            (nuqs + react-query → local state + mocks)
+ *   WarmIntrosV2InvestorDrawer → InvestorDrawerMock.tsx
+ *   MasterProfileModal     → MasterProfileModalMock.tsx
+ *   WarmIntrosV2Table      → WarmIntrosV2TableMock.tsx (Team + Industry/Sector columns dropped)
+ *
+ * Design changes on top of production:
+ *   - the list picker gains an "All investor lists" option, and opens on it
+ *
+ * Deliberate simplifications, all data-layer only:
+ *   - filters live in component state instead of the URL (no nuqs in prototypes)
+ *   - the 14 mocked rows fit on one page, so infinite scroll / pagination is dropped
+ *   - PostHog analytics calls are dropped
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { FilterSelect } from '@/components/common/filters/FilterSelect/FilterSelect';
+import type { Option } from '@/components/form/FormSelect/types';
+import { useDebounce } from '@/hooks/useDebounce';
+import { exportWarmIntrosV2Csv } from '@/components/page/investors/WarmIntrosV2Workspace/exportWarmIntrosV2Csv';
+import { WarmIntrosV2GlossaryDrawer } from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2GlossaryDrawer';
+import {
+  WARM_INTROS_V2_LIST_SLUG_BY_TARGET_SET,
+  WARM_INTROS_V2_TARGET_SET_LABEL,
+  WARM_INTROS_V2_TARGET_SETS,
+  type WarmIntrosV2InvestorSummary,
+  type WarmIntrosV2PathListItem,
+} from '@/services/investors/warm-intros-v2.types';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Workspace.module.scss';
+import {
+  ALL_LISTS,
+  ALL_LISTS_LABEL,
+  ALL_LISTS_MEMBER_COUNT,
+  MOCK_INVESTOR_LISTS,
+  facetsForTargetSet,
+  filterPaths,
+  type TargetSetScope,
+} from './mocks';
+import shell from './PageShell.module.scss';
+import { InvestorDrawerMock } from './InvestorDrawerMock';
+import { WarmIntrosV2TableMock } from './WarmIntrosV2TableMock';
+import { MasterProfileModalMock } from './MasterProfileModalMock';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default function WarmIntrosV2Prototype() {
+  // Opens unscoped: "All investor lists" is the default, the two real lists narrow it.
+  const [targetSet, setTargetSet] = useState<TargetSetScope>(ALL_LISTS);
+  const [connectorUid, setConnectorUid] = useState<string | null>(null);
+  const [sector, setSector] = useState<string | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const debouncedSearch = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
+
+  const [glossaryOpen, setGlossaryOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [selectedProfileUid, setSelectedProfileUid] = useState<string | null>(null);
+  const [drawerRow, setDrawerRow] = useState<WarmIntrosV2PathListItem | null>(null);
+
+  const paths = useMemo(
+    () =>
+      filterPaths({
+        targetSet,
+        search: debouncedSearch.trim() || undefined,
+        connectorProfileUid: connectorUid || undefined,
+        sector: sector || undefined,
+      }),
+    [targetSet, debouncedSearch, connectorUid, sector],
+  );
+  const total = paths.length;
+
+  const facets = useMemo(() => facetsForTargetSet(targetSet), [targetSet]);
+
+  const targetSetOptions = useMemo<Option[]>(() => {
+    const withCount = (name: string, count: number | undefined) =>
+      typeof count === 'number' ? `${name} · ${count.toLocaleString()} ${count === 1 ? 'member' : 'members'}` : name;
+
+    const lists = WARM_INTROS_V2_TARGET_SETS.map((value) => {
+      const list = MOCK_INVESTOR_LISTS.find((l) => l.slug === WARM_INTROS_V2_LIST_SLUG_BY_TARGET_SET[value]);
+      const name = list?.name ?? WARM_INTROS_V2_TARGET_SET_LABEL[value];
+      return { value, label: withCount(name, list?.member_count) };
+    });
+
+    // "All" leads the list — it is the default scope, not a clear-filter action.
+    return [{ value: ALL_LISTS, label: withCount(ALL_LISTS_LABEL, ALL_LISTS_MEMBER_COUNT) }, ...lists];
+  }, []);
+
+  const targetSetValue = targetSetOptions.find((o) => o.value === targetSet) ?? targetSetOptions[0];
+
+  const scopeLabel = targetSet === ALL_LISTS ? ALL_LISTS_LABEL : WARM_INTROS_V2_TARGET_SET_LABEL[targetSet];
+
+  const connectorOptions = useMemo<Option[]>(
+    () => facets.connectors.map((c) => ({ value: c.profileUid, label: `${c.name} (${c.pathCount})` })),
+    [facets],
+  );
+  const connectorValue = connectorOptions.find((o) => o.value === connectorUid) ?? null;
+
+  const sectorOptions = useMemo<Option[]>(
+    () => facets.sectors.map((sec) => ({ value: sec.value, label: `${sec.value} (${sec.count})` })),
+    [facets],
+  );
+  const sectorValue = sectorOptions.find((o) => o.value === sector) ?? null;
+
+  const onPickTargetSet = useCallback((opt: Option | null) => {
+    setTargetSet((opt?.value as TargetSetScope | undefined) ?? ALL_LISTS);
+    setConnectorUid(null);
+    setSector(null);
+  }, []);
+
+  const onExportCsv = useCallback(() => {
+    setExporting(true);
+    try {
+      if (paths.length === 0) return;
+      exportWarmIntrosV2Csv(paths, `warm-intros-v2-${targetSet}-mock.csv`);
+    } finally {
+      setExporting(false);
+    }
+  }, [paths, targetSet]);
+
+  const onOpenMasterProfile = useCallback((investor: WarmIntrosV2InvestorSummary) => {
+    setSelectedProfileUid(investor.profileUid);
+  }, []);
+
+  const onOpenProfileUid = useCallback((uid: string) => {
+    setSelectedProfileUid(uid);
+  }, []);
+
+  const onViewAllPaths = useCallback((row: WarmIntrosV2PathListItem) => {
+    setDrawerRow(row);
+  }, []);
+
+  const onRowClick = useCallback((row: WarmIntrosV2PathListItem) => {
+    setDrawerRow(row);
+  }, []);
+
+  const clearSearch = useCallback(() => setSearchInput(''), []);
+
+  return (
+    <div className={shell.page}>
+      <div className={s.root}>
+        <section className={s.builder}>
+          <header className={s.builderH}>
+            <div className={s.builderHMain}>
+              <h2 className={s.title}>Warm Intros v2</h2>
+              <p className={s.desc}>
+                Who at PL can introduce you — MasterProfile + LLM paths for Neuro and Gold. Pick a list, then filter.
+              </p>
+            </div>
+            <button type="button" className={s.howScoredLink} onClick={() => setGlossaryOpen(true)}>
+              What do these terms mean?
+            </button>
+          </header>
+
+          <div className={s.filterBar}>
+            <div className={s.filterBarItem} style={{ minWidth: 280 }}>
+              <FilterSelect
+                options={targetSetOptions}
+                value={targetSetValue}
+                placeholder="Investors list"
+                aria-label="Investors list"
+                onChange={onPickTargetSet}
+              />
+            </div>
+
+            <div className={clsx(s.filterBarItem, s.filterBarSearch)}>
+              <div className={s.searchWrap}>
+                <span className={s.searchIcon} aria-hidden>
+                  <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
+                    <circle cx="9" cy="9" r="6" />
+                    <path d="M15 15l-3.5-3.5" strokeLinecap="round" />
+                  </svg>
+                </span>
+                <input
+                  className={s.searchInput}
+                  type="text"
+                  inputMode="search"
+                  autoComplete="off"
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Search name or email…"
+                  aria-label="Search name or email"
+                />
+                {searchInput ? (
+                  <button type="button" className={s.searchClear} onClick={clearSearch} aria-label="Clear search">
+                    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
+                      <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className={s.filterBarItem} style={{ minWidth: 160 }}>
+              <FilterSelect
+                options={connectorOptions}
+                value={connectorValue}
+                placeholder="PL member"
+                isClearable
+                isSearchable
+                aria-label="PL member"
+                onChange={(opt) => setConnectorUid(opt?.value || null)}
+              />
+            </div>
+
+            <div className={s.filterBarItem} style={{ minWidth: 160 }}>
+              <FilterSelect
+                options={sectorOptions}
+                value={sectorValue}
+                placeholder="Industry / Sector"
+                isClearable
+                isSearchable
+                aria-label="Industry / Sector"
+                onChange={(opt) => setSector(opt?.value || null)}
+              />
+            </div>
+
+            <div className={s.filterBarItem}>
+              <button type="button" className={s.exportBtn} onClick={onExportCsv} disabled={exporting || total === 0}>
+                {exporting ? 'Exporting…' : 'Export CSV'}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {total === 0 && <div className={s.state}>No paths match these filters.</div>}
+
+        {total > 0 && (
+          <div className={s.listWrap}>
+            <div className={s.meta}>
+              Showing {paths.length} paths · {scopeLabel}
+            </div>
+            <WarmIntrosV2TableMock
+              rows={paths}
+              onOpenMasterProfile={onOpenMasterProfile}
+              onOpenProfileUid={onOpenProfileUid}
+              onViewAllPaths={onViewAllPaths}
+              onRowClick={onRowClick}
+            />
+          </div>
+        )}
+
+        <WarmIntrosV2GlossaryDrawer open={glossaryOpen} onClose={() => setGlossaryOpen(false)} />
+
+        <InvestorDrawerMock
+          key={drawerRow?.uid ?? 'closed'}
+          row={drawerRow}
+          open={!!drawerRow}
+          onClose={() => setDrawerRow(null)}
+          onOpenMasterProfile={(uid) => setSelectedProfileUid(uid)}
+        />
+
+        <MasterProfileModalMock
+          profileUid={selectedProfileUid}
+          open={!!selectedProfileUid}
+          onClose={() => setSelectedProfileUid(null)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+/**
+ * Fork of production `WarmIntrosV2Table` with the **Team** and **Industry / Sector**
+ * columns removed, and Path moved ahead of Proximity — Investor · Path · Proximity.
+ *
+ * Everything else is a verbatim transcription and still uses the production
+ * `WarmIntrosV2Table.module.scss`. The only local CSS is the re-balanced column
+ * widths (see `TableColumns.module.scss`), because the production widths were
+ * apportioned across five columns.
+ *
+ * Firm + role no longer have a column of their own, so they ride along under the
+ * investor name where the email already sits — dropping the column shouldn't lose
+ * the data. Sectors are gone from the row entirely; they remain in the drawer.
+ */
+
+import type { ReactNode, Ref } from 'react';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import type { WarmIntrosV2InvestorSummary, WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
+import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
+import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss';
+import c from './TableColumns.module.scss';
+
+interface Props {
+  rows: WarmIntrosV2PathListItem[];
+  onOpenMasterProfile: (investor: WarmIntrosV2InvestorSummary) => void;
+  onOpenProfileUid: (profileUid: string) => void;
+  onViewAllPaths: (row: WarmIntrosV2PathListItem) => void;
+  onRowClick?: (row: WarmIntrosV2PathListItem) => void;
+  scrollRootRef?: Ref<HTMLDivElement>;
+  sentinelRef?: Ref<HTMLDivElement>;
+  footer?: ReactNode;
+}
+
+function pathCount(row: WarmIntrosV2PathListItem): number {
+  return (row.pathSummary?.alternateCount ?? 0) + 1;
+}
+
+function memberAvatarSrc(investor: WarmIntrosV2InvestorSummary | undefined): string | null {
+  if (!investor?.memberUid) return null;
+  return investor.imageUrl?.trim() || getDefaultAvatar(investor.name);
+}
+
+export function WarmIntrosV2TableMock({
+  rows,
+  onOpenMasterProfile,
+  onOpenProfileUid,
+  onViewAllPaths,
+  onRowClick,
+  scrollRootRef,
+  sentinelRef,
+  footer,
+}: Props) {
+  return (
+    <div className={s.tableWrap} ref={scrollRootRef}>
+      <table className={`${s.table} ${c.table}`}>
+        <thead>
+          <tr>
+            <th className={`${s.th} ${c.colInvestor}`} scope="col">
+              Investor
+            </th>
+            <th className={`${s.th} ${c.colPath}`} scope="col">
+              Path
+            </th>
+            <th className={`${s.th} ${c.colProximity}`} scope="col">
+              Proximity
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const investor = row.investor;
+            const name = investor?.name?.trim() || row.targetProfileUid;
+            const org = investor?.currentOrg?.trim();
+            const title = investor?.currentTitle?.trim();
+            const count = pathCount(row);
+            const avatarSrc = memberAvatarSrc(investor);
+            const connector = row.bestConnector;
+            // Firm · role, folded into the investor cell now that Team has no column.
+            const orgLine = [org, title].filter(Boolean).join(' · ');
+
+            return (
+              <tr
+                key={row.uid}
+                className={s.row}
+                onClick={() => onRowClick?.(row)}
+                tabIndex={onRowClick ? 0 : undefined}
+                onKeyDown={
+                  onRowClick
+                    ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onRowClick(row);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                <td className={s.td}>
+                  <div className={s.investorText}>
+                    <button
+                      type="button"
+                      className={s.nameBtn}
+                      aria-label={`Open profile for ${name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (investor) onOpenMasterProfile(investor);
+                      }}
+                    >
+                      {name}
+                    </button>
+                    {orgLine ? <div className={s.subtle}>{orgLine}</div> : null}
+                    {investor?.email ? <div className={s.subtle}>{investor.email}</div> : null}
+                  </div>
+                </td>
+
+                <td className={s.td}>
+                  <div className={s.pathCell}>
+                    <div className={s.pathChain}>
+                      {connector ? (
+                        <PathProfileChip
+                          name={connector.name}
+                          profileUid={connector.profileUid}
+                          imageUrl={
+                            connector.memberUid
+                              ? connector.imageUrl?.trim() || getDefaultAvatar(connector.name)
+                              : connector.imageUrl
+                          }
+                          onOpen={onOpenProfileUid}
+                        />
+                      ) : (
+                        <span className={s.muted}>—</span>
+                      )}
+                      {connector && investor ? <span className={s.pathArrow}>→</span> : null}
+                      {investor ? (
+                        <PathProfileChip
+                          name={investor.name}
+                          profileUid={investor.profileUid}
+                          imageUrl={avatarSrc}
+                          onOpen={onOpenProfileUid}
+                        />
+                      ) : null}
+                    </div>
+                    <button
+                      type="button"
+                      className={s.viewAllLink}
+                      aria-label={`View all ${count} paths for ${name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onViewAllPaths(row);
+                      }}
+                    >
+                      View all ({count})
+                    </button>
+                  </div>
+                </td>
+
+                <td className={s.td}>
+                  <div className={s.proximityCell}>
+                    {row.proximityCode ? (
+                      <ProximityCodeBadge code={row.proximityCode} />
+                    ) : (
+                      <span className={s.muted}>—</span>
+                    )}
+                    <ScorePercentPill scorePercent={row.scorePercent} scoreBand={row.scoreBand} />
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div ref={sentinelRef} className={s.sentinel} />
+      {footer}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
@@ -21,7 +21,11 @@ import type { WarmIntrosV2InvestorSummary, WarmIntrosV2PathListItem } from '@/se
 import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
 import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
 import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss';
+// The MasterProfile modal already colours the two lists — Neuro blue, Gold amber.
+// Reusing those pills keeps one colour language for "which list" across surfaces.
+import p from '@/components/page/investors/WarmIntrosV2Workspace/MasterProfileModal.module.scss';
 import c from './TableColumns.module.scss';
+import { TARGET_SET_SHORT_LABEL } from './mocks';
 
 interface Props {
   rows: WarmIntrosV2PathListItem[];
@@ -29,9 +33,30 @@ interface Props {
   onOpenProfileUid: (profileUid: string) => void;
   onViewAllPaths: (row: WarmIntrosV2PathListItem) => void;
   onRowClick?: (row: WarmIntrosV2PathListItem) => void;
+  /**
+   * Show which list each row came from. Only worth it when the scope spans more
+   * than one list — under a single list every badge would say the same thing.
+   */
+  showListName?: boolean;
   scrollRootRef?: Ref<HTMLDivElement>;
   sentinelRef?: Ref<HTMLDivElement>;
   footer?: ReactNode;
+}
+
+const LIST_FULL_LABEL: Record<string, string> = {
+  'neuro-fund-i': 'Neuro Fund I LP Pipeline',
+  'gold-co-investors': 'Gold PLC Co-Investors',
+};
+
+function ListBadge({ targetSet }: { targetSet: string }) {
+  const short = TARGET_SET_SHORT_LABEL[targetSet as keyof typeof TARGET_SET_SHORT_LABEL];
+  if (!short) return null;
+  const tone = targetSet === 'neuro-fund-i' ? p.listNeuro : targetSet === 'gold-co-investors' ? p.listGold : undefined;
+  return (
+    <span className={`${p.listPill} ${tone ?? ''} ${c.listBadge}`} title={LIST_FULL_LABEL[targetSet] ?? short}>
+      {short}
+    </span>
+  );
 }
 
 function pathCount(row: WarmIntrosV2PathListItem): number {
@@ -49,6 +74,7 @@ export function WarmIntrosV2TableMock({
   onOpenProfileUid,
   onViewAllPaths,
   onRowClick,
+  showListName = false,
   scrollRootRef,
   sentinelRef,
   footer,
@@ -100,17 +126,20 @@ export function WarmIntrosV2TableMock({
               >
                 <td className={s.td}>
                   <div className={s.investorText}>
-                    <button
-                      type="button"
-                      className={s.nameBtn}
-                      aria-label={`Open profile for ${name}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (investor) onOpenMasterProfile(investor);
-                      }}
-                    >
-                      {name}
-                    </button>
+                    <div className={c.nameLine}>
+                      <button
+                        type="button"
+                        className={s.nameBtn}
+                        aria-label={`Open profile for ${name}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (investor) onOpenMasterProfile(investor);
+                        }}
+                      >
+                        {name}
+                      </button>
+                      {showListName ? <ListBadge targetSet={row.targetSet} /> : null}
+                    </div>
                     {orgLine ? <div className={s.subtle}>{orgLine}</div> : null}
                     {investor?.email ? <div className={s.subtle}>{investor.email}</div> : null}
                   </div>

--- a/prototypes/entries/warm-intros-v2/mocks.ts
+++ b/prototypes/entries/warm-intros-v2/mocks.ts
@@ -32,6 +32,16 @@ export type TargetSetScope = typeof ALL_LISTS | WarmIntrosV2TargetSet;
 
 export const ALL_LISTS_LABEL = 'All investor lists';
 
+/**
+ * Short list names for the per-row badge. The full labels
+ * ("Neuro Fund I LP Pipeline") are too long to sit beside a name, so the badge
+ * abbreviates and carries the full label as its tooltip.
+ */
+export const TARGET_SET_SHORT_LABEL: Record<WarmIntrosV2TargetSet, string> = {
+  'neuro-fund-i': 'Neuro Fund I',
+  'gold-co-investors': 'Gold PLC',
+};
+
 /** Total members across the mocked lists — the count shown on the "All" option. */
 export const ALL_LISTS_MEMBER_COUNT = MOCK_INVESTOR_LISTS.reduce((sum, l) => sum + l.member_count, 0);
 

--- a/prototypes/entries/warm-intros-v2/mocks.ts
+++ b/prototypes/entries/warm-intros-v2/mocks.ts
@@ -1,0 +1,611 @@
+/**
+ * Mocked Warm Intros v2 data.
+ *
+ * Shapes mirror `@/services/investors/warm-intros-v2.types` exactly so the prototype
+ * can hand rows straight to the production `WarmIntrosV2Table` / drawer / modal markup.
+ * All people, firms, emails and Affinity ids below are invented.
+ */
+
+import { derivePathProximity } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import type {
+  MasterProfileDetail,
+  WarmIntrosV2ConnectorSummary,
+  WarmIntrosV2Facets,
+  WarmIntrosV2InvestorSummary,
+  WarmIntrosV2PathListItem,
+  WarmIntrosV2TargetSet,
+} from '@/services/investors/warm-intros-v2.types';
+
+/** v1 InvestorList rows the target-set picker reads names + counts from. */
+export const MOCK_INVESTOR_LISTS: Array<{ slug: string; name: string; member_count: number }> = [
+  { slug: 'neuro-lp', name: 'Neuro Fund I LP Pipeline', member_count: 128 },
+  { slug: 'gold-coinvestors', name: 'Gold PLC Co-Investors', member_count: 64 },
+];
+
+/**
+ * The list picker's scope. Production only offers the two target sets; the
+ * prototype adds an unscoped "All" default so the workspace opens on everything
+ * rather than pre-committing to one list.
+ */
+export const ALL_LISTS = 'all' as const;
+export type TargetSetScope = typeof ALL_LISTS | WarmIntrosV2TargetSet;
+
+export const ALL_LISTS_LABEL = 'All investor lists';
+
+/** Total members across the mocked lists — the count shown on the "All" option. */
+export const ALL_LISTS_MEMBER_COUNT = MOCK_INVESTOR_LISTS.reduce((sum, l) => sum + l.member_count, 0);
+
+// ── PL connectors ────────────────────────────────────────────────────────────
+// The six PL people v2 ranks as introducers. `memberUid` present ⇒ directory
+// member ⇒ the chip renders a generated avatar (getDefaultAvatar) instead of initials.
+
+export const MOCK_CONNECTORS: Record<string, WarmIntrosV2ConnectorSummary> = {
+  'pl-mara': {
+    profileUid: 'mp-pl-mara',
+    personKey: 'mara.velasquez',
+    name: 'Mara Velasquez',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Head of Capital Formation',
+    memberUid: 'member-mara',
+    imageUrl: null,
+  },
+  'pl-devin': {
+    profileUid: 'mp-pl-devin',
+    personKey: 'devin.okafor',
+    name: 'Devin Okafor',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Network Growth Lead',
+    memberUid: 'member-devin',
+    imageUrl: null,
+  },
+  'pl-ilse': {
+    profileUid: 'mp-pl-ilse',
+    personKey: 'ilse.brandt',
+    name: 'Ilse Brandt',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Ecosystem Partnerships',
+    memberUid: 'member-ilse',
+    imageUrl: null,
+  },
+  'pl-tomas': {
+    profileUid: 'mp-pl-tomas',
+    personKey: 'tomas.reyna',
+    name: 'Tomás Reyna',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Research Partnerships',
+    memberUid: 'member-tomas',
+    imageUrl: null,
+  },
+  'pl-nadia': {
+    profileUid: 'mp-pl-nadia',
+    personKey: 'nadia.sorensen',
+    name: 'Nadia Sørensen',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Portfolio Support',
+    memberUid: 'member-nadia',
+    imageUrl: null,
+  },
+  'pl-quan': {
+    profileUid: 'mp-pl-quan',
+    personKey: 'quan.tran',
+    name: 'Quan Tran',
+    currentOrg: 'Protocol Labs',
+    currentTitle: 'Founder Relations',
+    memberUid: null,
+    imageUrl: null,
+  },
+};
+
+// ── Investors ────────────────────────────────────────────────────────────────
+
+type InvestorSeed = WarmIntrosV2InvestorSummary & {
+  /** Which mocked list this investor belongs to. */
+  targetSet: WarmIntrosV2TargetSet;
+  /** Best connector key into MOCK_CONNECTORS. */
+  connector: keyof typeof MOCK_CONNECTORS;
+  /** 0–1 path strength; drives proximity code, caliber, score % and band. */
+  score: number;
+  /** Reason lines the drawer lists under "Best path". */
+  reasons: string[];
+  /** Alternate connectors, weaker than the best path. */
+  alternates: Array<{ connector: keyof typeof MOCK_CONNECTORS; score: number; reason: string }>;
+};
+
+const INVESTOR_SEEDS: InvestorSeed[] = [
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-linnea-holm',
+    personKey: 'linnea.holm',
+    name: 'Linnéa Holm',
+    email: 'linnea@northaxis.vc',
+    currentOrg: 'North Axis Capital',
+    currentTitle: 'General Partner',
+    sectors: ['neurotech', 'biotech', 'ai'],
+    affinityPersonId: '80114221',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-mara',
+    score: 0.87,
+    reasons: [
+      'Mara and Linnéa co-hosted the Neuro Capital roundtable at LabWeek 2025 and have exchanged mail since.',
+      'North Axis is an existing LP in two Protocol Labs–adjacent funds.',
+    ],
+    alternates: [
+      { connector: 'pl-ilse', score: 0.52, reason: 'Ilse shares the DeSci Foundation advisory board with Linnéa.' },
+      { connector: 'pl-devin', score: 0.24, reason: 'Overlapping attendance at two 2024 ecosystem events.' },
+    ],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-arjun-pillai',
+    personKey: 'arjun.pillai',
+    name: 'Arjun Pillai',
+    email: 'arjun@meridianbio.fund',
+    currentOrg: 'Meridian Bio Ventures',
+    currentTitle: 'Managing Partner',
+    sectors: ['biotech', 'neurotech'],
+    affinityPersonId: '80114998',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-tomas',
+    score: 0.74,
+    reasons: [
+      'Tomás and Arjun co-authored a 2024 position paper on open neuro datasets.',
+      'Meridian Bio backed a portfolio company Tomás sourced.',
+    ],
+    alternates: [
+      { connector: 'pl-nadia', score: 0.31, reason: 'Nadia supported a shared portfolio company through diligence.' },
+    ],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-sofia-marchetti',
+    personKey: 'sofia.marchetti',
+    name: 'Sofia Marchetti',
+    email: 'sofia@cortexpartners.com',
+    currentOrg: 'Cortex Partners',
+    currentTitle: 'Partner',
+    sectors: ['neurotech', 'frontier-tech', 'robotics'],
+    affinityPersonId: '80115402',
+    memberUid: 'member-sofia',
+    imageUrl: null,
+    connector: 'pl-ilse',
+    score: 0.68,
+    reasons: ['Ilse and Sofia served together on the LabWeek programme committee.'],
+    alternates: [
+      { connector: 'pl-mara', score: 0.44, reason: 'Warm but dated — one intro thread in early 2024.' },
+      { connector: 'pl-quan', score: 0.19, reason: 'Weak signal: shared alumni network only.' },
+    ],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-hendrik-vos',
+    personKey: 'hendrik.vos',
+    name: 'Hendrik Vos',
+    email: 'h.vos@delftseed.nl',
+    currentOrg: 'Delft Seed',
+    currentTitle: 'Founding Partner',
+    sectors: ['frontier-tech', 'robotics'],
+    affinityPersonId: null,
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-devin',
+    score: 0.55,
+    reasons: ['Devin and Hendrik are both mentors in the same hardware accelerator cohort.'],
+    alternates: [],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-yara-nasser',
+    personKey: 'yara.nasser',
+    name: 'Yara Nasser',
+    email: 'yara@openminds.capital',
+    currentOrg: 'OpenMinds Capital',
+    currentTitle: 'Principal',
+    sectors: ['neurotech', 'ai', 'desci'],
+    affinityPersonId: '80116077',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-mara',
+    score: 0.49,
+    reasons: ['Mara met Yara at the Neuro Fund I kickoff; follow-up thread is still open.'],
+    alternates: [
+      { connector: 'pl-tomas', score: 0.36, reason: 'Tomás cited two of Yara’s DeSci essays in a workshop.' },
+    ],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-callum-doyle',
+    personKey: 'callum.doyle',
+    name: 'Callum Doyle',
+    email: 'callum@severnhill.co',
+    currentOrg: 'Severnhill',
+    currentTitle: 'Investment Director',
+    sectors: ['biotech', 'climate'],
+    affinityPersonId: null,
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-nadia',
+    score: 0.33,
+    reasons: ['Nadia and Callum overlapped on one diligence call in 2025 — thin but real.'],
+    alternates: [{ connector: 'pl-ilse', score: 0.21, reason: 'Shared conference panel, no direct correspondence.' }],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-petra-svoboda',
+    personKey: 'petra.svoboda',
+    name: 'Petra Svoboda',
+    email: null,
+    currentOrg: 'Vltava Growth',
+    currentTitle: 'Partner',
+    sectors: ['saas', 'ai'],
+    affinityPersonId: null,
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-quan',
+    score: 0.18,
+    reasons: ['Model-inferred only: Quan and Petra share two portfolio companies, no correspondence found.'],
+    alternates: [],
+  },
+  {
+    targetSet: 'neuro-fund-i',
+    profileUid: 'mp-inv-thabo-mokoena',
+    personKey: 'thabo.mokoena',
+    name: 'Thabo Mokoena',
+    email: 'thabo@kalaharicap.africa',
+    currentOrg: 'Kalahari Capital',
+    currentTitle: 'General Partner',
+    sectors: ['fintech', 'infrastructure', 'ai', 'climate'],
+    affinityPersonId: '80116540',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-devin',
+    score: 0.63,
+    reasons: [
+      'Devin ran a joint founder session with Kalahari in Cape Town.',
+      'Two live email threads in the last quarter.',
+    ],
+    alternates: [{ connector: 'pl-mara', score: 0.29, reason: 'One LP-side introduction in 2024.' }],
+  },
+
+  // ── Gold PLC Co-Investors ──────────────────────────────────────────────────
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-elena-marchand',
+    personKey: 'elena.marchand',
+    name: 'Elena Marchand',
+    email: 'elena@auventures.fr',
+    currentOrg: 'Au Ventures',
+    currentTitle: 'Managing Partner',
+    sectors: ['crypto', 'defi', 'infrastructure'],
+    affinityPersonId: '80117001',
+    memberUid: 'member-elena',
+    imageUrl: null,
+    connector: 'pl-mara',
+    score: 0.91,
+    reasons: [
+      'Au Ventures co-invested with Gold PLC in two consecutive rounds; Mara led both syndicates.',
+      'Standing quarterly call between Mara and Elena.',
+    ],
+    alternates: [
+      { connector: 'pl-nadia', score: 0.57, reason: 'Nadia supports a jointly held portfolio company.' },
+      { connector: 'pl-devin', score: 0.34, reason: 'Met at two consecutive ecosystem summits.' },
+    ],
+  },
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-ken-abelard',
+    personKey: 'ken.abelard',
+    name: 'Ken Abelard',
+    email: 'ken@bluerockdigital.com',
+    currentOrg: 'Bluerock Digital',
+    currentTitle: 'Partner',
+    sectors: ['crypto', 'gaming'],
+    affinityPersonId: '80117223',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-quan',
+    score: 0.71,
+    reasons: ['Quan has introduced three founders to Ken since 2024; two converted to term sheets.'],
+    alternates: [{ connector: 'pl-ilse', score: 0.4, reason: 'Ilse and Ken sit on the same standards working group.' }],
+  },
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-ingrid-lundqvist',
+    personKey: 'ingrid.lundqvist',
+    name: 'Ingrid Lundqvist',
+    email: 'ingrid@norrskenlp.se',
+    currentOrg: 'Norrsken LP',
+    currentTitle: 'Head of Ventures',
+    sectors: ['climate', 'infrastructure', 'desci'],
+    affinityPersonId: null,
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-ilse',
+    score: 0.58,
+    reasons: ['Ilse and Ingrid co-chaired the open-infrastructure track at two conferences.'],
+    alternates: [],
+  },
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-rafael-ortiz',
+    personKey: 'rafael.ortiz',
+    name: 'Rafael Ortiz',
+    email: 'rafael@andescrypto.io',
+    currentOrg: 'Andes Crypto',
+    currentTitle: 'Founder & GP',
+    sectors: ['crypto', 'defi'],
+    affinityPersonId: '80117690',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-devin',
+    score: 0.42,
+    reasons: ['Devin and Rafael have an open thread from a 2025 co-investment that did not close.'],
+    alternates: [{ connector: 'pl-mara', score: 0.27, reason: 'Indirect: shared LP base, no direct contact.' }],
+  },
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-mei-lin-chow',
+    personKey: 'mei.lin.chow',
+    name: 'Mei-Lin Chow',
+    email: 'meilin@harborlightpartners.sg',
+    currentOrg: 'Harborlight Partners',
+    currentTitle: 'Partner',
+    sectors: ['fintech', 'saas', 'ai'],
+    affinityPersonId: null,
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-nadia',
+    score: 0.22,
+    reasons: ['Weak: one shared board observer seat, no correspondence in the last 18 months.'],
+    alternates: [],
+  },
+  {
+    targetSet: 'gold-co-investors',
+    profileUid: 'mp-inv-samuel-adeyemi',
+    personKey: 'samuel.adeyemi',
+    name: 'Samuel Adeyemi',
+    email: 'sam@lagosdeltafund.com',
+    currentOrg: 'Lagos Delta Fund',
+    currentTitle: 'Investment Partner',
+    sectors: ['infrastructure', 'fintech'],
+    affinityPersonId: '80118014',
+    memberUid: null,
+    imageUrl: null,
+    connector: 'pl-tomas',
+    score: 0.66,
+    reasons: ['Tomás and Samuel ran a joint research grant programme in 2025.'],
+    alternates: [
+      { connector: 'pl-quan', score: 0.38, reason: 'Quan referred one founder that Lagos Delta later backed.' },
+    ],
+  },
+];
+
+// ── Row assembly ─────────────────────────────────────────────────────────────
+
+function toInvestorSummary(seed: InvestorSeed): WarmIntrosV2InvestorSummary {
+  return {
+    profileUid: seed.profileUid,
+    personKey: seed.personKey,
+    name: seed.name,
+    email: seed.email,
+    currentOrg: seed.currentOrg,
+    currentTitle: seed.currentTitle,
+    sectors: seed.sectors,
+    affinityPersonId: seed.affinityPersonId,
+    memberUid: seed.memberUid,
+    imageUrl: seed.imageUrl,
+  };
+}
+
+function buildRow(seed: InvestorSeed, index: number): WarmIntrosV2PathListItem {
+  const investor = toInvestorSummary(seed);
+  const connector = MOCK_CONNECTORS[seed.connector];
+  const proximity = derivePathProximity(seed.score, 1);
+
+  const alternates = seed.alternates.map((alt) => {
+    const c = MOCK_CONNECTORS[alt.connector];
+    const altProximity = derivePathProximity(alt.score, 1);
+    return {
+      profileUid: c.profileUid,
+      name: c.name,
+      score: alt.score,
+      memberUid: c.memberUid,
+      imageUrl: c.imageUrl,
+      reasons: [{ description: alt.reason, sourceType: 'llmPairing' }],
+      proximityCode: altProximity?.proximityCode ?? null,
+      caliber: altProximity?.caliber ?? null,
+      scorePercent: altProximity?.scorePercent,
+      scoreBand: altProximity?.scoreBand,
+    };
+  });
+
+  return {
+    uid: `wp2-${index + 1}`,
+    targetProfileUid: seed.profileUid,
+    targetSet: seed.targetSet,
+    rank: 1,
+    score: seed.score,
+    hopCount: 1,
+    hopChain: {
+      relationKind: 'pl_direct',
+      hops: [
+        {
+          profileUid: connector.profileUid,
+          name: connector.name,
+          role: 'pl_connector',
+          score: seed.score,
+          memberUid: connector.memberUid,
+          imageUrl: connector.imageUrl,
+        },
+        {
+          profileUid: investor.profileUid,
+          name: investor.name,
+          role: 'investor',
+          memberUid: investor.memberUid,
+          imageUrl: investor.imageUrl,
+        },
+      ],
+      reasons: seed.reasons.map((description, i) => ({
+        description,
+        sourceType: i === 0 ? 'webVerify' : 'llmPairing',
+      })),
+      alternates,
+    },
+    bestConnectorProfileUid: connector.profileUid,
+    alternateConnectorProfileUids: alternates.map((a) => a.profileUid),
+    runId: 'mock-run-2026-07',
+    computedAt: '2026-07-21T09:00:00.000Z',
+    proximityCode: proximity?.proximityCode ?? 'PL+1B',
+    caliber: proximity?.caliber ?? null,
+    scorePercent: proximity?.scorePercent ?? 0,
+    scoreBand: proximity?.scoreBand,
+    investor,
+    bestConnector: connector,
+    pathSummary: {
+      explanation: seed.reasons[0] ?? null,
+      alternateCount: alternates.length,
+    },
+  };
+}
+
+/** Every mocked path row, both target sets, already rank-1 sorted by score. */
+export const MOCK_PATHS: WarmIntrosV2PathListItem[] = INVESTOR_SEEDS.map(buildRow).sort(
+  (a, b) => b.scorePercent - a.scorePercent,
+);
+
+/** Facets for the PL member + sector selects, derived from the rows in scope. */
+export function facetsForTargetSet(targetSet: TargetSetScope): WarmIntrosV2Facets {
+  const rows = targetSet === ALL_LISTS ? MOCK_PATHS : MOCK_PATHS.filter((p) => p.targetSet === targetSet);
+
+  const connectorCounts = new Map<string, { profileUid: string; name: string; pathCount: number }>();
+  const sectorCounts = new Map<string, number>();
+
+  for (const row of rows) {
+    const c = row.bestConnector;
+    if (c) {
+      const prev = connectorCounts.get(c.profileUid);
+      connectorCounts.set(c.profileUid, {
+        profileUid: c.profileUid,
+        name: c.name,
+        pathCount: (prev?.pathCount ?? 0) + 1,
+      });
+    }
+    for (const sector of row.investor.sectors) {
+      sectorCounts.set(sector, (sectorCounts.get(sector) ?? 0) + 1);
+    }
+  }
+
+  return {
+    connectors: Array.from(connectorCounts.values()).sort((a, b) => b.pathCount - a.pathCount),
+    sectors: Array.from(sectorCounts.entries())
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+/** Client-side stand-in for the list endpoint's filtering. */
+export function filterPaths(params: {
+  targetSet: TargetSetScope;
+  search?: string;
+  connectorProfileUid?: string;
+  sector?: string;
+}): WarmIntrosV2PathListItem[] {
+  const q = params.search?.trim().toLowerCase();
+
+  return MOCK_PATHS.filter((row) => {
+    if (params.targetSet !== ALL_LISTS && row.targetSet !== params.targetSet) return false;
+    if (params.connectorProfileUid && row.bestConnector?.profileUid !== params.connectorProfileUid) return false;
+    if (params.sector && !row.investor.sectors.includes(params.sector)) return false;
+    if (q) {
+      const haystack =
+        `${row.investor.name} ${row.investor.email ?? ''} ${row.investor.currentOrg ?? ''}`.toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+// ── Master profiles ──────────────────────────────────────────────────────────
+// Keyed by profileUid; covers both investors and connectors so every chip in the
+// table and drawer opens something.
+
+function investorProfile(seed: InvestorSeed): MasterProfileDetail {
+  return {
+    uid: seed.profileUid,
+    personKey: seed.personKey,
+    types: ['investor'],
+    canonicalName: seed.name,
+    memberUid: seed.memberUid,
+    affinityPersonId: seed.affinityPersonId,
+    emails: seed.email ? [{ value: seed.email, sources: [{ type: 'affinity', confidence: 0.9 }] }] : [],
+    phones: [],
+    socials: {
+      linkedin: `https://www.linkedin.com/in/${seed.personKey.replace(/\./g, '-')}`,
+      website: `https://${(seed.currentOrg ?? 'example').toLowerCase().replace(/[^a-z]+/g, '')}.com`,
+    },
+    organizations: [{ name: seed.currentOrg }],
+    experience: [
+      { company: seed.currentOrg, title: seed.currentTitle, startYear: 2019 },
+      { company: 'Helix Growth', title: 'Investment Manager', startYear: 2015, endYear: 2019 },
+    ],
+    education: [{ school: 'Northfield University', degree: 'MSc Economics', endYear: 2013 }],
+    investorMeta: {
+      firm: seed.currentOrg,
+      investorType: 'Venture',
+      stages: ['Seed', 'Series A'],
+      checkSize: '$500k – $3M',
+      sectors: seed.sectors,
+      thesis: 'Backs research-dense teams commercialising open scientific infrastructure.',
+    },
+    locations: [{ city: 'Lisbon', country: 'Portugal' }],
+    listMemberships: [
+      {
+        listSlug: seed.targetSet,
+        listName: seed.targetSet === 'neuro-fund-i' ? 'Neuro Fund I LP Pipeline' : 'Gold PLC Co-Investors',
+      },
+    ],
+    bio: `${seed.name} is ${seed.currentTitle} at ${seed.currentOrg}, focused on ${seed.sectors.join(', ')}.`,
+    currentOrg: seed.currentOrg,
+    currentTitle: seed.currentTitle,
+    projects: [{ name: 'Open Neuro Data Commons' }, { name: 'Frontier Compute Alliance' }],
+    events: [{ name: 'LabWeek 2025' }, { name: 'Neuro Capital Roundtable' }],
+    sourceSnapshots: {
+      affinity: { sourceType: 'affinity', fetchedAt: '2026-07-18T00:00:00.000Z' },
+      web: { sourceType: 'webVerify', fetchedAt: '2026-07-20T00:00:00.000Z' },
+    },
+    enrichmentVersion: 'v2.3.0',
+    enrichedAt: '2026-07-20T11:42:00.000Z',
+    raw: { note: 'Mocked payload — no real enrichment behind this prototype.' },
+  };
+}
+
+function connectorProfile(connector: WarmIntrosV2ConnectorSummary): MasterProfileDetail {
+  return {
+    uid: connector.profileUid,
+    personKey: connector.personKey,
+    types: ['pl_internal'],
+    canonicalName: connector.name,
+    memberUid: connector.memberUid ?? null,
+    affinityPersonId: null,
+    emails: [{ value: `${connector.personKey.replace(/\./g, '.')}@protocol.ai`, sources: [{ type: 'directory' }] }],
+    socials: { linkedin: `https://www.linkedin.com/in/${connector.personKey.replace(/\./g, '-')}` },
+    organizations: [{ name: 'Protocol Labs' }],
+    experience: [{ company: 'Protocol Labs', title: connector.currentTitle, startYear: 2021 }],
+    locations: [{ city: 'Remote' }],
+    bio: `${connector.name} is ${connector.currentTitle} at Protocol Labs and is one of the six connectors v2 ranks.`,
+    currentOrg: connector.currentOrg,
+    currentTitle: connector.currentTitle,
+    enrichedAt: '2026-07-20T11:42:00.000Z',
+  };
+}
+
+export const MOCK_MASTER_PROFILES: Record<string, MasterProfileDetail> = {
+  ...Object.fromEntries(INVESTOR_SEEDS.map((seed) => [seed.profileUid, investorProfile(seed)])),
+  ...Object.fromEntries(Object.values(MOCK_CONNECTORS).map((c) => [c.profileUid, connectorProfile(c)])),
+};
+
+/** Detail-endpoint stand-in: every rank-1 path recorded for one investor. */
+export function pathsForInvestor(profileUid: string, targetSet?: string): WarmIntrosV2PathListItem[] {
+  return MOCK_PATHS.filter((p) => p.targetProfileUid === profileUid && (!targetSet || p.targetSet === targetSet));
+}

--- a/prototypes/registry.ts
+++ b/prototypes/registry.ts
@@ -214,6 +214,14 @@ export const prototypeRegistry: PrototypeEntry[] = [
     category: 'AI Apps',
     load: () => import('./entries/ai-apps-secrets/AiAppsSecretsPrototype'),
   },
+  {
+    key: 'auth-copy-audit',
+    title: 'Auth copy audit — “Log in” → “Sign in”',
+    description:
+      'Every visible string that needs the log→sign change, with file, line, current text and replacement: wrong verb, wrong case, body copy and assistive text. Also lists the identifiers a sweep will match but must not rename — the #login route, auth events, PostHog names, CSS classes — and a suggested order.',
+    category: 'Cross-product',
+    load: () => import('./entries/auth-copy-audit/AuthCopyAuditPrototype'),
+  },
   // TODO: prototype not built yet — folder entries/warm-intros-side-drawer-improvements/ is missing.
   // Re-enable this entry once WarmIntrosSideDrawerPrototype.tsx exists (the import below breaks the build otherwise).
   // {

--- a/prototypes/registry.ts
+++ b/prototypes/registry.ts
@@ -79,6 +79,14 @@ export const prototypeRegistry: PrototypeEntry[] = [
     load: () => import('./entries/warm-intros-filter-update/WarmPathStatesPrototype'),
   },
   {
+    key: 'warm-intros-v2',
+    title: 'Warm intros v2 — mocked clone',
+    description:
+      'Faithful mocked clone of the production Warm Intros v2 workspace: list picker + search + PL-member / sector filters + CSV export, the real results table (proximity code, score %, connector → investor path chips), the glossary drawer, the investor drawer with best path, reasons and alternate connectors, and the MasterProfile modal.',
+    category: 'Investor DB',
+    load: () => import('./entries/warm-intros-v2/WarmIntrosV2Prototype'),
+  },
+  {
     key: 'members',
     title: 'Members — listing page',
     description:


### PR DESCRIPTION
UX fixes on top of production:
- results table drops the Team and Industry / Sector columns; firm + role fold under the investor name, and Path now precedes Proximity, so the connector chain reads before the score that qualifies it
- list picker gains an "All investor lists" default scope, so the workspace opens unscoped instead of pre-committing to one list
- MasterProfile modal moves to the shared content-modal chrome (SubmitDealModal styles + CloseIcon), picking up real dialog semantics, scroll lock and background inerting from Modal instead of hand-rolled markup, with a slimmer single-line header
- LinkedIn / website render inline with the email as icons, matching the v1 InvestorDrawer and member details; type tags sit next to the name