### PR TITLE
fix(team-news): stop feed from scrolling to top on guest Like/Follow

### DIFF
--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -218,6 +218,6 @@ describe('FeedCommentsThread — signed-out gate', () => {
     expect(screen.getByText('Readable while signed out')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'sign in to comment' }));
-    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
   });
 });

--- a/__tests__/page/home/news-card.test.tsx
+++ b/__tests__/page/home/news-card.test.tsx
@@ -78,7 +78,7 @@ describe('NewsCard upvotes', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Like (2)' }));
 
     expect(onUpvoteToggle).not.toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
   });
 
   it('withholds the upvote button until the auth store hydrates', () => {

--- a/__tests__/page/home/news-detail-modal.test.tsx
+++ b/__tests__/page/home/news-detail-modal.test.tsx
@@ -171,7 +171,7 @@ describe('NewsDetailModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Like (4)' }));
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/home?news=story-1#login');
+    expect(mockRouterPush).toHaveBeenCalledWith('/home?news=story-1#login', { scroll: false });
     expect(onUpvoteToggle).not.toHaveBeenCalled();
   });
 

--- a/__tests__/page/home/news-group-card.test.tsx
+++ b/__tests__/page/home/news-group-card.test.tsx
@@ -136,7 +136,7 @@ describe('NewsGroupCard', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Follow Acme' }));
     expect(onFollowToggle).not.toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
   });
 
   it('renders a story with its summary when present, and omits the paragraph when absent', () => {
@@ -252,7 +252,7 @@ describe('NewsGroupCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Like (0)' }));
     expect(onUpvoteToggle).not.toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
   });
 
   it('calls onUpvoteToggle with the clicked story when authenticated, without opening the story', () => {

--- a/__tests__/page/home/news-rail.test.tsx
+++ b/__tests__/page/home/news-rail.test.tsx
@@ -63,7 +63,7 @@ describe('NewsRail', () => {
     render(<NewsRail onPopularItemClick={mockOnPopularItemClick} />);
     fireEvent.click(screen.getByRole('button', { name: 'Subscribe' }));
     expect(mockMutate).not.toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
   });
 
   it('calls the forum-digest mutation with weekly frequency and news enabled when an authenticated user subscribes, and fires onForumDigestOptionSelect(source: home-feed) once it succeeds', () => {

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -976,7 +976,7 @@ describe('TeamNews', () => {
 
       fireEvent.click(within(getDialog()).getByRole('button', { name: 'Like (0)' }));
 
-      expect(mockRouterPush).toHaveBeenCalledWith('/home?news=ai-1#login');
+      expect(mockRouterPush).toHaveBeenCalledWith('/home?news=ai-1#login', { scroll: false });
     });
 
     it('a valid deep link opens the modal on first render and reports the deep-link open once', () => {

--- a/__tests__/page/home/teams-to-follow-card.test.tsx
+++ b/__tests__/page/home/teams-to-follow-card.test.tsx
@@ -143,7 +143,7 @@ describe('TeamsToFollowCard', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /follow banyan storage/i }));
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
     expect(mockOnFollowToggle).not.toHaveBeenCalled();
   });
 

--- a/components/core/login/components/AuthBox/AuthBox.tsx
+++ b/components/core/login/components/AuthBox/AuthBox.tsx
@@ -33,8 +33,10 @@ export function AuthBox({ isLoggedIn }: { isLoggedIn: boolean }) {
   // Prevent authenticated users from accessing login modal
   useEffect(() => {
     if (isLoggedIn && hash === '#login') {
-      // Only redirect if the hash is specifically #login, preserve other hashes
-      router.push(`${window.location.pathname}${window.location.search}`);
+      // Only redirect if the hash is specifically #login, preserve other hashes.
+      // scroll: false — same canonicalUrl-vs-actual-URL mismatch as AuthInfo's
+      // push can make this look like a real navigation and reset scroll.
+      router.push(`${window.location.pathname}${window.location.search}`, { scroll: false });
     }
   }, [router, hash, isLoggedIn]);
 

--- a/components/core/login/components/AuthInfo/AuthInfo.tsx
+++ b/components/core/login/components/AuthInfo/AuthInfo.tsx
@@ -49,7 +49,11 @@ export function AuthInfo() {
       }
 
       authEvents.emit('auth:init-login');
-      router.push(`${window.location.pathname}${window.location.search}`);
+      // scroll: false — this fires right after login() opens the Privy modal;
+      // without it, Next treats the hash-stripping push as a real navigation
+      // (same canonicalUrl-vs-actual-URL mismatch as the modal's #login gate)
+      // and resets the underlying page's scroll to the top.
+      router.push(`${window.location.pathname}${window.location.search}`, { scroll: false });
     } catch (err) {
       console.log('Login Failed', err);
     }

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -103,7 +103,7 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
   };
 
   const goToLogin = () => {
-    router.push(`${window.location.pathname}${window.location.search}#login`);
+    router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
   };
 
   const pendingText = addComment.isPending ? addComment.variables?.text.trim() : undefined;

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
@@ -67,7 +67,7 @@ export const NewsCard = ({
   const handleFollowClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!currentUser) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
     onFollowToggle?.(item.teamUid, item.teamName, isFollowing);
@@ -75,7 +75,7 @@ export const NewsCard = ({
 
   const handleUpvoteToggle = () => {
     if (!currentUser) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
     onUpvoteToggle?.(item);

--- a/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.tsx
+++ b/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.tsx
@@ -100,7 +100,11 @@ export function NewsDetailModal({
 
   const handleFollowClick = () => {
     if (!currentUser) {
-      router.push(`/home?news=${encodeURIComponent(item.uid)}#login`);
+      // scroll: false — Next resolves this push as a real navigation (its
+      // canonicalUrl never learned the ?news= param, since useNewsDeepLink
+      // writes it via raw history.replaceState) and would otherwise reset
+      // the feed's scroll position to the top on every guest login-gate.
+      router.push(`/home?news=${encodeURIComponent(item.uid)}#login`, { scroll: false });
       return;
     }
     onFollowToggle?.(item.teamUid, item.teamName, isFollowing);
@@ -111,7 +115,8 @@ export function NewsDetailModal({
       // Constructed, not read from location.search — the URL write on open is
       // synchronous (history.replaceState), but building the target explicitly
       // keeps the login round-trip correct even if that ever changes.
-      router.push(`/home?news=${encodeURIComponent(item.uid)}#login`);
+      // scroll: false for the same reason as handleFollowClick above.
+      router.push(`/home?news=${encodeURIComponent(item.uid)}#login`, { scroll: false });
       return;
     }
     onUpvoteToggle(item);

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -72,7 +72,7 @@ export function NewsGroupCard({
   const handleFollowClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!currentUser) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
     onFollowToggle?.(cluster.teamUid, cluster.teamName, isFollowing);
@@ -80,7 +80,7 @@ export function NewsGroupCard({
 
   const handleUpvoteClick = (story: ITeamNewsItem) => {
     if (!currentUser) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
     onUpvoteToggle?.(story);

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -187,7 +187,7 @@ export function NewsRail({
 
   const handleSubscribeClick = () => {
     if (!currentUser?.uid) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
 

--- a/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
@@ -74,7 +74,7 @@ export function TeamsToFollowCard({
   const handleFollowClick = (team: ISuggestedTeam, position: number) => (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!currentUser) {
-      router.push(`${window.location.pathname}${window.location.search}#login`);
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
       return;
     }
     if (followedTeamUids.has(team.uid)) return;


### PR DESCRIPTION
## Summary
- Guest login-gate `router.push('...#login')` calls in Team News (feed rows, rail, comments, modal) and the shared auth flow (`AuthInfo`, `AuthBox`) were treated by Next as real navigations instead of hash-only changes, resetting scroll to the top.
- Root cause: `useNewsDeepLink` writes the `?news=` param via raw `history.replaceState`, so Next's internal `canonicalUrl` never learns about it — any subsequent `router.push` with a differing search string (adding `#login`, or `AuthInfo`/`AuthBox` stripping it again after Privy's modal opens) gets resolved as a full navigation and resets scroll.
- Fix: pass `{ scroll: false }` on all of these guest-gate pushes, matching the pattern already used elsewhere in the codebase (e.g. IRL pages).

## Test plan
- [x] `tsc --noEmit` clean on all touched files
- [x] `eslint` clean on all touched files (pre-existing unrelated warnings/error in `NewsRail.tsx` confirmed present before this change too)
- [ ] Manually verify: as a logged-out user, scroll down the home feed, click Like on a feed row story — page should not jump to top
- [ ] Manually verify: same for Follow on a feed row/rail
- [ ] Manually verify: open a news item's detail modal, click Like/Follow while logged out, including through the Privy login modal opening — no scroll jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)