### PR TITLE
fix(team-news): add missing OTHER category to feed filter menu

### DIFF
--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -181,6 +181,26 @@ describe('TeamNews', () => {
     expect(screen.getByRole('button', { name: /All categories/ })).not.toBeDisabled();
   });
 
+  it('renders an Other category chip, disabled when no OTHER items exist', () => {
+    renderTeamNews(<TeamNews groups={groups} />);
+    // Neither fixture group has an OTHER item, so the chip should render but disable like any other zero-count category.
+    expect(screen.getByRole('button', { name: /^Other$/ })).toBeDisabled();
+  });
+
+  it('enables the Other category chip and filters by it when OTHER items exist', () => {
+    const otherItem = makeItem('ai-other', 'OTHER', ['AI & Robotics']);
+    const groupsWithOther: ITeamNewsGroup[] = [
+      { focusArea: FA_AI, total: aiItems.length + 1, items: [...aiItems, otherItem] },
+      { focusArea: FA_DHR, total: dhrItems.length, items: dhrItems },
+    ];
+    renderTeamNews(<TeamNews groups={groupsWithOther} />);
+    expect(screen.getByRole('button', { name: /^Other/ })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /^Other/ }));
+    expect(mockOnCategoryClicked).toHaveBeenCalledWith('OTHER', 1, 'All');
+    expect(screen.getByText(/Headline ai-other/)).toBeInTheDocument();
+    expect(screen.queryByText(/Headline ai-1/)).not.toBeInTheDocument();
+  });
+
   it('shows all items on Show All click and collapses back on Show Less, reports analytics', () => {
     renderTeamNews(<TeamNews groups={groups} pageSize={2} />);
     // 5 items total, pageSize=2 → first 2 visible

--- a/components/page/home/TeamNews/constants.ts
+++ b/components/page/home/TeamNews/constants.ts
@@ -1,5 +1,7 @@
 import type { TeamNewsEventType } from '@/types/team-news.types';
 
+import { EVENT_TYPE_LABEL } from './utils/getEventTypeConfig';
+
 export const ALL_TAB = 'All';
 export const ALL_CAT = 'all';
 export const ACTIVE_DISCUSSIONS_CAT = 'active-discussions';
@@ -13,9 +15,7 @@ export const ACTIVE_DISCUSSIONS_CATEGORY = {
 
 export const CATEGORIES: Array<{ id: TeamNewsEventType | typeof ALL_CAT; label: string }> = [
   { id: ALL_CAT, label: 'All categories' },
-  { id: 'FUNDING', label: 'Funding' },
-  { id: 'LAUNCH', label: 'Launch' },
-  { id: 'PARTNERSHIP', label: 'Partnership' },
-  { id: 'ANNOUNCEMENT', label: 'Announcement' },
-  { id: 'MILESTONE', label: 'Milestone' },
+  // Safe: EVENT_TYPE_LABEL is declared as an exact Record<TeamNewsEventType, string>,
+  // so its keys are exactly TeamNewsEventType (Object.keys itself only returns string[]).
+  ...(Object.keys(EVENT_TYPE_LABEL) as TeamNewsEventType[]).map((id) => ({ id, label: EVENT_TYPE_LABEL[id] })),
 ];

--- a/components/page/home/TeamNews/utils/getEventTypeConfig.ts
+++ b/components/page/home/TeamNews/utils/getEventTypeConfig.ts
@@ -2,7 +2,7 @@ import type { TeamNewsEventType } from '@/types/team-news.types';
 
 import s from '../components/NewsCard/NewsCard.module.scss';
 
-const LABEL: Record<TeamNewsEventType, string> = {
+export const EVENT_TYPE_LABEL: Record<TeamNewsEventType, string> = {
   FUNDING: 'Funding',
   LAUNCH: 'Launch',
   PARTNERSHIP: 'Partnership',
@@ -21,5 +21,5 @@ const DOT_CLASS: Record<TeamNewsEventType, string> = {
 };
 
 export function getEventTypeConfig(eventType: TeamNewsEventType) {
-  return { label: LABEL[eventType], dotClassName: DOT_CLASS[eventType] };
+  return { label: EVENT_TYPE_LABEL[eventType], dotClassName: DOT_CLASS[eventType] };
 }


### PR DESCRIPTION
## Summary
- The Team News category filter menu was missing an "Other" pill even though `OTHER` has always been a valid `TeamNewsEventType` value (matching the backend Prisma enum and Zod contract exactly).
- Root cause: `CATEGORIES` in `constants.ts` was a hand-maintained array that silently drifted out of sync with the `TeamNewsEventType` union.
- Fix: `CATEGORIES` now derives from the same exhaustive `Record<TeamNewsEventType, string>` label map that `getEventTypeConfig.ts` already uses for card badges (exported as `EVENT_TYPE_LABEL`), so a future addition to the enum fails the TypeScript build instead of silently dropping a filter pill.

Note: the original bug report also claimed "Announcement" and "Discussion" were missing. Investigation showed Announcement was already present in the menu, and "Discussion" isn't a real category — it's the intentional, conditionally-shown "Active Discussions" pill (untouched by this change).

## Testing
- Added two test cases to `__tests__/page/home/team-news.test.tsx`: Other chip disabled at zero count, and enabled + filterable when an `OTHER` item exists.
- `npx jest __tests__/page/home/team-news.test.tsx` — 70/70 passing.
- `npx tsc --noEmit` — no new type errors introduced.
- `npx eslint` on changed files — clean.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)