### PR TITLE
feat(feed): real forum comments + replies in the newsfeed

### DIFF
--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -6,7 +6,7 @@ import { useCurrentUserStore } from '@/services/auth/store';
 import { useFeedComments } from '@/services/feed/hooks/useFeedComments';
 import { useAddFeedComment } from '@/services/feed/hooks/useAddFeedComment';
 import { useDeleteFeedComment } from '@/services/feed/hooks/useDeleteFeedComment';
-import type { IFeedComment } from '@/types/feed.types';
+import type { IFeedComment, IFeedCommentsResponse } from '@/types/feed.types';
 
 jest.mock('@/services/feed/hooks/useFeedComments', () => ({ useFeedComments: jest.fn() }));
 jest.mock('@/services/feed/hooks/useAddFeedComment', () => ({ useAddFeedComment: jest.fn() }));
@@ -52,8 +52,13 @@ function reply(
 }
 
 // Comments are oldest-first — these fixtures are ordered accordingly.
-function mockThread(items: IFeedComment[]) {
-  useFeedCommentsMock.mockReturnValue({ data: { items } });
+function mockThread(items: IFeedComment[], forumTopic?: IFeedCommentsResponse['forumTopic']) {
+  useFeedCommentsMock.mockReturnValue({ data: { items, forumTopic } });
+}
+
+/** What the service reports about a NodeBB topic alongside its replies. */
+function forumTopicMeta(totalReplyCount: number, url: string | null = '/forum/topics/5/96') {
+  return { url, totalReplyCount, like: { likeCount: 0, viewerHasLiked: false } };
 }
 
 function mockMutation(mock: jest.Mock, overrides: Partial<Record<string, unknown>> = {}) {
@@ -433,6 +438,50 @@ describe('FeedCommentsThread — forum posts', () => {
     render(<FeedCommentsThread itemUid="n-1" kind="news" source="news-modal" />);
 
     expect(screen.getByPlaceholderText('Write your comment here…')).toBeInTheDocument();
+  });
+
+  it('links to the forum for the replies NodeBB’s single page left out', () => {
+    // 50 replies exist; one page of them arrived.
+    mockThread([comment('c1', 'Loaded'), comment('c2', 'Also loaded')], forumTopicMeta(50));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    const link = screen.getByRole('link', { name: '48 more comments on the forum →' });
+    expect(link).toHaveAttribute('href', '/forum/topics/5/96');
+  });
+
+  it('says "Show more" rather than "View all N" when N would understate the thread', () => {
+    mockThread([comment('c1', 'One'), comment('c2', 'Two'), comment('c3', 'Three')], forumTopicMeta(50));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByRole('button', { name: 'Show more comments' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+  });
+
+  it('shows no forum link when the whole thread is already here', () => {
+    mockThread([comment('c1', 'One'), comment('c2', 'Two')], forumTopicMeta(2));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.queryByRole('link', { name: /on the forum/ })).not.toBeInTheDocument();
+  });
+
+  it('labels an attachment-only comment instead of rendering a blank row', () => {
+    // A comment that was just an image strips to empty text by contract.
+    mockThread([comment('c1', '')], forumTopicMeta(1));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByRole('link', { name: /Shared an image or file/ })).toHaveAttribute('href', '/forum/topics/5/96');
+  });
+
+  it('still labels an attachment-only comment when there is no topic link', () => {
+    mockThread([comment('c1', '')], forumTopicMeta(1, null));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByText('Shared an image or file.')).toBeInTheDocument();
   });
 
   it('surfaces the forum’s own reason when it has one, in place of the generic line', () => {

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -21,15 +21,28 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: routerPush }),
 }));
 
-function comment(uid: string, text: string, isOwn = false): IFeedComment {
+function comment(uid: string, text: string, isOwn = false, replies: IFeedComment[] = []): IFeedComment {
   return {
     uid,
     itemUid: 'n-1',
-    author: { memberUid: `m-${uid}`, name: `Author ${uid}`, avatarUrl: null, role: 'Founder @ Lattice' },
+    parentUid: null,
+    author: { uid: `m-${uid}`, name: `Author ${uid}`, avatarUrl: null, role: 'Founder @ Lattice' },
     text,
     createdAt: '2026-07-01T00:00:00.000Z',
     isOwn,
+    replies,
   };
+}
+
+/** A reply carries its parent, mirroring what both backends send. */
+function reply(
+  uid: string,
+  text: string,
+  parentUid: string,
+  isOwn = false,
+  replies: IFeedComment[] = [],
+): IFeedComment {
+  return { ...comment(uid, text, isOwn, replies), parentUid };
 }
 
 // Comments are oldest-first — these fixtures are ordered accordingly.
@@ -96,6 +109,89 @@ describe('FeedCommentsThread — list', () => {
     const { container } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
     expect(screen.getByText('<script>alert(1)</script>')).toBeInTheDocument();
     expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('falls back to a readable byline when the author has no name (the wire allows null)', () => {
+    const nameless = { ...comment('c1', 'Anonymous-ish'), author: { uid: 'm-1', name: null, avatarUrl: null } };
+    mockThread([nameless]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(screen.getByText('Member')).toBeInTheDocument();
+  });
+
+  it('shows a role only when the source provides one (news comments have none)', () => {
+    const roleless = {
+      ...comment('c1', 'No role here'),
+      author: { uid: 'm-1', name: 'Author c1', avatarUrl: null },
+    };
+    mockThread([roleless]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(screen.queryByText(/Founder @ Lattice/)).not.toBeInTheDocument();
+  });
+});
+
+describe('FeedCommentsThread — replies', () => {
+  it('renders a reply nested under the comment it answers', () => {
+    mockThread([comment('c1', 'Top level', false, [reply('c2', 'A reply', 'c1')])]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(screen.getByText('Top level')).toBeInTheDocument();
+    expect(screen.getByText('A reply')).toBeInTheDocument();
+  });
+
+  it('renders three levels: comment → reply → reply-to-reply', () => {
+    mockThread([
+      comment('c1', 'Level 0', false, [reply('c2', 'Level 1', 'c1', false, [reply('c3', 'Level 2', 'c2')])]),
+    ]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(screen.getByText('Level 2')).toBeInTheDocument();
+  });
+
+  it('keeps a level-3 reply visible by lifting it to the cap — the wire allows unlimited depth', () => {
+    mockThread([
+      comment('c1', 'Level 0', false, [
+        reply('c2', 'Level 1', 'c1', false, [
+          reply('c3', 'Level 2', 'c2', false, [reply('c4', 'Level 3 lifted', 'c3')]),
+        ]),
+      ]),
+    ]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(screen.getByText('Level 3 lifted')).toBeInTheDocument();
+  });
+
+  it('counts replies in "View all N comments" — the cap applies to top-level comments only', () => {
+    mockThread([
+      comment('c1', 'First', false, [reply('c1r', 'Reply to first', 'c1')]),
+      comment('c2', 'Second'),
+      comment('c3', 'Third'),
+    ]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // 3 top-level + 1 reply = 4, matching what the count badge shows.
+    expect(screen.getByRole('button', { name: 'View all 4 comments' })).toBeInTheDocument();
+    // Only the last 2 top-level comments are visible, so the reply is hidden too.
+    expect(screen.queryByText('Reply to first')).not.toBeInTheDocument();
+  });
+
+  it('offers delete on an own reply, not just on top-level comments', () => {
+    mockThread([comment('c1', 'Not mine', false, [reply('c2', 'My reply', 'c1', true)])]);
+    mockMutation(useAddFeedCommentMock);
+    const deleteMutation = mockMutation(useDeleteFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes' }));
+
+    expect(deleteMutation.mutate).toHaveBeenCalledWith({ commentUid: 'c2' }, expect.any(Object));
   });
 });
 

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -21,6 +21,12 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: routerPush }),
 }));
 
+// Forum writes are gated on forum.write, the same gate the /forum composer uses.
+const mockForumAccess = jest.fn();
+jest.mock('@/services/access-control/hooks/useForumAccess', () => ({
+  useForumAccess: () => mockForumAccess(),
+}));
+
 function comment(uid: string, text: string, isOwn = false, replies: IFeedComment[] = []): IFeedComment {
   return {
     uid,
@@ -79,6 +85,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   signIn();
   mockMutation(useDeleteFeedCommentMock);
+  mockForumAccess.mockReturnValue({ canWrite: true });
 });
 
 describe('FeedCommentsThread — list', () => {
@@ -182,6 +189,99 @@ describe('FeedCommentsThread — replies', () => {
     expect(screen.queryByText('Reply to first')).not.toBeInTheDocument();
   });
 
+  it('submits a reply with its parentUid, and closes the reply box on success', () => {
+    mockThread([comment('c1', 'Top level')]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    const input = screen.getByPlaceholderText('Reply to Author c1…');
+    fireEvent.change(input, { target: { value: '  Agreed  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    expect(mutation.mutate).toHaveBeenCalledWith({ text: 'Agreed', parentUid: 'c1' }, expect.any(Object));
+
+    act(() => mutation.mutate.mock.calls[0][1].onSuccess());
+    expect(screen.queryByPlaceholderText('Reply to Author c1…')).not.toBeInTheDocument();
+  });
+
+  it('keeps the top-level composer separate from the reply box', () => {
+    mockThread([comment('c1', 'Top level')]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    fireEvent.change(screen.getByPlaceholderText('Write your comment here…'), { target: { value: 'Top-level text' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    // No parentUid — typing in the main composer must never become a reply.
+    expect(mutation.mutate).toHaveBeenCalledWith({ text: 'Top-level text' }, expect.any(Object));
+  });
+
+  it('opens only one reply box at a time', () => {
+    mockThread([comment('c1', 'First'), comment('c2', 'Second')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const [firstReply, secondReply] = screen.getAllByRole('button', { name: 'Reply' });
+    fireEvent.click(firstReply);
+    expect(screen.getByPlaceholderText('Reply to Author c1…')).toBeInTheDocument();
+
+    fireEvent.click(secondReply);
+    expect(screen.queryByPlaceholderText('Reply to Author c1…')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Reply to Author c2…')).toBeInTheDocument();
+  });
+
+  it('Cancel discards the reply draft without mutating', () => {
+    mockThread([comment('c1', 'Top level')]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+    fireEvent.change(screen.getByPlaceholderText('Reply to Author c1…'), { target: { value: 'never mind' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mutation.mutate).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText('Reply to Author c1…')).not.toBeInTheDocument();
+  });
+
+  it('hides Reply at the depth cap — a deeper reply would render alongside its own parent', () => {
+    mockThread([
+      comment('c1', 'Level 0', false, [reply('c2', 'Level 1', 'c1', false, [reply('c3', 'Level 2', 'c2')])]),
+    ]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // Levels 0 and 1 can be replied to; level 2 (the cap) cannot.
+    expect(screen.getAllByRole('button', { name: 'Reply' })).toHaveLength(2);
+  });
+
+  it('renders an in-flight reply under the comment it answers, not at the top of the thread', () => {
+    mockThread([comment('c1', 'Answered'), comment('c2', 'Untouched')]);
+    mockMutation(useAddFeedCommentMock, { isPending: true, variables: { text: 'Sending', parentUid: 'c1' } });
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const pending = screen.getByText('Sending');
+    const answeredRow = screen.getByText('Answered').closest('div');
+    const untouchedRow = screen.getByText('Untouched').closest('div');
+
+    expect(answeredRow?.contains(pending)).toBe(true);
+    expect(untouchedRow?.contains(pending)).toBe(false);
+    expect(screen.getByText('· posting…')).toBeInTheDocument();
+  });
+
+  it('scopes a failed reply’s error to that reply box only', () => {
+    mockThread([comment('c1', 'Top level')]);
+    mockMutation(useAddFeedCommentMock, { isError: true, variables: { text: 'Agreed', parentUid: 'c1' } });
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    // Exactly one error, next to the composer that produced it — not duplicated
+    // above the top-level composer.
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+  });
+
   it('offers delete on an own reply, not just on top-level comments', () => {
     mockThread([comment('c1', 'Not mine', false, [reply('c2', 'My reply', 'c1', true)])]);
     mockMutation(useAddFeedCommentMock);
@@ -238,7 +338,7 @@ describe('FeedCommentsThread — composer', () => {
     const mutation = mockMutation(useAddFeedCommentMock, { isError: true });
     render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t post your comment — try again.'.replace('’', "'"));
+    expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t post your comment — try again.');
 
     const input = screen.getByPlaceholderText('Write your comment here…');
     fireEvent.change(input, { target: { value: 'retry text' } });
@@ -300,6 +400,63 @@ describe('FeedCommentsThread — delete', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
     expect(screen.getByText(/Couldn.t delete/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDisabled();
+  });
+});
+
+describe('FeedCommentsThread — forum posts', () => {
+  it('lets a member with forum.write comment and reply on a forum post', () => {
+    mockThread([comment('c1', 'A real forum reply')]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Write your comment here…'), { target: { value: 'Nice work' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    expect(mutation.mutate).toHaveBeenCalledWith({ text: 'Nice work' }, expect.any(Object));
+  });
+
+  it('leaves the thread readable but offers no composer without forum.write', () => {
+    mockForumAccess.mockReturnValue({ canWrite: false });
+    mockThread([comment('c1', 'A real forum reply')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByText('A real forum reply')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
+  });
+
+  it('never gates a news thread on forum.write', () => {
+    mockForumAccess.mockReturnValue({ canWrite: false });
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="news-modal" />);
+
+    expect(screen.getByPlaceholderText('Write your comment here…')).toBeInTheDocument();
+  });
+
+  it('surfaces the forum’s own reason when it has one, in place of the generic line', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock, {
+      isError: true,
+      error: new Error('[[error:content-too-short, Content too short]]'),
+      variables: { text: 'ok' },
+    });
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('too short for the forum');
+  });
+
+  it('hides an untranslated NodeBB error key behind the generic line', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock, {
+      isError: true,
+      error: new Error('[[error:some-key-nobody-can-read]]'),
+      variables: { text: 'ok' },
+    });
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t post your comment — try again.');
   });
 });
 

--- a/__tests__/page/home/forum-post-card.test.tsx
+++ b/__tests__/page/home/forum-post-card.test.tsx
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ForumPostCard } from '@/components/page/home/TeamNews/components/ForumPostCard/ForumPostCard';
+import type { ForumPostUid, IFeedForumPost } from '@/types/feed.types';
+
+jest.mock('@/utils/formatTimeAgo', () => ({ formatTimeAgo: () => '2d ago' }));
+
+const onFeedForumPostCardClicked = jest.fn();
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({ onFeedForumPostCardClicked }),
+}));
+
+jest.mock('@/components/page/home/TeamNews/components/NewsShareMenu', () => ({
+  FeedForumPostShareMenu: () => null,
+}));
+
+const post: IFeedForumPost = {
+  uid: 'fp_96' as ForumPostUid,
+  tid: 96,
+  mainPid: 263,
+  title: 'Willow Is Live!',
+  body: 'Hi Protocol Labs',
+  author: { memberUid: 'm-1', name: 'Matt Curran', avatarUrl: null, role: 'Marketing' },
+  focusAreas: [],
+  category: 'Intros',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  forumTopicUrl: '/forum/topics/5/96',
+  commentCount: 2,
+  likeCount: 5,
+  viewerHasLiked: false,
+};
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof ForumPostCard>> = {}) {
+  const props = {
+    post,
+    position: 0,
+    onOpenDetail: jest.fn(),
+    onLikeToggle: jest.fn(),
+    ...overrides,
+  };
+  render(<ForumPostCard {...props} />);
+  return props;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ForumPostCard', () => {
+  it('renders the post as plain text with its author and category kicker', () => {
+    renderCard();
+
+    expect(screen.getByText('Willow Is Live!')).toBeInTheDocument();
+    expect(screen.getByText('Hi Protocol Labs')).toBeInTheDocument();
+    expect(screen.getByText('Matt Curran')).toBeInTheDocument();
+  });
+
+  it('opens the detail modal on a row click, reported as a row open', () => {
+    const { onOpenDetail } = renderCard();
+
+    fireEvent.click(screen.getByText('Willow Is Live!'));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(post);
+    expect(onFeedForumPostCardClicked).toHaveBeenCalledWith(post, 0, 'home', 'row');
+  });
+
+  it('opens the same modal from the comment badge, flagged as such for analytics', () => {
+    const { onOpenDetail } = renderCard();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(post);
+    expect(onFeedForumPostCardClicked).toHaveBeenCalledWith(post, 0, 'home', 'comment-button');
+  });
+
+  it('never renders a thread inline on the card — the real NodeBB thread lives in the modal', () => {
+    renderCard();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+
+    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+  });
+
+  it('toggles the like without opening the modal', () => {
+    const { onLikeToggle, onOpenDetail } = renderCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /5/ }));
+
+    expect(onLikeToggle).toHaveBeenCalledWith(post);
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/page/home/merge-feed-entries.test.ts
+++ b/__tests__/page/home/merge-feed-entries.test.ts
@@ -1,7 +1,7 @@
 import { feedEntryKey, mergeFeedEntries, type FeedEntry } from '@/components/page/home/TeamNews/utils/mergeFeedEntries';
 import { filterFeedForumPosts, matchesFeedForumPost } from '@/components/page/home/TeamNews/utils/matchesFeedForumPost';
 import { sortTeamNewsClusters, type TeamNewsSort } from '@/components/page/home/TeamNews/utils/sortTeamNewsClusters';
-import { ALL_CAT, ALL_TAB } from '@/components/page/home/TeamNews/constants';
+import { ALL_CAT, ALL_TAB, DISCUSSIONS_CAT } from '@/components/page/home/TeamNews/constants';
 import type { ITeamNewsItem, TeamCluster } from '@/types/team-news.types';
 import type { ForumPostUid, IFeedForumPost } from '@/types/feed.types';
 
@@ -197,9 +197,22 @@ describe('filterFeedForumPosts / matchesFeedForumPost', () => {
     post('fp_net', 2, '2026-07-02', ['Networking']),
   ];
 
-  it('returns nothing outside the All category pill (posts have no event type)', () => {
+  it('returns nothing under an event-type pill (posts have no event type)', () => {
     expect(filterFeedForumPosts(POSTS, { tab: ALL_TAB, category: 'FUNDING', query: '' })).toEqual([]);
-    expect(filterFeedForumPosts(POSTS, { tab: ALL_TAB, category: 'active-discussions', query: '' })).toEqual([]);
+    expect(filterFeedForumPosts(POSTS, { tab: ALL_TAB, category: 'LAUNCH', query: '' })).toEqual([]);
+  });
+
+  it('shows posts under Discussions — the pill that exists to filter to them', () => {
+    expect(filterFeedForumPosts(POSTS, { tab: ALL_TAB, category: DISCUSSIONS_CAT, query: '' })).toHaveLength(2);
+  });
+
+  it('still narrows by tab and search under Discussions', () => {
+    expect(
+      filterFeedForumPosts(POSTS, { tab: 'Networking', category: DISCUSSIONS_CAT, query: '' }).map((p) => p.uid),
+    ).toEqual(['fp_net']);
+    expect(
+      filterFeedForumPosts(POSTS, { tab: ALL_TAB, category: DISCUSSIONS_CAT, query: 'fp_infra' }).map((p) => p.uid),
+    ).toEqual(['fp_infra']);
   });
 
   it('scopes to the focus-area tab, always including the All tab', () => {

--- a/__tests__/page/home/merge-feed-entries.test.ts
+++ b/__tests__/page/home/merge-feed-entries.test.ts
@@ -33,6 +33,8 @@ function cluster(teamUid: string, items: ITeamNewsItem[]): TeamCluster {
 function post(uid: string, likeCount: number, createdAt: string, focusAreas: string[] = ['Infra']): IFeedForumPost {
   return {
     uid: uid as ForumPostUid,
+    tid: 1,
+    mainPid: 10,
     title: `Post ${uid}`,
     body: 'Body text',
     author: { memberUid: 'm1', name: 'Mira Chen', avatarUrl: null, role: 'Founder @ Lattice' },

--- a/__tests__/page/home/news-group-card.test.tsx
+++ b/__tests__/page/home/news-group-card.test.tsx
@@ -186,6 +186,28 @@ describe('NewsGroupCard', () => {
     openSpy.mockRestore();
   });
 
+  it('opens the detail modal from the comment badge, flagged as such for analytics', () => {
+    const onStoryOpen = jest.fn();
+    const item = makeItem('a', '2026-05-03T00:00:00.000Z');
+    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+
+    // The badge is not a disclosure toggle — the thread lives in the modal, and
+    // `via` is the only thing that distinguishes this from a row click.
+    expect(onStoryOpen).toHaveBeenCalledWith(item, 'comment-button');
+  });
+
+  it('never renders a thread inline on the card', () => {
+    render(
+      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+
+    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+  });
+
   it('exposes rows as dialog-opening buttons with the title as accessible name', () => {
     render(
       <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={jest.fn()} />,

--- a/__tests__/page/home/resolve-forum-post-like.test.ts
+++ b/__tests__/page/home/resolve-forum-post-like.test.ts
@@ -1,0 +1,41 @@
+import { resolveForumPostLike } from '@/components/page/home/TeamNews/utils/resolveForumPostLike';
+
+/** Only the like fields matter here; the rest of the post rides along. */
+const post = { uid: 'fp_96', likeCount: 5, viewerHasLiked: false, title: 'Willow Is Live!' };
+
+describe('resolveForumPostLike', () => {
+  it('falls back to the post’s own fields when nothing better is known', () => {
+    expect(resolveForumPostLike(post, undefined, undefined)).toEqual(post);
+  });
+
+  it('takes the topic’s state over the listing’s blind default', () => {
+    // /api/recent can't say whether the viewer liked it; the topic can.
+    const resolved = resolveForumPostLike(post, { likeCount: 7, viewerHasLiked: true }, undefined);
+
+    expect(resolved).toEqual(expect.objectContaining({ likeCount: 7, viewerHasLiked: true }));
+  });
+
+  it('takes the viewer’s own toggle over the topic — it is newer than any fetch', () => {
+    const resolved = resolveForumPostLike(
+      post,
+      { likeCount: 7, viewerHasLiked: true },
+      { likeCount: 6, viewerHasLiked: false },
+    );
+
+    expect(resolved).toEqual(expect.objectContaining({ likeCount: 6, viewerHasLiked: false }));
+  });
+
+  it('keeps every other field on the post untouched', () => {
+    const resolved = resolveForumPostLike(post, { likeCount: 7, viewerHasLiked: true }, undefined);
+
+    expect(resolved.title).toBe('Willow Is Live!');
+    expect(resolved.uid).toBe('fp_96');
+  });
+
+  it('does not mutate the post it was given', () => {
+    resolveForumPostLike(post, { likeCount: 7, viewerHasLiked: true }, undefined);
+
+    expect(post.likeCount).toBe(5);
+    expect(post.viewerHasLiked).toBe(false);
+  });
+});

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { TeamNews } from '@/components/page/home/TeamNews/TeamNews';
 import { useCurrentUserStore } from '@/services/auth/store';
+import type { IFeedForumPost } from '@/types/feed.types';
 import type {
   ITeamNewsDiscussion,
   ITeamNewsGroup,
@@ -43,6 +44,17 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsDetailModalOpened: (...a: unknown[]) => mockOnDetailModalOpened(...a),
     onTeamNewsShared: (...a: unknown[]) => mockOnShared(...a),
   }),
+}));
+
+// Forum posts reach the feed through this hook. Default: none, which is what the
+// globally-mocked useQuery already produced — so every other test in this file
+// behaves exactly as before.
+type FeedSocialResult = { forumPosts: IFeedForumPost[] | undefined; hasAccess: boolean; deepLinkSettled: boolean };
+const mockUseFeedSocial = jest.fn(
+  (): FeedSocialResult => ({ forumPosts: undefined, hasAccess: false, deepLinkSettled: true }),
+);
+jest.mock('@/components/page/home/TeamNews/hooks/useFeedSocial', () => ({
+  useFeedSocial: (...a: unknown[]) => mockUseFeedSocial(...(a as [])),
 }));
 
 // The global jest.setup.js mock returns a NEW object with fresh jest.fn()s on
@@ -132,6 +144,9 @@ describe('TeamNews', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSuggestedTeamsToFollow.mockReturnValue({ suggestions: [], isLoading: false });
+    // clearAllMocks clears calls, NOT return values — without this, a describe
+    // that supplies forum posts leaks them into every later test's feed.
+    mockUseFeedSocial.mockReturnValue({ forumPosts: undefined, hasAccess: false, deepLinkSettled: true });
     // useNewsDeepLink reads the real jsdom URL on mount — reset it so a
     // ?news= param written by one test can't open the modal in the next.
     window.history.replaceState(null, '', '/home');
@@ -276,7 +291,7 @@ describe('TeamNews', () => {
     expect(source).toBe('home');
   });
 
-  describe('Active Discussions', () => {
+  describe('Discussions category', () => {
     const aiDiscussed = makeItem('ai-discuss', 'FUNDING', ['AI & Robotics'], {
       count: 1,
       latestTopicUrl: '/forum/t/123',
@@ -287,43 +302,99 @@ describe('TeamNews', () => {
       { focusArea: FA_DHR, total: dhrItems.length, items: dhrItems },
     ];
 
-    it('does not render Active Discussions when no items have a forum thread', () => {
+    it('does not render Discussions when there are no forum posts and no threaded items', () => {
       renderTeamNews(<TeamNews groups={groups} />);
-      expect(screen.queryByRole('button', { name: /Active Discussions/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Discussions/ })).not.toBeInTheDocument();
     });
 
-    it('shows Active Discussions after All categories when at least one item has a thread', () => {
+    it('shows Discussions after All categories when at least one item has a thread', () => {
       renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
       const chips = screen.getAllByRole('button', { name: /categories|Discussions|Funding|Launch/i });
       const allCat = screen.getByRole('button', { name: /All categories/ });
-      const activeDisc = screen.getByRole('button', { name: /Active Discussions/ });
-      expect(chips.indexOf(activeDisc)).toBeGreaterThan(chips.indexOf(allCat));
-      expect(within(activeDisc).getByText('1')).toBeInTheDocument();
+      const discussions = screen.getByRole('button', { name: /Discussions/ });
+      expect(chips.indexOf(discussions)).toBeGreaterThan(chips.indexOf(allCat));
+      expect(within(discussions).getByText('1')).toBeInTheDocument();
     });
 
     it('filters to discussion items and reports analytics', () => {
       renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
-      fireEvent.click(screen.getByRole('button', { name: /Active Discussions/ }));
-      expect(mockOnCategoryClicked).toHaveBeenCalledWith('active-discussions', 1, 'All');
+      fireEvent.click(screen.getByRole('button', { name: /Discussions/ }));
+      expect(mockOnCategoryClicked).toHaveBeenCalledWith('discussions', 1, 'All');
       expect(screen.getByText(/Headline ai-discuss/)).toBeInTheDocument();
       expect(screen.queryByText(/Headline ai-plain/)).not.toBeInTheDocument();
     });
 
-    it('hides Active Discussions on a focus tab with no threads', () => {
+    it('hides Discussions on a focus tab with nothing to show', () => {
       renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
-      expect(screen.getByRole('button', { name: /Active Discussions/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Discussions/ })).toBeInTheDocument();
       fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
-      expect(screen.queryByRole('button', { name: /Active Discussions/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Discussions/ })).not.toBeInTheDocument();
     });
 
-    it('scopes Active Discussions count to the selected focus tab', () => {
+    it('scopes the Discussions count to the selected focus tab', () => {
       renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
       fireEvent.click(screen.getByRole('tab', { name: /AI & Robotics/ }));
-      const activeDisc = screen.getByRole('button', { name: /Active Discussions/ });
-      expect(within(activeDisc).getByText('1')).toBeInTheDocument();
-      fireEvent.click(activeDisc);
+      const discussions = screen.getByRole('button', { name: /Discussions/ });
+      expect(within(discussions).getByText('1')).toBeInTheDocument();
+      fireEvent.click(discussions);
       expect(screen.getByText(/Headline ai-discuss/)).toBeInTheDocument();
       expect(screen.queryByText(/Headline ai-plain/)).not.toBeInTheDocument();
+    });
+
+    describe('with forum posts in the feed', () => {
+      const forumPost: IFeedForumPost = {
+        uid: 'fp_96',
+        tid: 96,
+        mainPid: 263,
+        title: 'Willow Is Live!',
+        body: 'Hi Protocol Labs',
+        author: { memberUid: 'm-1', name: 'Matt Curran', avatarUrl: null, role: null },
+        focusAreas: [],
+        category: 'Intros',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        forumTopicUrl: '/forum/topics/5/96',
+        commentCount: 2,
+        likeCount: 5,
+        viewerHasLiked: false,
+      };
+
+      beforeEach(() => {
+        mockUseFeedSocial.mockReturnValue({ forumPosts: [forumPost], hasAccess: true, deepLinkSettled: true });
+      });
+
+      it('offers the Discussions pill for forum posts alone, with no threaded news items', () => {
+        // `groups` has no item with a forum thread — before this, the cards were
+        // in the feed with no pill that could reach them.
+        renderTeamNews(<TeamNews groups={groups} />);
+
+        const discussions = screen.getByRole('button', { name: /Discussions/ });
+        expect(within(discussions).getByText('1')).toBeInTheDocument();
+      });
+
+      it('counts forum posts alongside threaded news items', () => {
+        renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
+
+        // 1 threaded news item + 1 forum post.
+        expect(within(screen.getByRole('button', { name: /Discussions/ })).getByText('2')).toBeInTheDocument();
+      });
+
+      it('keeps the forum post visible when Discussions is selected, and drops plain news', () => {
+        renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /Discussions/ }));
+
+        expect(screen.getByText('Willow Is Live!')).toBeInTheDocument();
+        expect(screen.getByText(/Headline ai-discuss/)).toBeInTheDocument();
+        expect(screen.queryByText(/Headline ai-plain/)).not.toBeInTheDocument();
+      });
+
+      it('still hides forum posts under an event-type pill (a post has no event type)', () => {
+        renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /Funding/ }));
+
+        expect(screen.queryByText('Willow Is Live!')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/__tests__/page/home/use-forum-post-deep-link.test.tsx
+++ b/__tests__/page/home/use-forum-post-deep-link.test.tsx
@@ -13,6 +13,8 @@ jest.mock('next/navigation', () => ({
 function post(uid: string): IFeedForumPost {
   return {
     uid: uid as ForumPostUid,
+    tid: 1,
+    mainPid: 10,
     title: `Post ${uid}`,
     body: 'Body',
     author: { memberUid: 'm1', name: 'Mira Chen', avatarUrl: null, role: null },

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -498,4 +498,100 @@ describe('feed.service', () => {
       await expect(getFeedComments('fp_96')).rejects.toThrow('Failed to fetch feed comments');
     });
   });
+
+  describe('writing a forum post comment (a real NodeBB reply)', () => {
+    const created = {
+      response: {
+        pid: 500,
+        content: '<p>Great update!</p>',
+        timestamp: 1782906219045,
+        user: { memberUid: 'viewer-1', displayname: 'Test Viewer', picture: null, teamRole: null },
+      },
+    };
+
+    it('replies to the topic’s opening post for a top-level comment, using the pid it was given', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
+
+      await createFeedComment({ itemUid: 'fp_96', text: 'Great update!', forumMainPid: 263 });
+
+      // One request, not a fetch-the-topic-then-post pair.
+      expect(customFetchMock).toHaveBeenCalledTimes(1);
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://forum.example.com/api/v3/topics/96',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ content: '<p>Great update!</p>', toPid: 263 }),
+        }),
+        false,
+      );
+    });
+
+    it('replies to a comment’s own post when replying to that comment', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
+
+      await createFeedComment({ itemUid: 'fp_96', parentUid: 'fpc_264', text: 'Agreed', forumMainPid: 263 });
+
+      expect(JSON.parse(customFetchMock.mock.calls[0][1].body).toPid).toBe(264);
+    });
+
+    it('falls back to fetching the topic when no mainPid was supplied', async () => {
+      customFetchMock
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ mainPid: 263, posts: [] }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => created });
+
+      await createFeedComment({ itemUid: 'fp_96', text: 'Great update!' });
+
+      expect(customFetchMock).toHaveBeenNthCalledWith(
+        1,
+        'https://forum.example.com/api/topic/96',
+        expect.anything(),
+        false,
+      );
+      expect(JSON.parse(customFetchMock.mock.calls[1][1].body).toPid).toBe(263);
+    });
+
+    it('escapes member text — NodeBB stores content as HTML', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
+
+      await createFeedComment({ itemUid: 'fp_96', text: '<script>alert(1)</script> & "done"', forumMainPid: 263 });
+
+      expect(JSON.parse(customFetchMock.mock.calls[0][1].body).content).toBe(
+        '<p>&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;done&quot;</p>',
+      );
+    });
+
+    it('returns the created comment carrying the caller’s parentUid, which NodeBB does not always echo', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
+
+      const comment = await createFeedComment({
+        itemUid: 'fp_96',
+        parentUid: 'fpc_264',
+        text: 'Agreed',
+        forumMainPid: 263,
+      });
+
+      expect(comment).toEqual(
+        expect.objectContaining({
+          uid: 'fpc_500',
+          itemUid: 'fp_96',
+          // Without this the cache patch would land the reply at the root.
+          parentUid: 'fpc_264',
+          isOwn: false,
+          replies: [],
+        }),
+      );
+    });
+
+    it('propagates NodeBB’s rejection message so the composer can explain itself', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ status: { message: '[[error:content-too-short]]' } }),
+      });
+
+      await expect(createFeedComment({ itemUid: 'fp_96', text: 'hi', forumMainPid: 263 })).rejects.toThrow(
+        '[[error:content-too-short]]',
+      );
+    });
+  });
 });

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -4,25 +4,69 @@ import {
   getFeedCommentCounts,
   getFeedComments,
   getFeedForumPosts,
+  toggleFeedForumPostLike,
 } from '@/services/feed/feed.service';
 import { customFetch } from '@/utils/fetch-wrapper';
 
 jest.mock('@/utils/fetch-wrapper', () => ({ customFetch: jest.fn() }));
 
 const customFetchMock = customFetch as jest.Mock;
-const VIEWER = { memberUid: 'viewer-1', name: 'Test Viewer', avatarUrl: null, role: null };
+
+/** A comment as the directory backend sends it (BE PR #3293). */
+const WIRE_AUTHOR = { uid: 'member-1', name: 'Test Viewer', avatarUrl: null };
+
+function wireComment(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: 'c-1',
+    newsItemUid: 'n-1',
+    parentUid: null,
+    text: 'Hi',
+    author: WIRE_AUTHOR,
+    createdAt: 'now',
+    isOwn: true,
+    replies: [],
+    ...overrides,
+  };
+}
+
+/** A NodeBB topic as /api/recent lists it. */
+const TOPIC = {
+  tid: 96,
+  cid: 5,
+  mainPid: 263,
+  titleRaw: 'Willow Is Live!',
+  title: 'Willow Is Live!',
+  teaser: { content: '<p>Hi Protocol Labs</p>' },
+  category: { name: 'Intros' },
+  timestamp: 1782891482999,
+  postcount: 3,
+  upvotes: 5,
+  user: {
+    memberUid: 'cmo6tw96g005kq04h7yu2rkar',
+    displayname: 'Matt Curran',
+    username: 'matt-curran',
+    picture: null,
+    teamRole: 'Marketing & Business Development',
+  },
+};
 
 const originalApiUrl = process.env.DIRECTORY_API_URL;
+const originalForumApiUrl = process.env.FORUM_API_URL;
+const originalForumToken = process.env.CUSTOM_FORUM_AUTH_TOKEN;
 
 afterAll(() => {
   process.env.DIRECTORY_API_URL = originalApiUrl;
+  process.env.FORUM_API_URL = originalForumApiUrl;
+  process.env.CUSTOM_FORUM_AUTH_TOKEN = originalForumToken;
 });
 
-describe('feed.service (real API)', () => {
+describe('feed.service', () => {
   const fetchMock = jest.fn();
 
   beforeAll(() => {
     process.env.DIRECTORY_API_URL = 'https://api.example.com';
+    process.env.FORUM_API_URL = 'https://forum.example.com';
+    process.env.CUSTOM_FORUM_AUTH_TOKEN = 'forum-token';
     global.fetch = fetchMock;
   });
 
@@ -31,86 +75,427 @@ describe('feed.service (real API)', () => {
     customFetchMock.mockReset();
   });
 
-  it('getFeedForumPosts requests a single bounded page (limit=100, page=0)', async () => {
-    customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [] }) });
-    await getFeedForumPosts();
-    expect(customFetchMock).toHaveBeenCalledWith(
-      'https://api.example.com/v1/feed/forum-posts?limit=100&page=0',
-      { method: 'GET' },
-      true,
-    );
-  });
+  describe('forum posts (NodeBB, no longer proxied by the directory backend)', () => {
+    it('reads NodeBB /api/recent directly, with the forum token', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ topics: [] }) });
 
-  it('getFeedForumPosts returns items on success (no access shows up as an empty list, not an error)', async () => {
-    customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [] }) });
-    const { items } = await getFeedForumPosts();
-    expect(items).toEqual([]);
-  });
+      await getFeedForumPosts();
 
-  it('getFeedForumPosts throws a plain error on failure (queryFns never return null)', async () => {
-    customFetchMock.mockResolvedValue({ ok: false, status: 500 });
-    await expect(getFeedForumPosts()).rejects.toThrow('Failed to fetch feed forum posts');
-  });
-
-  it('getFeedCommentCounts POSTs the uid batch and unwraps the {counts} envelope', async () => {
-    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ counts: { 'n-1': 2 } }) });
-    const counts = await getFeedCommentCounts(['n-1'], 'token-123');
-    expect(counts).toEqual({ 'n-1': 2 });
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.example.com/v1/feed/comments/counts',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ uids: ['n-1'] }) }),
-    );
-    expect(customFetchMock).not.toHaveBeenCalled();
-  });
-
-  it('getFeedComments throws on failure', async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 500 });
-    await expect(getFeedComments('n-1')).rejects.toThrow('Failed to fetch feed comments');
-  });
-
-  it('getFeedComments returns the real {items} shape with no total field', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ items: [{ uid: 'c-1', itemUid: 'n-1', author: VIEWER, text: 'Hi', createdAt: 'now', isOwn: true }] }),
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://forum.example.com/api/recent',
+        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer forum-token' }) }),
+        false,
+      );
     });
-    const { items } = await getFeedComments('n-1');
-    expect(items).toHaveLength(1);
-    expect(items[0].isOwn).toBe(true);
-  });
 
-  it('createFeedComment goes through the authenticated wrapper', async () => {
-    customFetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ uid: 'c-1', itemUid: 'n-1', author: VIEWER, text: 'Hi', createdAt: 'now', isOwn: true }),
+    it('maps a topic onto the feed shape, carrying tid/mainPid so votes and replies need no lookup', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ topics: [TOPIC] }) });
+
+      const { items } = await getFeedForumPosts();
+
+      expect(items).toEqual([
+        expect.objectContaining({
+          uid: 'fp_96',
+          tid: 96,
+          mainPid: 263,
+          title: 'Willow Is Live!',
+          body: 'Hi Protocol Labs',
+          category: 'Intros',
+          forumTopicUrl: '/forum/topics/5/96',
+          likeCount: 5,
+          viewerHasLiked: false,
+        }),
+      ]);
     });
-    const created = await createFeedComment({ itemUid: 'n-1', text: 'Hi' });
-    expect(created.uid).toBe('c-1');
-    expect(customFetchMock).toHaveBeenCalledWith(
-      'https://api.example.com/v1/feed/comments',
-      expect.objectContaining({ method: 'POST' }),
-      true,
-    );
+
+    it('counts replies as postcount minus the topic’s own opening post', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ topics: [TOPIC] }) });
+
+      const { items } = await getFeedForumPosts();
+
+      expect(items[0].commentCount).toBe(2);
+    });
+
+    it('never reports a negative reply count for a topic with no posts', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ topics: [{ ...TOPIC, postcount: 0 }] }) });
+
+      const { items } = await getFeedForumPosts();
+
+      expect(items[0].commentCount).toBe(0);
+    });
+
+    it('throws on failure (queryFns never return null)', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(getFeedForumPosts()).rejects.toThrow('Failed to fetch feed forum posts');
+    });
+
+    it('tolerates a response with no topics array', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      await expect(getFeedForumPosts()).resolves.toEqual({ items: [] });
+    });
   });
 
-  it('deleteFeedComment DELETEs through the authenticated wrapper', async () => {
-    customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ uid: 'c-1', deleted: true }) });
-    const result = await deleteFeedComment('c-1');
-    expect(result).toEqual({ uid: 'c-1', deleted: true });
-    expect(customFetchMock).toHaveBeenCalledWith(
-      'https://api.example.com/v1/feed/comments/c-1',
-      { method: 'DELETE' },
-      true,
-    );
+  describe('forum post likes (NodeBB votes)', () => {
+    it('votes on the topic’s opening post, using the mainPid carried on the post', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      const status = await toggleFeedForumPostLike({ mainPid: 263, likeCount: 5 }, true);
+
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://forum.example.com/api/v3/posts/263/vote',
+        expect.objectContaining({ method: 'PUT', body: JSON.stringify({ delta: 1 }) }),
+        false,
+      );
+      expect(status).toEqual({ likeCount: 6, viewerHasLiked: true });
+    });
+
+    it('removes the vote with DELETE and no body', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      const status = await toggleFeedForumPostLike({ mainPid: 263, likeCount: 5 }, false);
+
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://forum.example.com/api/v3/posts/263/vote',
+        expect.not.objectContaining({ body: expect.anything() }),
+        false,
+      );
+      expect(status).toEqual({ likeCount: 4, viewerHasLiked: false });
+    });
+
+    it('never reports a negative like count when unliking something already at zero', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      await expect(toggleFeedForumPostLike({ mainPid: 263, likeCount: 0 }, false)).resolves.toEqual({
+        likeCount: 0,
+        viewerHasLiked: false,
+      });
+    });
+
+    it('throws on failure so the caller can roll its overlay back', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(toggleFeedForumPostLike({ mainPid: 263, likeCount: 5 }, true)).rejects.toThrow(
+        'Failed to toggle feed forum post like',
+      );
+    });
   });
 
-  it('deleteFeedComment treats a 404 (already deleted) as a success no-op', async () => {
-    customFetchMock.mockResolvedValue({ ok: false, status: 404 });
-    const result = await deleteFeedComment('c-1');
-    expect(result).toEqual({ uid: 'c-1', deleted: true });
+  describe('comment counts', () => {
+    it('POSTs the uid batch and unwraps the {counts} envelope', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ counts: { 'n-1': 2 } }) });
+
+      const counts = await getFeedCommentCounts(['n-1'], 'token-123');
+
+      expect(counts).toEqual({ 'n-1': 2 });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/v1/feed/comments/counts',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ uids: ['n-1'] }) }),
+      );
+      expect(customFetchMock).not.toHaveBeenCalled();
+    });
+
+    it('splits a batch larger than the server’s 200-uid cap and merges the results', async () => {
+      const uids = Array.from({ length: 250 }, (_, i) => `n-${i}`);
+      fetchMock.mockImplementation((_url: string, init: { body: string }) => {
+        const { uids: batch } = JSON.parse(init.body) as { uids: string[] };
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ counts: Object.fromEntries(batch.map((uid) => [uid, 1])) }),
+        });
+      });
+
+      const counts = await getFeedCommentCounts(uids);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const sentBatches = fetchMock.mock.calls.map((call) => JSON.parse(call[1].body).uids.length);
+      expect(sentBatches).toEqual([200, 50]);
+      // Every uid survives the split — one oversized request would have 400ed
+      // and taken every count badge on the page with it.
+      expect(Object.keys(counts)).toHaveLength(250);
+    });
+
+    it('sends exactly one request at the cap boundary', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ counts: {} }) });
+
+      await getFeedCommentCounts(Array.from({ length: 200 }, (_, i) => `n-${i}`));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops forum-post uids — the directory backend only knows news items now', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ counts: { 'n-1': 2 } }) });
+
+      await getFeedCommentCounts(['n-1', 'fp_96']);
+
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body).uids).toEqual(['n-1']);
+    });
+
+    it('makes no request at all when nothing is left to ask about', async () => {
+      await expect(getFeedCommentCounts(['fp_96'])).resolves.toEqual({});
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a response with no counts object', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      await expect(getFeedCommentCounts(['n-1'])).resolves.toEqual({});
+    });
   });
 
-  it('deleteFeedComment throws on other failures (e.g. 403 not-author, 401 expired session)', async () => {
-    customFetchMock.mockResolvedValue({ ok: false, status: 403 });
-    await expect(deleteFeedComment('c-1')).rejects.toThrow('Failed to delete feed comment');
+  describe('news comments (directory backend)', () => {
+    it('queries by newsItemUid, and also sends the old itemUid so either backend version accepts it', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [] }) });
+
+      await getFeedComments('n-1');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.example.com/v1/feed/comments?newsItemUid=n-1&itemUid=n-1');
+    });
+
+    it('maps the wire shape onto the view model (newsItemUid → itemUid)', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [wireComment()] }) });
+
+      const { items } = await getFeedComments('n-1');
+
+      expect(items[0]).toEqual({
+        uid: 'c-1',
+        itemUid: 'n-1',
+        parentUid: null,
+        author: { uid: 'member-1', name: 'Test Viewer', avatarUrl: null },
+        text: 'Hi',
+        createdAt: 'now',
+        isOwn: true,
+        replies: [],
+      });
+    });
+
+    it('maps nested replies at any depth', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            wireComment({
+              replies: [
+                wireComment({
+                  uid: 'c-2',
+                  parentUid: 'c-1',
+                  isOwn: false,
+                  replies: [wireComment({ uid: 'c-3', parentUid: 'c-2', isOwn: false })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      });
+
+      const { items } = await getFeedComments('n-1');
+
+      expect(items[0].replies[0].uid).toBe('c-2');
+      expect(items[0].replies[0].replies[0].uid).toBe('c-3');
+      expect(items[0].replies[0].replies[0].itemUid).toBe('n-1');
+    });
+
+    it('keeps a null author name null rather than inventing one', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [wireComment({ author: { uid: 'm-9', name: null, avatarUrl: null } })] }),
+      });
+
+      const { items } = await getFeedComments('n-1');
+
+      expect(items[0].author.name).toBeNull();
+    });
+
+    it('tolerates a response with no items array', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      await expect(getFeedComments('n-1')).resolves.toEqual({ items: [] });
+    });
+
+    it('throws on failure', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(getFeedComments('n-1')).rejects.toThrow('Failed to fetch feed comments');
+    });
+
+    it('createFeedComment sends both field names through the authenticated wrapper', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => wireComment() });
+
+      const created = await createFeedComment({ itemUid: 'n-1', text: 'Hi' });
+
+      expect(created.uid).toBe('c-1');
+      expect(created.itemUid).toBe('n-1');
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/v1/feed/comments',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ newsItemUid: 'n-1', itemUid: 'n-1', text: 'Hi' }),
+        }),
+        true,
+      );
+    });
+
+    it('createFeedComment sends parentUid for a reply, and omits it entirely otherwise', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => wireComment({ uid: 'c-2', parentUid: 'c-1' }) });
+
+      const created = await createFeedComment({ itemUid: 'n-1', parentUid: 'c-1', text: 'Agreed' });
+
+      expect(created.parentUid).toBe('c-1');
+      expect(JSON.parse(customFetchMock.mock.calls[0][1].body)).toEqual({
+        newsItemUid: 'n-1',
+        itemUid: 'n-1',
+        parentUid: 'c-1',
+        text: 'Agreed',
+      });
+    });
+
+    it('createFeedComment throws on failure', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 400 });
+
+      await expect(createFeedComment({ itemUid: 'n-1', text: 'Hi' })).rejects.toThrow('Failed to post feed comment');
+    });
+
+    it('deleteFeedComment DELETEs through the authenticated wrapper', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ uid: 'c-1', deleted: true }) });
+
+      const result = await deleteFeedComment('c-1');
+
+      expect(result).toEqual({ uid: 'c-1', deleted: true });
+      expect(customFetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/v1/feed/comments/c-1',
+        { method: 'DELETE' },
+        true,
+      );
+    });
+
+    it('deleteFeedComment treats a 404 (already deleted) as a success no-op', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+      await expect(deleteFeedComment('c-1')).resolves.toEqual({ uid: 'c-1', deleted: true });
+    });
+
+    it('deleteFeedComment throws on other failures (e.g. 403 not-author, 401 expired session)', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(deleteFeedComment('c-1')).rejects.toThrow('Failed to delete feed comment');
+    });
+  });
+
+  describe('forum post comments (the real NodeBB thread)', () => {
+    const topicResponse = {
+      mainPid: 263,
+      posts: [
+        // posts[0] is the topic's own opening post — the card, not a comment.
+        { pid: 263, content: '<p>Hi Protocol Labs</p>', timestamp: 1782891482999, user: {} },
+        {
+          pid: 264,
+          content: '<p>awesome!</p>',
+          timestamp: 1782906219045,
+          parent: { pid: 263 },
+          user: { memberUid: 'm-2', displayname: 'Lacey Wisdom', picture: null, teamRole: 'General Partner' },
+        },
+        {
+          pid: 265,
+          content: '<p>thanks!</p>',
+          timestamp: 1782906319045,
+          parent: { pid: 264 },
+          user: { memberUid: 'm-3', displayname: 'Matt Curran', picture: null, teamRole: null },
+        },
+      ],
+    };
+
+    it('reads the topic from NodeBB rather than the directory backend', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => topicResponse });
+
+      await getFeedComments('fp_96');
+
+      expect(customFetchMock).toHaveBeenCalledWith('https://forum.example.com/api/topic/96', expect.anything(), false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('nests real replies on parent.pid instead of flattening them', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => topicResponse });
+
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items).toHaveLength(1);
+      expect(items[0].uid).toBe('fpc_264');
+      expect(items[0].replies.map((reply) => reply.uid)).toEqual(['fpc_265']);
+    });
+
+    it('treats a reply to the opening post as top-level — the opening post is the card, not a comment', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => topicResponse });
+
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items[0].parentUid).toBeNull();
+      expect(items[0].replies[0].parentUid).toBe('fpc_264');
+    });
+
+    it('maps a NodeBB post onto the comment view model, HTML stripped', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => topicResponse });
+
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items[0]).toEqual({
+        uid: 'fpc_264',
+        itemUid: 'fp_96',
+        parentUid: null,
+        author: { uid: 'm-2', name: 'Lacey Wisdom', avatarUrl: null, role: 'General Partner' },
+        text: 'awesome!',
+        createdAt: new Date(1782906219045).toISOString(),
+        isOwn: false,
+        // Its own reply, asserted in full by the nesting tests above.
+        replies: [expect.objectContaining({ uid: 'fpc_265' })],
+      });
+    });
+
+    it('never marks a forum comment as the viewer’s own — there is no delete path against NodeBB', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          posts: [
+            { pid: 263, user: {} },
+            { pid: 264, content: 'mine', timestamp: 1, selfPost: true, user: { memberUid: 'viewer-1' } },
+          ],
+        }),
+      });
+
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items[0].isOwn).toBe(false);
+    });
+
+    it('keeps a reply whose parent is not on this page (a paginated thread) rather than dropping it', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          posts: [
+            { pid: 263, user: {} },
+            { pid: 900, content: 'deep reply', timestamp: 1, parent: { pid: 800 }, user: {} },
+          ],
+        }),
+      });
+
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items.map((item) => item.uid)).toEqual(['fpc_900']);
+    });
+
+    it('returns an empty thread for a topic with no replies', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ mainPid: 263, posts: [{ pid: 263 }] }) });
+
+      await expect(getFeedComments('fp_96')).resolves.toEqual({ items: [] });
+    });
+
+    it('throws when the forum is unreachable', async () => {
+      customFetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(getFeedComments('fp_96')).rejects.toThrow('Failed to fetch feed comments');
+    });
   });
 });

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -489,7 +489,76 @@ describe('feed.service', () => {
     it('returns an empty thread for a topic with no replies', async () => {
       customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ mainPid: 263, posts: [{ pid: 263 }] }) });
 
-      await expect(getFeedComments('fp_96')).resolves.toEqual({ items: [] });
+      const { items } = await getFeedComments('fp_96');
+
+      expect(items).toEqual([]);
+    });
+
+    it('reports the topic’s own vote state, which the card’s listing never carries', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          cid: 5,
+          postcount: 3,
+          posts: [
+            { pid: 263, upvotes: 7, upvoted: true },
+            { pid: 264, content: 'hi', timestamp: 1, user: {} },
+          ],
+        }),
+      });
+
+      const { forumTopic } = await getFeedComments('fp_96');
+
+      expect(forumTopic?.like).toEqual({ likeCount: 7, viewerHasLiked: true });
+      expect(forumTopic?.url).toBe('/forum/topics/5/96');
+    });
+
+    it('reports the topic’s real reply count, which can exceed the page it just served', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          cid: 5,
+          // 50 replies exist; NodeBB returned one page of them.
+          postcount: 51,
+          posts: [{ pid: 263 }, { pid: 264, content: 'hi', timestamp: 1, user: {} }],
+        }),
+      });
+
+      const { items, forumTopic } = await getFeedComments('fp_96');
+
+      expect(items).toHaveLength(1);
+      expect(forumTopic?.totalReplyCount).toBe(50);
+    });
+
+    it('treats a missing vote state as not-liked rather than undefined', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ mainPid: 263, cid: 5, postcount: 1, posts: [{ pid: 263 }] }),
+      });
+
+      const { forumTopic } = await getFeedComments('fp_96');
+
+      expect(forumTopic?.like).toEqual({ likeCount: 0, viewerHasLiked: false });
+    });
+
+    it('keeps an attachment-only reply as an empty-text comment for the UI to label', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          cid: 5,
+          postcount: 2,
+          posts: [{ pid: 263 }, { pid: 264, content: '<p><img src="/x.png" /></p>', timestamp: 1, user: {} }],
+        }),
+      });
+
+      const { items } = await getFeedComments('fp_96');
+
+      // Not dropped, and not given fake text — the component says what it is.
+      expect(items).toHaveLength(1);
+      expect(items[0].text).toBe('');
     });
 
     it('throws when the forum is unreachable', async () => {

--- a/__tests__/services/feed/useAddFeedComment.test.tsx
+++ b/__tests__/services/feed/useAddFeedComment.test.tsx
@@ -15,8 +15,24 @@ jest.mock('@/services/feed/feed.service', () => ({ createFeedComment: jest.fn() 
 
 const createFeedCommentMock = createFeedComment as jest.MockedFunction<typeof createFeedComment>;
 
-function comment(uid: string, itemUid: string, text: string, createdAt: string): IFeedComment {
-  return { uid, itemUid, author: { memberUid: 'm-1', name: 'Author', avatarUrl: null, role: null }, text, createdAt, isOwn: true };
+function comment(
+  uid: string,
+  itemUid: string,
+  text: string,
+  createdAt: string,
+  parentUid: string | null = null,
+  replies: IFeedComment[] = [],
+): IFeedComment {
+  return {
+    uid,
+    itemUid,
+    parentUid,
+    author: { uid: 'm-1', name: 'Author', avatarUrl: null },
+    text,
+    createdAt,
+    isOwn: true,
+    replies,
+  };
 }
 
 describe('useAddFeedComment', () => {
@@ -60,5 +76,61 @@ describe('useAddFeedComment', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.items).toEqual([created]);
+  });
+
+  it('passes parentUid through to the service so a reply is created as a reply', async () => {
+    const itemUid = 'n-1';
+    createFeedCommentMock.mockResolvedValue(comment('c-2', itemUid, 'Agreed', '2026-01-02T00:00:00.000Z', 'c-1'));
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ text: 'Agreed', parentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(createFeedCommentMock).toHaveBeenCalledWith({ itemUid, parentUid: 'c-1', text: 'Agreed' });
+  });
+
+  it('nests a reply under its parent instead of appending it to the root list', async () => {
+    const itemUid = 'n-1';
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [comment('c-1', itemUid, 'First', '2026-01-01T00:00:00.000Z')],
+    });
+    client.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), { [itemUid]: 1 });
+
+    const reply = comment('c-2', itemUid, 'Agreed', '2026-01-02T00:00:00.000Z', 'c-1');
+    createFeedCommentMock.mockResolvedValue(reply);
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ text: 'Agreed', parentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const patched = client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid));
+    // The reply must NOT become a second top-level comment — that's the failure
+    // mode a flat append produces, and it looks correct until you reload.
+    expect(patched?.items.map((c) => c.uid)).toEqual(['c-1']);
+    expect(patched?.items[0].replies.map((c) => c.uid)).toEqual(['c-2']);
+    // Counts include replies at any depth.
+    expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(2);
+  });
+
+  it('nests a reply-to-a-reply under the right comment, several levels down', async () => {
+    const itemUid = 'n-1';
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [
+        comment('c-1', itemUid, 'First', '2026-01-01T00:00:00.000Z', null, [
+          comment('c-2', itemUid, 'Agreed', '2026-01-02T00:00:00.000Z', 'c-1'),
+        ]),
+      ],
+    });
+
+    createFeedCommentMock.mockResolvedValue(comment('c-3', itemUid, 'Same', '2026-01-03T00:00:00.000Z', 'c-2'));
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ text: 'Same', parentUid: 'c-2' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const patched = client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid));
+    expect(patched?.items[0].replies[0].replies.map((c) => c.uid)).toEqual(['c-3']);
   });
 });

--- a/__tests__/services/feed/useDeleteFeedComment.test.tsx
+++ b/__tests__/services/feed/useDeleteFeedComment.test.tsx
@@ -13,14 +13,21 @@ jest.mock('@/services/feed/feed.service', () => ({ deleteFeedComment: jest.fn() 
 
 const deleteFeedCommentMock = deleteFeedComment as jest.MockedFunction<typeof deleteFeedComment>;
 
-function comment(uid: string, itemUid: string): IFeedComment {
+function comment(
+  uid: string,
+  itemUid: string,
+  parentUid: string | null = null,
+  replies: IFeedComment[] = [],
+): IFeedComment {
   return {
     uid,
     itemUid,
-    author: { memberUid: 'm-1', name: 'Author', avatarUrl: null, role: null },
+    parentUid,
+    author: { uid: 'm-1', name: 'Author', avatarUrl: null },
     text: 'text',
     createdAt: '2026-01-01T00:00:00.000Z',
     isOwn: true,
+    replies,
   };
 }
 
@@ -64,6 +71,64 @@ describe('useDeleteFeedComment', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(0);
+  });
+
+  it('removes a nested reply without disturbing its siblings', async () => {
+    const itemUid = 'n-1';
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [comment('c-1', itemUid, null, [comment('c-2', itemUid, 'c-1'), comment('c-3', itemUid, 'c-1')])],
+    });
+    client.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), { [itemUid]: 3 });
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'c-2', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-2' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const patched = client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid));
+    expect(patched?.items[0].replies.map((c) => c.uid)).toEqual(['c-3']);
+    expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(2);
+  });
+
+  it('drops the count by the WHOLE subtree — the backend cascades replies', async () => {
+    const itemUid = 'n-1';
+    // c-1 > c-2 > c-3, plus an unrelated c-4: deleting c-1 deletes three rows.
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [
+        comment('c-1', itemUid, null, [comment('c-2', itemUid, 'c-1', [comment('c-3', itemUid, 'c-2')])]),
+        comment('c-4', itemUid),
+      ],
+    });
+    client.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), { [itemUid]: 4 });
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'c-1', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(
+      client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.items.map((c) => c.uid),
+    ).toEqual(['c-4']);
+    // Decrementing by 1 would leave the badge permanently overstated at 3.
+    expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(1);
+  });
+
+  it('leaves the count alone when the comment was never in the cached thread', async () => {
+    const itemUid = 'n-1';
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), { items: [comment('c-1', itemUid)] });
+    client.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), { [itemUid]: 1 });
+    // Already deleted in another tab — the service maps the 404 to a success.
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'gone', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'gone' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(1);
+    expect(client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.items).toHaveLength(1);
   });
 
   it('surfaces isError so the UI can show an inline retry message', async () => {

--- a/__tests__/services/feed/useFeedForumTopicLike.test.tsx
+++ b/__tests__/services/feed/useFeedForumTopicLike.test.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+
+// jest.setup.js stubs useQuery globally; this hook is all about reading a real
+// cache entry through `select`, so it needs the real implementation.
+jest.unmock('@tanstack/react-query');
+
+import { useFeedForumTopicLike } from '@/services/feed/hooks/useFeedComments';
+import { feedQueryKeys } from '@/services/feed/constants';
+import { getFeedComments } from '@/services/feed/feed.service';
+import type { IFeedCommentsResponse } from '@/types/feed.types';
+
+jest.mock('@/services/feed/feed.service', () => ({ getFeedComments: jest.fn() }));
+jest.mock('@/utils/third-party.helper', () => ({ getCookiesFromClient: () => ({ authToken: 'token' }) }));
+
+const getFeedCommentsMock = getFeedComments as jest.MockedFunction<typeof getFeedComments>;
+
+describe('useFeedForumTopicLike', () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  function seedThread(uid: string, forumTopic: IFeedCommentsResponse['forumTopic']) {
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(uid), { items: [], forumTopic });
+  }
+
+  it('reads the topic’s vote state out of the thread’s cache entry', () => {
+    seedThread('fp_96', {
+      url: '/forum/topics/5/96',
+      totalReplyCount: 2,
+      like: { likeCount: 7, viewerHasLiked: true },
+    });
+
+    const { result } = renderHook(() => useFeedForumTopicLike('fp_96'), { wrapper });
+
+    expect(result.current).toEqual({ likeCount: 7, viewerHasLiked: true });
+  });
+
+  it('never fetches — the thread owns the request, this only observes it', () => {
+    seedThread('fp_96', { url: null, totalReplyCount: 0, like: { likeCount: 1, viewerHasLiked: false } });
+
+    renderHook(() => useFeedForumTopicLike('fp_96'), { wrapper });
+
+    expect(getFeedCommentsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined before the thread has been opened, so nothing gets seeded', () => {
+    const { result } = renderHook(() => useFeedForumTopicLike('fp_96'), { wrapper });
+
+    expect(result.current).toBeUndefined();
+    expect(getFeedCommentsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a news item, which has no forum topic', () => {
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments('n-1'), { items: [] });
+
+    const { result } = renderHook(() => useFeedForumTopicLike('n-1'), { wrapper });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('stays idle with no active post', () => {
+    const { result } = renderHook(() => useFeedForumTopicLike(null), { wrapper });
+
+    expect(result.current).toBeUndefined();
+    expect(getFeedCommentsMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/forum/forum.service.test.ts
+++ b/__tests__/services/forum/forum.service.test.ts
@@ -1,0 +1,92 @@
+import { forumErrorMessage, postForumReply } from '@/services/forum/forum.service';
+import { customFetch } from '@/utils/fetch-wrapper';
+
+jest.mock('@/utils/fetch-wrapper', () => ({ customFetch: jest.fn() }));
+
+const customFetchMock = customFetch as jest.Mock;
+
+const FALLBACK = 'Couldn’t post your comment — try again.';
+
+const originalForumApiUrl = process.env.FORUM_API_URL;
+const originalForumToken = process.env.CUSTOM_FORUM_AUTH_TOKEN;
+
+afterAll(() => {
+  process.env.FORUM_API_URL = originalForumApiUrl;
+  process.env.CUSTOM_FORUM_AUTH_TOKEN = originalForumToken;
+});
+
+describe('postForumReply', () => {
+  beforeAll(() => {
+    process.env.FORUM_API_URL = 'https://forum.example.com';
+    process.env.CUSTOM_FORUM_AUTH_TOKEN = 'forum-token';
+  });
+
+  beforeEach(() => customFetchMock.mockReset());
+
+  it('posts to the topic with the reply target', async () => {
+    customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ response: { pid: 500 } }) });
+
+    await postForumReply({ tid: 96, toPid: 263, content: '<p>Hi</p>' });
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      'https://forum.example.com/api/v3/topics/96',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ content: '<p>Hi</p>', toPid: 263 }) }),
+      false,
+    );
+  });
+
+  it('throws with NodeBB’s own message when it supplies one', async () => {
+    customFetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ status: { message: '[[error:content-too-short]]' } }),
+    });
+
+    await expect(postForumReply({ tid: 96, toPid: 263, content: '<p>x</p>' })).rejects.toThrow(
+      '[[error:content-too-short]]',
+    );
+  });
+
+  it('throws a plain error when the failure body is unreadable', async () => {
+    customFetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+
+    await expect(postForumReply({ tid: 96, toPid: 263, content: '<p>x</p>' })).rejects.toThrow('Failed to add comment');
+  });
+});
+
+describe('forumErrorMessage', () => {
+  it('explains the minimum post length, which members hit constantly', () => {
+    // NodeBB's minimumPostLength defaults to 8 characters, so "nice!" is refused
+    // — a generic "try again" leaves no way to work that out.
+    expect(forumErrorMessage(new Error('[[error:content-too-short, Content too short]]'), FALLBACK)).toMatch(
+      /too short for the forum/,
+    );
+  });
+
+  it('explains the post rate limit', () => {
+    expect(forumErrorMessage(new Error('[[error:too-many-posts, 10]]'), FALLBACK)).toMatch(/posting a little fast/);
+  });
+
+  it('explains a missing forum privilege', () => {
+    expect(forumErrorMessage(new Error('[[error:no-privileges]]'), FALLBACK)).toMatch(/permission to reply/);
+  });
+
+  it('hides any other untranslated key behind the fallback', () => {
+    expect(forumErrorMessage(new Error('[[error:some-internal-key]]'), FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('passes through a message that is already a sentence', () => {
+    expect(forumErrorMessage(new Error('Topic is locked.'), FALLBACK)).toBe('Topic is locked.');
+  });
+
+  it('falls back for a non-Error or empty rejection', () => {
+    expect(forumErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(forumErrorMessage(new Error(''), FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/__tests__/services/forum/forum.service.test.ts
+++ b/__tests__/services/forum/forum.service.test.ts
@@ -1,4 +1,4 @@
-import { forumErrorMessage, postForumReply } from '@/services/forum/forum.service';
+import { ForumWriteError, forumErrorMessage, postForumReply } from '@/services/forum/forum.service';
 import { customFetch } from '@/utils/fetch-wrapper';
 
 jest.mock('@/utils/fetch-wrapper', () => ({ customFetch: jest.fn() }));
@@ -47,7 +47,7 @@ describe('postForumReply', () => {
     );
   });
 
-  it('throws a plain error when the failure body is unreadable', async () => {
+  it('carries the status when the failure body is unreadable, and invents no message', async () => {
     customFetchMock.mockResolvedValue({
       ok: false,
       status: 500,
@@ -56,7 +56,22 @@ describe('postForumReply', () => {
       },
     });
 
-    await expect(postForumReply({ tid: 96, toPid: 263, content: '<p>x</p>' })).rejects.toThrow('Failed to add comment');
+    await expect(postForumReply({ tid: 96, toPid: 263, content: '<p>x</p>' })).rejects.toMatchObject({
+      name: 'ForumWriteError',
+      status: 500,
+      forumMessage: undefined,
+    });
+  });
+
+  it('carries a 401 from the auth layer in front of NodeBB, whose body is not NodeBB-shaped', async () => {
+    // Observed with an expired CUSTOM_FORUM_AUTH_TOKEN: reads still succeed as a
+    // guest, writes come back like this.
+    customFetchMock.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: 'Invalid token' }) });
+
+    await expect(postForumReply({ tid: 96, toPid: 263, content: '<p>x</p>' })).rejects.toMatchObject({
+      status: 401,
+      forumMessage: 'Invalid token',
+    });
   });
 });
 
@@ -88,5 +103,24 @@ describe('forumErrorMessage', () => {
   it('falls back for a non-Error or empty rejection', () => {
     expect(forumErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
     expect(forumErrorMessage(new Error(''), FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('explains a rejected session on 401 — in practice an expired forum token', () => {
+    const rejected = new ForumWriteError(401, 'Invalid token');
+
+    expect(forumErrorMessage(rejected, FALLBACK)).toMatch(/didn’t accept your session/);
+  });
+
+  it('explains a 403 as a permission problem, not a session one', () => {
+    expect(forumErrorMessage(new ForumWriteError(403, undefined), FALLBACK)).toMatch(/permission to reply/);
+  });
+
+  it('never leaks our own synthesised wording to a member', () => {
+    // No message from the forum ⇒ the Error's text is ours, not theirs.
+    expect(forumErrorMessage(new ForumWriteError(500, undefined), FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('still prefers the forum’s message when it sent a real one', () => {
+    expect(forumErrorMessage(new ForumWriteError(400, 'Topic is locked.'), FALLBACK)).toBe('Topic is locked.');
   });
 });

--- a/__tests__/utils/buildCommentTree.test.ts
+++ b/__tests__/utils/buildCommentTree.test.ts
@@ -1,0 +1,121 @@
+import { buildCommentTree } from '@/utils/comments/buildCommentTree';
+
+interface Flat {
+  id: string;
+  parentId: string | null;
+}
+
+interface Node {
+  id: string;
+  replies: Node[];
+}
+
+/** Shape the feed and the forum both pass in: id/parent accessors + a node factory. */
+function build(items: Flat[]): Node[] {
+  return buildCommentTree<Flat, Node>({
+    items,
+    idOf: (item) => item.id,
+    parentIdOf: (item) => item.parentId,
+    makeNode: (item) => ({ id: item.id, replies: [] }),
+  });
+}
+
+/** Every id in the tree, so "nothing disappears" can be asserted directly. */
+function ids(nodes: Node[]): string[] {
+  return nodes.flatMap((node) => [node.id, ...ids(node.replies)]);
+}
+
+describe('buildCommentTree', () => {
+  it('nests replies under their parent and leaves roots at the top', () => {
+    const tree = build([
+      { id: 'a', parentId: null },
+      { id: 'b', parentId: 'a' },
+      { id: 'c', parentId: null },
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(['a', 'c']);
+    expect(tree[0].replies.map((n) => n.id)).toEqual(['b']);
+  });
+
+  it('nests to unlimited depth (the backend allows it; capping is clampDepth’s job)', () => {
+    const tree = build([
+      { id: 'a', parentId: null },
+      { id: 'b', parentId: 'a' },
+      { id: 'c', parentId: 'b' },
+      { id: 'd', parentId: 'c' },
+    ]);
+
+    expect(tree[0].replies[0].replies[0].replies[0].id).toBe('d');
+  });
+
+  it('preserves input order at every level (oldest-first in, oldest-first out)', () => {
+    const tree = build([
+      { id: 'a', parentId: null },
+      { id: 'r1', parentId: 'a' },
+      { id: 'r2', parentId: 'a' },
+      { id: 'r3', parentId: 'a' },
+    ]);
+
+    expect(tree[0].replies.map((n) => n.id)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('promotes an orphan to a root rather than dropping it', () => {
+    // 'b' answers a comment that is not in this page of results.
+    const tree = build([
+      { id: 'a', parentId: null },
+      { id: 'b', parentId: 'missing' },
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  it('promotes a self-parenting comment to a root', () => {
+    const tree = build([{ id: 'a', parentId: 'a' }]);
+
+    expect(tree.map((n) => n.id)).toEqual(['a']);
+    expect(tree[0].replies).toEqual([]);
+  });
+
+  it('breaks a parent cycle instead of building one — an attached cycle would infinitely recurse the renderer', () => {
+    const tree = build([
+      { id: 'a', parentId: 'b' },
+      { id: 'b', parentId: 'a' },
+    ]);
+
+    expect(tree.map((n) => n.id)).toEqual(['a', 'b']);
+    expect(tree.every((n) => n.replies.length === 0)).toBe(true);
+  });
+
+  it('keeps every item when a cycle sits above a longer chain', () => {
+    const tree = build([
+      { id: 'a', parentId: 'c' },
+      { id: 'b', parentId: 'a' },
+      { id: 'c', parentId: 'b' },
+      { id: 'd', parentId: null },
+    ]);
+
+    expect(ids(tree).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('returns an empty tree for an empty list', () => {
+    expect(build([])).toEqual([]);
+  });
+
+  it('works with numeric ids (NodeBB pids)', () => {
+    interface PidNode {
+      pid: number;
+      replies: PidNode[];
+    }
+
+    const tree = buildCommentTree<{ pid: number; parent?: { pid: number } }, PidNode>({
+      items: [{ pid: 263 }, { pid: 264, parent: { pid: 263 } }],
+      idOf: (item) => item.pid,
+      parentIdOf: (item) => item.parent?.pid,
+      makeNode: (item) => ({ pid: item.pid, replies: [] }),
+    });
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].pid).toBe(263);
+    expect(tree[0].replies).toHaveLength(1);
+  });
+});

--- a/__tests__/utils/clampDepth.test.ts
+++ b/__tests__/utils/clampDepth.test.ts
@@ -1,0 +1,89 @@
+import { clampDepth } from '@/utils/comments/clampDepth';
+
+interface Node {
+  id: string;
+  replies: Node[];
+}
+
+function node(id: string, replies: Node[] = []): Node {
+  return { id, replies };
+}
+
+/** Depth of every node, keyed by id — the thing the display cap is about. */
+function depths(nodes: Node[], depth = 0, out: Record<string, number> = {}): Record<string, number> {
+  for (const n of nodes) {
+    out[n.id] = depth;
+    depths(n.replies, depth + 1, out);
+  }
+  return out;
+}
+
+function ids(nodes: Node[]): string[] {
+  return nodes.flatMap((n) => [n.id, ...ids(n.replies)]);
+}
+
+describe('clampDepth', () => {
+  it('leaves a tree that already fits untouched', () => {
+    const tree = [node('a', [node('b', [node('c')])])];
+
+    expect(depths(clampDepth(tree, 2))).toEqual({ a: 0, b: 1, c: 2 });
+  });
+
+  it('lifts a depth-3 reply to depth 2, as a sibling of the reply it answered', () => {
+    const tree = [node('a', [node('b', [node('c', [node('d')])])])];
+
+    const clamped = clampDepth(tree, 2);
+
+    expect(depths(clamped)).toEqual({ a: 0, b: 1, c: 2, d: 2 });
+    expect(clamped[0].replies[0].replies.map((n) => n.id)).toEqual(['c', 'd']);
+  });
+
+  it('collapses an arbitrarily deep chain onto the cap, keeping every comment', () => {
+    // a > b > c > d > e > f — the backend permits this; the card cannot show it.
+    const deep = [node('a', [node('b', [node('c', [node('d', [node('e', [node('f')])])])])])];
+
+    const clamped = clampDepth(deep, 2);
+
+    expect(ids(clamped).sort()).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+    expect(depths(clamped)).toEqual({ a: 0, b: 1, c: 2, d: 2, e: 2, f: 2 });
+  });
+
+  it('flattens descendants in pre-order, so a reply follows the comment it answered', () => {
+    const tree = [node('a', [node('b', [node('b1', [node('b1a')]), node('b2')]), node('c', [node('c1')])])];
+
+    const clamped = clampDepth(tree, 2);
+
+    expect(clamped[0].replies.map((n) => n.id)).toEqual(['b', 'c']);
+    expect(clamped[0].replies[0].replies.map((n) => n.id)).toEqual(['b1', 'b1a', 'b2']);
+    expect(clamped[0].replies[1].replies.map((n) => n.id)).toEqual(['c1']);
+  });
+
+  it('flattens everything to one level at maxDepth 0', () => {
+    const tree = [node('a', [node('b', [node('c')])]), node('d')];
+
+    const clamped = clampDepth(tree, 0);
+
+    expect(clamped.map((n) => n.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(clamped.every((n) => n.replies.length === 0)).toBe(true);
+  });
+
+  it('allows two levels at maxDepth 1', () => {
+    const tree = [node('a', [node('b', [node('c')])])];
+
+    expect(depths(clampDepth(tree, 1))).toEqual({ a: 0, b: 1, c: 1 });
+  });
+
+  it('does not mutate the input tree', () => {
+    const grandchild = node('c', [node('d')]);
+    const tree = [node('a', [node('b', [grandchild])])];
+
+    clampDepth(tree, 2);
+
+    expect(grandchild.replies.map((n) => n.id)).toEqual(['d']);
+    expect(depths(tree)).toEqual({ a: 0, b: 1, c: 2, d: 3 });
+  });
+
+  it('returns an empty list for an empty tree', () => {
+    expect(clampDepth([], 2)).toEqual([]);
+  });
+});

--- a/__tests__/utils/mutateCommentTree.test.ts
+++ b/__tests__/utils/mutateCommentTree.test.ts
@@ -1,0 +1,125 @@
+import { insertCommentIntoTree, removeCommentFromTree } from '@/utils/comments/mutateCommentTree';
+
+interface Node {
+  uid: string;
+  parentUid: string | null;
+  replies: Node[];
+}
+
+function node(uid: string, parentUid: string | null = null, replies: Node[] = []): Node {
+  return { uid, parentUid, replies };
+}
+
+function ids(nodes: Node[]): string[] {
+  return nodes.flatMap((n) => [n.uid, ...ids(n.replies)]);
+}
+
+describe('insertCommentIntoTree', () => {
+  it('appends a top-level comment at the end (threads are oldest-first)', () => {
+    const tree = [node('a'), node('b')];
+
+    expect(insertCommentIntoTree(tree, node('c')).map((n) => n.uid)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('appends a reply under its parent, not at the root', () => {
+    const tree = [node('a', null, [node('a1', 'a')]), node('b')];
+
+    const next = insertCommentIntoTree(tree, node('a2', 'a'));
+
+    expect(next.map((n) => n.uid)).toEqual(['a', 'b']);
+    expect(next[0].replies.map((n) => n.uid)).toEqual(['a1', 'a2']);
+  });
+
+  it('finds a parent nested several levels down', () => {
+    const tree = [node('a', null, [node('b', 'a', [node('c', 'b')])])];
+
+    const next = insertCommentIntoTree(tree, node('d', 'c'));
+
+    expect(next[0].replies[0].replies[0].replies.map((n) => n.uid)).toEqual(['d']);
+  });
+
+  it('falls back to the root when the parent is not in the tree, rather than dropping the comment', () => {
+    const tree = [node('a')];
+
+    const next = insertCommentIntoTree(tree, node('x', 'gone'));
+
+    expect(next.map((n) => n.uid)).toEqual(['a', 'x']);
+  });
+
+  it('inserts into an empty tree', () => {
+    expect(insertCommentIntoTree([], node('a')).map((n) => n.uid)).toEqual(['a']);
+  });
+
+  it('does not mutate the input tree', () => {
+    const parent = node('a', null, [node('a1', 'a')]);
+    const tree = [parent];
+
+    insertCommentIntoTree(tree, node('a2', 'a'));
+
+    expect(parent.replies.map((n) => n.uid)).toEqual(['a1']);
+  });
+
+  it('leaves sibling branches untouched by identity (no needless re-render)', () => {
+    const untouched = node('b', null, [node('b1', 'b')]);
+    const tree = [node('a'), untouched];
+
+    const next = insertCommentIntoTree(tree, node('a1', 'a'));
+
+    expect(next[1]).toBe(untouched);
+  });
+});
+
+describe('removeCommentFromTree', () => {
+  it('removes a top-level comment and counts it once', () => {
+    const tree = [node('a'), node('b')];
+
+    const { items, removedCount } = removeCommentFromTree(tree, 'a');
+
+    expect(items.map((n) => n.uid)).toEqual(['b']);
+    expect(removedCount).toBe(1);
+  });
+
+  it('removes a nested reply', () => {
+    const tree = [node('a', null, [node('a1', 'a'), node('a2', 'a')])];
+
+    const { items, removedCount } = removeCommentFromTree(tree, 'a1');
+
+    expect(items[0].replies.map((n) => n.uid)).toEqual(['a2']);
+    expect(removedCount).toBe(1);
+  });
+
+  it('counts the whole subtree — the backend cascades, so the badge must drop by more than 1', () => {
+    const tree = [node('a', null, [node('a1', 'a', [node('a1a', 'a1'), node('a1b', 'a1')]), node('a2', 'a')])];
+
+    const { items, removedCount } = removeCommentFromTree(tree, 'a1');
+
+    expect(removedCount).toBe(3);
+    expect(ids(items)).toEqual(['a', 'a2']);
+  });
+
+  it('counts an entire thread when its root is deleted', () => {
+    const tree = [node('a', null, [node('a1', 'a', [node('a1a', 'a1')])]), node('b')];
+
+    const { items, removedCount } = removeCommentFromTree(tree, 'a');
+
+    expect(removedCount).toBe(3);
+    expect(items.map((n) => n.uid)).toEqual(['b']);
+  });
+
+  it('reports 0 for a comment that is not in the tree, so a stale delete cannot move the count', () => {
+    const tree = [node('a', null, [node('a1', 'a')])];
+
+    const { items, removedCount } = removeCommentFromTree(tree, 'gone');
+
+    expect(removedCount).toBe(0);
+    expect(ids(items)).toEqual(['a', 'a1']);
+  });
+
+  it('does not mutate the input tree', () => {
+    const parent = node('a', null, [node('a1', 'a')]);
+
+    removeCommentFromTree([parent], 'a1');
+
+    expect(parent.replies.map((n) => n.uid)).toEqual(['a1']);
+  });
+});

--- a/__tests__/utils/stripHtml.test.ts
+++ b/__tests__/utils/stripHtml.test.ts
@@ -1,0 +1,36 @@
+import { stripHtml } from '@/utils/forum/stripHtml';
+
+describe('stripHtml', () => {
+  it('removes tags and collapses whitespace', () => {
+    expect(stripHtml('<p>Hi  Protocol   Labs</p>')).toBe('Hi Protocol Labs');
+  });
+
+  it('drops markdown images', () => {
+    expect(stripHtml('<p>Ship it ![screenshot](https://cdn/img.png) today</p>')).toBe('Ship it today');
+  });
+
+  it('decodes the entities NodeBB escapes on the way in', () => {
+    expect(stripHtml('<p>a &lt; b &amp;&amp; c &gt; d</p>')).toBe('a < b && c > d');
+    expect(stripHtml('<p>&quot;quoted&quot; and &#39;single&#39;</p>')).toBe('"quoted" and \'single\'');
+    expect(stripHtml('<p>it&apos;s fine</p>')).toBe("it's fine");
+  });
+
+  it('decodes &amp; last, so a doubly-escaped entity stays text', () => {
+    // `&amp;lt;` is the escaped form of the literal text `&lt;` — decoding
+    // `&amp;` first would turn it into `&lt;` and then into a `<`.
+    expect(stripHtml('<p>&amp;lt;script&amp;gt;</p>')).toBe('&lt;script&gt;');
+  });
+
+  it('never turns an escaped tag back into markup', () => {
+    expect(stripHtml('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('<script>alert(1)</script>');
+  });
+
+  it('turns &nbsp; into a plain space', () => {
+    expect(stripHtml('<p>one&nbsp;two</p>')).toBe('one two');
+  });
+
+  it('returns an empty string for empty or tag-only content', () => {
+    expect(stripHtml('')).toBe('');
+    expect(stripHtml('<p></p>')).toBe('');
+  });
+});

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -14,6 +14,11 @@ export type TeamNewsAnalyticsSource = 'home' | 'team-profile-rail' | 'team-profi
  *  or navigated to the source article (team-details surfaces). */
 export type TeamNewsCardClickOutcome = 'modal' | 'source';
 
+/** Which affordance opened the card. Both the row and the comment badge open
+ *  the same detail modal now that threads live only there, so this is the only
+ *  thing that distinguishes "read this story" from "go to its comments". */
+export type TeamNewsCardClickVia = 'row' | 'comment-button';
+
 export type TeamNewsShareNetwork = 'linkedin' | 'x' | 'copy';
 
 export const useTeamNewsAnalytics = () => {
@@ -107,7 +112,12 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
-  const onTeamNewsCardClicked = (item: ITeamNewsItem, position: number, source: TeamNewsAnalyticsSource) => {
+  const onTeamNewsCardClicked = (
+    item: ITeamNewsItem,
+    position: number,
+    source: TeamNewsAnalyticsSource,
+    via: TeamNewsCardClickVia = 'row',
+  ) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_CARD_CLICKED, {
       itemUid: item.uid,
       teamUid: item.teamUid,
@@ -118,6 +128,7 @@ export const useTeamNewsAnalytics = () => {
       sourceCount: item.sourceUrls?.length ?? 1,
       position,
       source,
+      via,
       // The same event name now means "opened the detail modal" on /home but
       // still "opened the source article" on team-details. Derived here — the
       // one place that knows source→surface semantics — so dashboards can
@@ -231,13 +242,19 @@ export const useTeamNewsAnalytics = () => {
   // failed the access gate (e.g. a stripped ?post= deep link) — these fire only
   // from surfaces the viewer was allowed to render.
 
-  const onFeedForumPostCardClicked = (post: IFeedForumPost, position: number, source: TeamNewsAnalyticsSource) => {
+  const onFeedForumPostCardClicked = (
+    post: IFeedForumPost,
+    position: number,
+    source: TeamNewsAnalyticsSource,
+    via: TeamNewsCardClickVia = 'row',
+  ) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_FORUM_POST_CARD_CLICKED, {
       postUid: post.uid,
       authorMemberUid: post.author.memberUid,
       category: post.category,
       position,
       source,
+      via,
     });
   };
 
@@ -280,25 +297,21 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
-  const onFeedCommentThreadToggled = (
+  // No thread-toggled event: threads are always expanded in the detail modal,
+  // so there is nothing to toggle. The intent that event used to capture now
+  // rides on the card-clicked events' `via` property.
+
+  const onFeedCommentSubmitted = (
     itemUid: string,
     kind: FeedItemKind,
-    open: boolean,
     source: TeamNewsAnalyticsSource,
+    isReply = false,
   ) => {
-    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED, {
-      itemUid,
-      kind,
-      open,
-      source,
-    });
-  };
-
-  const onFeedCommentSubmitted = (itemUid: string, kind: FeedItemKind, source: TeamNewsAnalyticsSource) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_SUBMITTED, {
       itemUid,
       kind,
       source,
+      isReply,
     });
   };
 
@@ -321,7 +334,6 @@ export const useTeamNewsAnalytics = () => {
     onFeedForumPostModalOpened,
     onFeedForumPostLikeToggled,
     onFeedForumPostShared,
-    onFeedCommentThreadToggled,
     onFeedCommentSubmitted,
   };
 };

--- a/components/page/forum/PostComments/types.ts
+++ b/components/page/forum/PostComments/types.ts
@@ -2,4 +2,14 @@ import { TopicResponse } from '@/services/forum/hooks/useForumPost';
 
 type Comment = TopicResponse['posts'][0];
 
-export type NestedComment = Comment & { replies: NestedComment[] };
+/**
+ * A post plus its nested replies.
+ *
+ * `replies` is Omit-ed from the NodeBB post first: NodeBB already ships a
+ * `replies` field on every post, but it's reply *metadata*
+ * (`{count, hasMore, users, …}`), not the replies themselves. Intersecting the
+ * two produced a type nothing could satisfy, which is why the nesting code used
+ * to be typed as `any`. The nested array is what every consumer actually reads
+ * (`item.replies.length`, `item.replies.map`), so it wins the name outright.
+ */
+export type NestedComment = Omit<Comment, 'replies'> & { replies: NestedComment[] };

--- a/components/page/forum/PostComments/utils/nestComments.ts
+++ b/components/page/forum/PostComments/utils/nestComments.ts
@@ -1,26 +1,21 @@
 import { TopicResponse } from '@/services/forum/hooks/useForumPost';
+import { buildCommentTree } from '@/utils/comments';
 
 import { NestedComment } from '../types';
 
+/**
+ * NodeBB's flat post list → a reply tree, nested on `parent.pid`.
+ *
+ * The algorithm lives in utils/comments/buildCommentTree so the /home feed can
+ * nest the same NodeBB payload the same way (it reads forum-post comments
+ * straight from the forum now). This wrapper keeps the forum's call site and
+ * types unchanged.
+ */
 export function nestComments(items: TopicResponse['posts']): NestedComment[] {
-  const map = new Map<number, any>();
-
-  // Create a lookup map and add `replies` to each
-  for (const item of items) {
-    map.set(item.pid, { ...item, replies: [] });
-  }
-
-  const roots: any[] = [];
-
-  for (const item of items) {
-    const current = map.get(item.pid);
-    if (item.parent?.pid && map.has(item.parent.pid)) {
-      const parent = map.get(item.parent.pid);
-      parent.replies.push(current);
-    } else {
-      roots.push(current);
-    }
-  }
-
-  return roots;
+  return buildCommentTree<TopicResponse['posts'][number], NestedComment>({
+    items,
+    idOf: (item) => item.pid,
+    parentIdOf: (item) => item.parent?.pid,
+    makeNode: (item) => ({ ...item, replies: [] }),
+  });
 }

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -22,8 +22,8 @@ import { SearchInput } from '@/components/common/filters/SearchInput';
 import { SortDropdown } from '@/components/common/filters/SortDropdown';
 
 import {
-  ACTIVE_DISCUSSIONS_CAT,
-  ACTIVE_DISCUSSIONS_CATEGORY,
+  DISCUSSIONS_CAT,
+  DISCUSSIONS_CATEGORY,
   ALL_TAB,
   ALL_CAT,
   CATEGORIES,
@@ -37,7 +37,7 @@ import { applyUpvoteOverlay } from './utils/applyUpvoteOverlay';
 import { resolveForumPostLike } from './utils/resolveForumPostLike';
 import { clusterByTeam } from './utils/clusterByTeam';
 import { assertNever, feedEntryKey, mergeFeedEntries } from './utils/mergeFeedEntries';
-import { filterFeedForumPosts } from './utils/matchesFeedForumPost';
+import { categoryIncludesForumPosts, filterFeedForumPosts } from './utils/matchesFeedForumPost';
 import { useStoryReveal } from './hooks/useStoryReveal';
 import { useNewsDeepLink } from './hooks/useNewsDeepLink';
 import { useFeedSocial } from './hooks/useFeedSocial';
@@ -83,7 +83,10 @@ function matchesTeamNewsQuery(item: ITeamNewsItem, lowerCaseQuery: string): bool
 // of "matches" — same rationale as matchesTeamNewsQuery above.
 function matchesTeamNewsCategory(item: ITeamNewsItem, categoryId: TeamNewsCategoryId): boolean {
   if (categoryId === ALL_CAT) return true;
-  if (categoryId === ACTIVE_DISCUSSIONS_CAT) return hasExistingDiscussion(item.discussion);
+  // A news item counts as a discussion when it has a forum thread of its own.
+  // Forum posts also live under this pill, but they aren't news items — see
+  // filterFeedForumPosts for that half.
+  if (categoryId === DISCUSSIONS_CAT) return hasExistingDiscussion(item.discussion);
   return item.eventType === categoryId;
 }
 
@@ -182,29 +185,37 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
     [forumPosts, activeTab],
   );
 
+  // One definition of "how many does this pill have", used both to render the
+  // pills and to report the count on click — two copies of this drifted apart
+  // once already.
+  const countForCategory = useCallback(
+    (id: TeamNewsCategoryId) => {
+      const newsCount =
+        id === ALL_CAT
+          ? itemsForActiveTab.length
+          : itemsForActiveTab.filter((i) => matchesTeamNewsCategory(i, id)).length;
+      // Forum posts show under All and Discussions, and nowhere else.
+      return newsCount + (categoryIncludesForumPosts(id) ? tabForumPosts.length : 0);
+    },
+    [itemsForActiveTab, tabForumPosts],
+  );
+
   const categoriesWithCounts = useMemo(() => {
-    const activeDiscussionsCount = itemsForActiveTab.filter((i) => hasExistingDiscussion(i.discussion)).length;
-    const base = CATEGORIES.map((c) => ({
-      ...c,
-      // The All pill counts everything the feed below will show — including
-      // this tab's forum posts (they're invisible under every other pill).
-      count:
-        c.id === ALL_CAT
-          ? itemsForActiveTab.length + tabForumPosts.length
-          : itemsForActiveTab.filter((i) => i.eventType === c.id).length,
-    }));
+    const base = CATEGORIES.map((c) => ({ ...c, count: countForCategory(c.id) }));
+    const discussionsCount = countForCategory(DISCUSSIONS_CAT);
 
-    if (activeDiscussionsCount === 0) return base;
+    // Nothing to filter to ⇒ no pill, the same rule every other pill follows.
+    if (discussionsCount === 0) return base;
 
-    const withActive: Array<{ id: TeamNewsCategoryId; label: string; count: number }> = [];
+    const withDiscussions: Array<{ id: TeamNewsCategoryId; label: string; count: number }> = [];
     for (const c of base) {
-      withActive.push(c);
+      withDiscussions.push(c);
       if (c.id === ALL_CAT) {
-        withActive.push({ ...ACTIVE_DISCUSSIONS_CATEGORY, count: activeDiscussionsCount });
+        withDiscussions.push({ ...DISCUSSIONS_CATEGORY, count: discussionsCount });
       }
     }
-    return withActive;
-  }, [itemsForActiveTab, tabForumPosts]);
+    return withDiscussions;
+  }, [countForCategory]);
 
   const filteredItems = useMemo(() => {
     if (activeCategory === ALL_CAT) return itemsForActiveTab;
@@ -330,13 +341,7 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   };
 
   const handleCategory = (id: TeamNewsCategoryId) => {
-    const nextCount =
-      id === ALL_CAT
-        ? itemsForActiveTab.length + tabForumPosts.length
-        : id === ACTIVE_DISCUSSIONS_CAT
-          ? itemsForActiveTab.filter((i) => hasExistingDiscussion(i.discussion)).length
-          : itemsForActiveTab.filter((i) => i.eventType === id).length;
-    analytics.onTeamNewsCategoryClicked(String(id), nextCount, activeTab);
+    analytics.onTeamNewsCategoryClicked(String(id), countForCategory(id), activeTab);
     setActiveCategory(id);
     setExpanded(false);
   };

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
 import { flushSync } from 'react-dom';
 
-import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import { useTeamNewsAnalytics, type TeamNewsCardClickVia } from '@/analytics/team-news.analytics';
 import { useFollowAnalytics, type FollowAnalyticsSource } from '@/analytics/follow.analytics';
 import { useFollowTeam } from '@/services/follow/hooks/useFollowTeam';
 import { useSuggestedTeamsToFollow } from '@/services/follow/hooks/useSuggestedTeamsToFollow';
@@ -337,9 +337,9 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   // Single owner of a row click's consequences: analytics (card-clicked with
   // outcome 'modal', derived in the analytics module) + modal state + URL.
   // Positions are entry-list indices now that forum posts interleave.
-  const handleStoryOpen = (item: ITeamNewsItem) => {
+  const handleStoryOpen = (item: ITeamNewsItem, via: TeamNewsCardClickVia = 'row') => {
     const position = visibleEntries.findIndex((e) => e.kind === 'news' && e.cluster.teamUid === item.teamUid);
-    analytics.onTeamNewsCardClicked(item, position >= 0 ? position : 0, 'home');
+    analytics.onTeamNewsCardClicked(item, position >= 0 ? position : 0, 'home', via);
     // One modal, one URL param at a time — closing the other side first keeps
     // ?news= and ?post= mutually exclusive (both writes are synchronous).
     if (activePostUid) closePost();

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -11,6 +11,7 @@ import { useFollowTeam } from '@/services/follow/hooks/useFollowTeam';
 import { useSuggestedTeamsToFollow } from '@/services/follow/hooks/useSuggestedTeamsToFollow';
 import { useTeamNewsUpvoteToggle } from '@/services/team-news/hooks/useTeamNewsUpvoteToggle';
 import { useFeedForumPostLikeToggle } from '@/services/feed/hooks/useFeedForumPostLikeToggle';
+import { useFeedForumTopicLike } from '@/services/feed/hooks/useFeedComments';
 import { useCurrentUserStore } from '@/services/auth/store';
 import type { ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import type { ITeamNewsGroup, ITeamNewsItem, ITeamNewsPopularItem } from '@/types/team-news.types';
@@ -33,6 +34,7 @@ import { hasExistingDiscussion } from './utils/hasExistingDiscussion';
 
 import { dedupeByUid } from './utils/dedupeByUid';
 import { applyUpvoteOverlay } from './utils/applyUpvoteOverlay';
+import { resolveForumPostLike } from './utils/resolveForumPostLike';
 import { clusterByTeam } from './utils/clusterByTeam';
 import { assertNever, feedEntryKey, mergeFeedEntries } from './utils/mergeFeedEntries';
 import { filterFeedForumPosts } from './utils/matchesFeedForumPost';
@@ -285,11 +287,30 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
   // activeNewsItem: modal and row can never disagree). `forumPosts` going
   // undefined — e.g. mid-session access revocation — nulls this out and the
   // modal unmounts; the effect below also strips the URL param.
+  // A forum card can't know whether the viewer already liked the post: the
+  // /api/recent listing it's built from has no per-viewer vote state, so
+  // `viewerHasLiked` is false by default and a "like" on something already liked
+  // would send a vote NodeBB ignores while the local count climbed. Opening the
+  // thread fetches the topic, which does know — resolved at render time, under
+  // the viewer's own toggle. Because the resolved value is what feeds
+  // handleForumPostLikeToggle, the correction lands in the overlay on first use
+  // and outlives the modal.
+  const activePostTopicLike = useFeedForumTopicLike(activePostUid);
+  const resolvePostLike = useCallback(
+    (post: IFeedForumPost) =>
+      resolveForumPostLike(
+        post,
+        post.uid === activePostUid ? activePostTopicLike : undefined,
+        postLikeOverlay.get(post.uid),
+      ),
+    [activePostUid, activePostTopicLike, postLikeOverlay],
+  );
+
   const activeForumPost = useMemo(() => {
     if (!activePostUid) return null;
     const post = forumPosts?.find((p) => p.uid === activePostUid);
-    return post ? { ...post, ...postLikeOverlay.get(post.uid) } : null;
-  }, [activePostUid, forumPosts, postLikeOverlay]);
+    return post ? resolvePostLike(post) : null;
+  }, [activePostUid, forumPosts, resolvePostLike]);
 
   useEffect(() => {
     if (activePostUid && !hasAccess) closePost();
@@ -693,9 +714,10 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
                       return (
                         <ForumPostCard
                           key={key}
-                          // Live like state merged at render only — the merge above
-                          // ranked by frozen counts, so likes never reorder the feed.
-                          post={{ ...entry.post, ...postLikeOverlay.get(entry.post.uid) }}
+                          // Live like state resolved at render only — the merge
+                          // above ranked by frozen counts, so likes never reorder
+                          // the feed.
+                          post={resolvePostLike(entry.post)}
                           position={index}
                           onOpenDetail={handleForumPostOpen}
                           onLikeToggle={handleForumPostLikeToggle}

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -525,7 +525,7 @@ export const TeamNews = ({ groups, popularItems = [], pageSize = 6, initialDiges
     const position = visibleEntries.findIndex((e) => feedEntryKey(e) === `forum:${post.uid}`);
 
     postLikeMutate(
-      { uid: post.uid, isLiked: nextLiked },
+      { post, isLiked: nextLiked },
       {
         onError: () => {
           setPostLikeOverlay((prev) => new Map(prev).set(post.uid, { viewerHasLiked: wasLiked, likeCount: prevCount }));

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -176,6 +176,18 @@
   opacity: 0.55;
 }
 
+/* Replies, indented under the comment they answer. 16px matches the forum's
+   CommentItem.module.scss `.repliesWrapper`, at this thread's tighter 14px
+   rhythm — display depth is capped at MAX_DEPTH, so the indent can't run away. */
+.repliesWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 14px;
+  padding-left: 16px;
+  min-width: 0;
+}
+
 .avatar {
   width: 28px;
   height: 28px;

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -176,6 +176,57 @@
   opacity: 0.55;
 }
 
+/* Quiet "Reply" affordance under a comment — same restraint as .deleteBtn and
+   .viewAll: available, but never competing with the comment text. */
+.replyBtn {
+  align-self: flex-start;
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin-top: 2px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  letter-spacing: -0.2px;
+  color: var(--action-foreground-brand-inverted_normal, #1b4dff);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.replyComposer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+/* Secondary to the brand submit next to it — dismissing a reply draft should
+   never look like the primary action. */
+.replyCancelBtn {
+  flex-shrink: 0;
+  height: 40px;
+  padding: 0 12px;
+  appearance: none;
+  border-radius: var(--corner-radius-md, 8px);
+  border: 1px solid var(--transparent-dark-12, rgba(14, 15, 17, 0.12));
+  background: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+
+  &:hover {
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  }
+}
+
 /* Replies, indented under the comment they answer. 16px matches the forum's
    CommentItem.module.scss `.repliesWrapper`, at this thread's tighter 14px
    rhythm — display depth is capped at MAX_DEPTH, so the indent can't run away. */

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -176,6 +176,29 @@
   opacity: 0.55;
 }
 
+/* Link out to the origin topic: for the replies a single NodeBB page didn't
+   include, and for a comment whose whole content was an attachment. */
+.forumLink {
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-brand-primary, #1b4dff);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* An attachment-only comment: not the member's words, so it doesn't get their
+   emphasis. */
+.textAttachment {
+  font-style: italic;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
 /* Quiet "Reply" affordance under a comment — same restraint as .deleteBtn and
    .viewAll: available, but never competing with the comment text. */
 .replyBtn {

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -8,12 +8,14 @@ import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { clampDepth } from '@/utils/comments';
 import { useCurrentUserStore } from '@/services/auth/store';
+import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
+import { forumErrorMessage } from '@/services/forum/forum.service';
 import { useFeedComments } from '@/services/feed/hooks/useFeedComments';
 import { useAddFeedComment } from '@/services/feed/hooks/useAddFeedComment';
 import { useDeleteFeedComment } from '@/services/feed/hooks/useDeleteFeedComment';
 import { FEED_COMMENT_MAX_LENGTH } from '@/services/feed/constants';
 import { useTeamNewsAnalytics, type FeedItemKind, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
-import type { IFeedComment } from '@/types/feed.types';
+import { isForumPostUid, type IFeedComment } from '@/types/feed.types';
 
 import s from './FeedCommentsThread.module.scss';
 
@@ -23,8 +25,10 @@ const VISIBLE = 2;
 // Deepest rendered level, as a depth index — 2 means comment → reply →
 // reply-to-reply, the same cap as the forum's CommentItem.MAX_DEPTH. The wire
 // allows unlimited depth, so anything deeper is lifted to this level by
-// clampDepth rather than indented off the edge of the card.
+// clampDepth rather than indented off the edge of the modal.
 const MAX_DEPTH = 2;
+
+const POST_FAILED = 'Couldn’t post your comment — try again.';
 
 /** Total comments in the thread, replies included — matches what the count
  *  badge shows (the backend counts every row under an item, at any depth). */
@@ -36,54 +40,72 @@ interface FeedCommentsThreadProps {
   itemUid: string;
   kind: FeedItemKind;
   source: TeamNewsAnalyticsSource;
+  /** Forum posts only: the topic's opening post, which a top-level comment
+   *  replies to. Lets the write happen in one request instead of two. */
+  forumMainPid?: number;
 }
 
 /**
- * Inline comment thread + composer for a feed item.
+ * Comment thread + composer for a feed item, rendered inside the detail modal.
  *
  * The comments come from one of two entirely separate systems, and this
  * component is deliberately blind to which: news comments are directory-native,
- * a forum post's comments are its real NodeBB topic replies. Both arrive as the
- * same `IFeedComment` tree from services/feed/feed.service.ts.
+ * a forum post's comments are its real NodeBB topic replies — posting one here
+ * really does appear on /forum. Both arrive as the same `IFeedComment` tree from
+ * services/feed/feed.service.ts.
  *
- * Mount = expanded: the parent renders this component only while the thread is
- * open, so the lazy comments query fetches on first expand and, with no
- * observer after collapse, never refetches in the background. All comment
- * text / names / roles render via JSX text interpolation only —
- * dangerouslySetInnerHTML is banned in this component.
+ * Mount = expanded: the parent renders this component only while the modal is
+ * open, so the lazy comments query fetches on mount and, with no observer after
+ * close, never refetches in the background. All comment text / names / roles
+ * render via JSX text interpolation only — dangerouslySetInnerHTML is banned in
+ * this component, and forum HTML arrives already stripped to plain text.
  *
  * Composer rules (no toasts, ever):
  * - The in-flight comment renders immediately from the mutation's `variables`
- *   (dimmed) — optimistic via UI, nothing written to the cache until the
- *   server confirms, so there's no rollback to get wrong.
+ *   (dimmed), under its parent when it's a reply — optimistic via UI, nothing
+ *   written to the cache until the server confirms, so there's no rollback to
+ *   get wrong.
  * - The input is cleared ONLY on success; on failure the draft is simply
  *   still there, with an inline error that clears on the next keystroke.
  * - Submit is guarded in the handler (not just the disabled attribute) so
  *   Enter can't double-fire while a submit is in flight.
+ * - Forum failures show NodeBB's reason when it's a sentence (too short, too
+ *   fast) and a generic line when it's an untranslated `[[error:…]]` key.
+ *
+ * Writing to a forum post additionally requires `forum.write` — the same gate
+ * the /forum page's composer uses. Without it the thread stays fully readable.
  *
  * Delete (author-only, `isOwn`): an inline "Delete this comment? Yes / Cancel"
  * swap on the row — no modal, no toast, matching the composer's style. No
  * optimistic removal: the row shows a disabled Yes while the request is in
- * flight, same "nothing touches the cache until the server confirms" rule the
- * composer follows. Deleting cascades to the comment's replies, server-side and
- * in the cache patch alike. NodeBB-sourced comments always report
- * `isOwn: false`, so the affordance never appears on them.
+ * flight. Deleting cascades to the comment's replies, server-side and in the
+ * cache patch alike. NodeBB-sourced comments always report `isOwn: false`, so
+ * the affordance never appears on them.
  */
-export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThreadProps) {
+export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: FeedCommentsThreadProps) {
   const router = useRouter();
   const analytics = useTeamNewsAnalytics();
   const { currentUser, isHydrated } = useCurrentUserStore();
+  const { canWrite: canWriteForum } = useForumAccess();
   const [draft, setDraft] = useState('');
   const [expanded, setExpanded] = useState(false);
   const [confirmingUid, setConfirmingUid] = useState<string | null>(null);
+  // One open reply composer at a time — a thread full of open inputs is noise,
+  // and the draft belongs to whichever comment the member is answering.
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
 
   const { data } = useFeedComments(itemUid, { enabled: true });
-  const addComment = useAddFeedComment(itemUid);
+  const addComment = useAddFeedComment(itemUid, forumMainPid);
   const deleteComment = useDeleteFeedComment(itemUid);
 
+  const isForumPost = isForumPostUid(itemUid);
+  // Forum writes go through NodeBB, which enforces this itself; checking here
+  // keeps a member from typing a comment only to have it refused.
+  const canComment = !isForumPost || canWriteForum;
+
   const items = data?.items;
-  // Display cap applied once, here: every consumer below can then recurse
-  // without re-checking depth.
+  // Display cap applied once, here: everything below can recurse without
+  // re-checking depth.
   const comments = useMemo(() => clampDepth<IFeedComment>(items ?? [], MAX_DEPTH), [items]);
   const totalCount = useMemo(() => countComments(comments), [comments]);
 
@@ -101,33 +123,51 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
     );
   };
 
-  const submit = () => {
-    const text = draft.trim();
-    if (!text || addComment.isPending) return;
+  const submit = (text: string, parentUid?: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || addComment.isPending) return false;
     addComment.mutate(
-      { text },
+      { text: trimmed, parentUid },
       {
         onSuccess: () => {
           // UI-local follow-ups only — the cache writes live in the hook's
           // options callbacks, which survive this component unmounting.
-          setDraft('');
-          analytics.onFeedCommentSubmitted(itemUid, kind, source);
+          if (parentUid) setReplyingTo(null);
+          else setDraft('');
+          analytics.onFeedCommentSubmitted(itemUid, kind, source, Boolean(parentUid));
         },
       },
     );
+    return true;
+  };
+
+  const clearError = () => {
+    // A stale "couldn't post" must not sit above a fresh draft.
+    if (addComment.isError) addComment.reset();
   };
 
   const handleDraftChange = (value: string) => {
     setDraft(value);
-    // A stale "couldn't post" must not sit above a fresh draft.
-    if (addComment.isError) addComment.reset();
+    clearError();
   };
 
   const goToLogin = () => {
     router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
   };
 
-  const pendingText = addComment.isPending ? addComment.variables?.text.trim() : undefined;
+  // The last submit attempted, which outlives the request itself — so a failure
+  // can be attributed to the composer it came from.
+  const attempt = addComment.variables;
+  const pending = addComment.isPending ? attempt : undefined;
+  const pendingText = pending?.text.trim();
+  const errorText = addComment.isError
+    ? isForumPost
+      ? forumErrorMessage(addComment.error, POST_FAILED)
+      : POST_FAILED
+    : undefined;
+  // `null` = the failure belongs to the top-level composer; a uid = to that
+  // comment's reply composer. Without this the same error renders in both.
+  const errorParentUid = errorText ? (attempt?.parentUid ?? null) : undefined;
 
   return (
     <div className={s.thread} onClick={(e) => e.stopPropagation()}>
@@ -140,64 +180,43 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
           </button>
         </div>
       ) : (
-        <div className={s.composer}>
-          <form
-            className={s.inline}
-            onSubmit={(e) => {
-              e.preventDefault();
-              submit();
-            }}
-          >
-            <input
-              className={s.forumField}
+        canComment && (
+          <div className={s.composer}>
+            <Composer
               value={draft}
-              maxLength={FEED_COMMENT_MAX_LENGTH}
+              onChange={handleDraftChange}
+              onSubmit={() => submit(draft)}
               placeholder="Write your comment here…"
-              onChange={(e) => handleDraftChange(e.target.value)}
+              submitLabel="Comment"
+              disabled={addComment.isPending}
             />
-            <button
-              type="submit"
-              className={clsx(
-                s.primaryBtn,
-                s.commentBtn,
-                (!draft.trim() || addComment.isPending) && s.commentBtnDisabled,
-              )}
-              disabled={!draft.trim() || addComment.isPending}
-            >
-              Comment
-            </button>
-          </form>
-          {addComment.isError && (
-            <p className={s.error} role="alert">
-              Couldn&apos;t post your comment — try again.
-            </p>
-          )}
-        </div>
+            {errorText && errorParentUid === null && (
+              <p className={s.error} role="alert">
+                {errorText}
+              </p>
+            )}
+          </div>
+        )
       )}
 
-      {(comments.length > 0 || pendingText) && (
+      {(comments.length > 0 || (pendingText && !pending?.parentUid)) && (
         <div className={s.list}>
-          {pendingText && (
-            <div className={clsx(s.item, s.itemPending)}>
-              <img
-                className={s.avatar}
-                src={currentUser?.profileImageUrl || getDefaultAvatar(currentUser?.name ?? 'You')}
-                alt=""
-                loading="lazy"
-              />
-              <div className={s.body}>
-                <div className={s.head}>
-                  <span className={s.name}>{currentUser?.name ?? 'You'}</span>
-                  <span className={s.time}>· posting…</span>
-                </div>
-                <p className={s.text}>{pendingText}</p>
-              </div>
-            </div>
-          )}
+          {pendingText && !pending?.parentUid && <PendingRow text={pendingText} />}
           {shown.map((comment) => (
             <CommentRow
               key={comment.uid}
               comment={comment}
+              depth={0}
+              canReply={canComment}
+              replyingTo={replyingTo}
+              setReplyingTo={(uid) => {
+                setReplyingTo(uid);
+                clearError();
+              }}
+              onSubmitReply={submit}
+              isSubmitting={addComment.isPending}
+              pendingReply={pending?.parentUid ? { parentUid: pending.parentUid, text: pendingText ?? '' } : undefined}
+              replyError={errorText && errorParentUid ? { parentUid: errorParentUid, text: errorText } : undefined}
               confirmingUid={confirmingUid}
               onConfirmDelete={setConfirmingUid}
               onDelete={requestDelete}
@@ -218,8 +237,94 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
   );
 }
 
+interface ComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder: string;
+  submitLabel: string;
+  disabled: boolean;
+  onCancel?: () => void;
+  autoFocus?: boolean;
+}
+
+/** The composer row, shared by the thread's own input and every reply input. */
+function Composer({
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  submitLabel,
+  disabled,
+  onCancel,
+  autoFocus,
+}: ComposerProps) {
+  const canSubmit = Boolean(value.trim()) && !disabled;
+
+  return (
+    <form
+      className={s.inline}
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <input
+        className={s.forumField}
+        value={value}
+        maxLength={FEED_COMMENT_MAX_LENGTH}
+        placeholder={placeholder}
+        // Opening a reply box is an explicit request to type in it, so focus
+        // follows the click rather than making the member click twice.
+        autoFocus={autoFocus}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {onCancel && (
+        <button type="button" className={s.replyCancelBtn} onClick={onCancel}>
+          Cancel
+        </button>
+      )}
+      <button
+        type="submit"
+        className={clsx(s.primaryBtn, s.commentBtn, !canSubmit && s.commentBtnDisabled)}
+        disabled={!canSubmit}
+      >
+        {submitLabel}
+      </button>
+    </form>
+  );
+}
+
+/** The viewer's own comment while it's in flight, rendered from the mutation's
+ *  variables rather than written to the cache. */
+function PendingRow({ text }: { text: string }) {
+  const { currentUser } = useCurrentUserStore();
+  const name = currentUser?.name ?? 'You';
+
+  return (
+    <div className={clsx(s.item, s.itemPending)}>
+      <img className={s.avatar} src={currentUser?.profileImageUrl || getDefaultAvatar(name)} alt="" loading="lazy" />
+      <div className={s.body}>
+        <div className={s.head}>
+          <span className={s.name}>{name}</span>
+          <span className={s.time}>· posting…</span>
+        </div>
+        <p className={s.text}>{text}</p>
+      </div>
+    </div>
+  );
+}
+
 interface CommentRowProps {
   comment: IFeedComment;
+  depth: number;
+  canReply: boolean;
+  replyingTo: string | null;
+  setReplyingTo: (uid: string | null) => void;
+  onSubmitReply: (text: string, parentUid: string) => boolean;
+  isSubmitting: boolean;
+  pendingReply: { parentUid: string; text: string } | undefined;
+  replyError: { parentUid: string; text: string } | undefined;
   confirmingUid: string | null;
   onConfirmDelete: (uid: string | null) => void;
   onDelete: (uid: string) => void;
@@ -230,27 +335,51 @@ interface CommentRowProps {
 }
 
 /**
- * One comment and its replies. Recursive, but bounded: the tree it renders has
- * already been through clampDepth, so recursion is at most MAX_DEPTH deep.
- * Delete state is passed down rather than held here — there is one delete
- * mutation for the whole thread, and only one row may be confirming at a time.
+ * One comment, its reply composer, and its replies. Recursive, but bounded: the
+ * tree it renders has already been through clampDepth, so recursion is at most
+ * MAX_DEPTH deep and Reply disappears at the cap (a deeper reply would be
+ * displayed at the same level as its parent, which reads as a non-sequitur).
+ *
+ * Reply and delete state is passed down rather than held here — there is one
+ * mutation of each kind for the whole thread, and only one row may be replying
+ * or confirming at a time.
  */
-function CommentRow({
-  comment,
-  confirmingUid,
-  onConfirmDelete,
-  onDelete,
-  isDeletePending,
-  deletingUid,
-  deleteFailed,
-  resetDelete,
-}: CommentRowProps) {
+function CommentRow(props: CommentRowProps) {
+  const {
+    comment,
+    depth,
+    canReply,
+    replyingTo,
+    setReplyingTo,
+    onSubmitReply,
+    isSubmitting,
+    pendingReply,
+    replyError,
+    confirmingUid,
+    onConfirmDelete,
+    onDelete,
+    isDeletePending,
+    deletingUid,
+    deleteFailed,
+    resetDelete,
+  } = props;
+
+  const [replyDraft, setReplyDraft] = useState('');
+
   const isConfirming = confirmingUid === comment.uid;
   const isDeletingThis = isDeletePending && deletingUid === comment.uid;
   const deleteFailedThis = deleteFailed && deletingUid === comment.uid;
+  const isReplying = replyingTo === comment.uid;
+  const showReply = canReply && depth < MAX_DEPTH;
+  const pendingHere = pendingReply?.parentUid === comment.uid ? pendingReply.text : undefined;
+  const errorHere = replyError?.parentUid === comment.uid ? replyError.text : undefined;
   // `name` is nullable on the wire; the fallback keeps the avatar deterministic
   // and the row readable rather than rendering a blank byline.
   const displayName = comment.author.name || 'Member';
+
+  const submitReply = () => {
+    if (onSubmitReply(replyDraft, comment.uid)) setReplyDraft('');
+  };
 
   return (
     <div className={s.item}>
@@ -293,25 +422,45 @@ function CommentRow({
         <p className={s.text}>{comment.text}</p>
         {deleteFailedThis && (
           <p className={s.error} role="alert">
-            Couldn&apos;t delete — try again.
+            Couldn’t delete — try again.
           </p>
         )}
 
-        {comment.replies.length > 0 && (
+        {showReply && !isReplying && (
+          <button type="button" className={s.replyBtn} onClick={() => setReplyingTo(comment.uid)}>
+            Reply
+          </button>
+        )}
+
+        {isReplying && (
+          <div className={s.replyComposer}>
+            <Composer
+              autoFocus
+              value={replyDraft}
+              onChange={setReplyDraft}
+              onSubmit={submitReply}
+              onCancel={() => {
+                setReplyDraft('');
+                setReplyingTo(null);
+              }}
+              placeholder={`Reply to ${displayName}…`}
+              submitLabel="Reply"
+              disabled={isSubmitting}
+            />
+            {errorHere && (
+              <p className={s.error} role="alert">
+                {errorHere}
+              </p>
+            )}
+          </div>
+        )}
+
+        {(comment.replies.length > 0 || pendingHere) && (
           <div className={s.repliesWrapper}>
             {comment.replies.map((reply) => (
-              <CommentRow
-                key={reply.uid}
-                comment={reply}
-                confirmingUid={confirmingUid}
-                onConfirmDelete={onConfirmDelete}
-                onDelete={onDelete}
-                isDeletePending={isDeletePending}
-                deletingUid={deletingUid}
-                deleteFailed={deleteFailed}
-                resetDelete={resetDelete}
-              />
+              <CommentRow key={reply.uid} {...props} comment={reply} depth={depth + 1} />
             ))}
+            {pendingHere && <PendingRow text={pendingHere} />}
           </div>
         )}
       </div>

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -2,10 +2,11 @@
 
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import { clampDepth } from '@/utils/comments';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useFeedComments } from '@/services/feed/hooks/useFeedComments';
 import { useAddFeedComment } from '@/services/feed/hooks/useAddFeedComment';
@@ -16,8 +17,20 @@ import type { IFeedComment } from '@/types/feed.types';
 
 import s from './FeedCommentsThread.module.scss';
 
-// Show at most this many comments before capping behind "View all N …".
+// Show at most this many TOP-LEVEL comments before capping behind "View all N …".
 const VISIBLE = 2;
+
+// Deepest rendered level, as a depth index — 2 means comment → reply →
+// reply-to-reply, the same cap as the forum's CommentItem.MAX_DEPTH. The wire
+// allows unlimited depth, so anything deeper is lifted to this level by
+// clampDepth rather than indented off the edge of the card.
+const MAX_DEPTH = 2;
+
+/** Total comments in the thread, replies included — matches what the count
+ *  badge shows (the backend counts every row under an item, at any depth). */
+function countComments(comments: readonly IFeedComment[]): number {
+  return comments.reduce((total, comment) => total + 1 + countComments(comment.replies), 0);
+}
 
 interface FeedCommentsThreadProps {
   itemUid: string;
@@ -26,9 +39,12 @@ interface FeedCommentsThreadProps {
 }
 
 /**
- * Inline feed-only comment thread + composer (ported from the newsfeed-v0
- * prototype's CommentsThread). Feed comments are their own system — posting
- * here never creates or updates a NodeBB forum reply.
+ * Inline comment thread + composer for a feed item.
+ *
+ * The comments come from one of two entirely separate systems, and this
+ * component is deliberately blind to which: news comments are directory-native,
+ * a forum post's comments are its real NodeBB topic replies. Both arrive as the
+ * same `IFeedComment` tree from services/feed/feed.service.ts.
  *
  * Mount = expanded: the parent renders this component only while the thread is
  * open, so the lazy comments query fetches on first expand and, with no
@@ -49,9 +65,9 @@ interface FeedCommentsThreadProps {
  * swap on the row — no modal, no toast, matching the composer's style. No
  * optimistic removal: the row shows a disabled Yes while the request is in
  * flight, same "nothing touches the cache until the server confirms" rule the
- * composer follows. If the card unmounts mid-confirm (e.g. a mid-session
- * access revocation drops this post from the feed), the pending confirm state
- * is silently discarded — same accepted behavior as an abandoned draft.
+ * composer follows. Deleting cascades to the comment's replies, server-side and
+ * in the cache patch alike. NodeBB-sourced comments always report
+ * `isOwn: false`, so the affordance never appears on them.
  */
 export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThreadProps) {
   const router = useRouter();
@@ -65,7 +81,12 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
   const addComment = useAddFeedComment(itemUid);
   const deleteComment = useDeleteFeedComment(itemUid);
 
-  const comments: IFeedComment[] = data?.items ?? [];
+  const items = data?.items;
+  // Display cap applied once, here: every consumer below can then recurse
+  // without re-checking depth.
+  const comments = useMemo(() => clampDepth<IFeedComment>(items ?? [], MAX_DEPTH), [items]);
+  const totalCount = useMemo(() => countComments(comments), [comments]);
+
   // Oldest-first data: the most recent VISIBLE comments are the LAST ones, not
   // the first — a plain slice(0, VISIBLE) would show the oldest instead.
   const shown = expanded ? comments : comments.slice(-VISIBLE);
@@ -173,70 +194,127 @@ export function FeedCommentsThread({ itemUid, kind, source }: FeedCommentsThread
               </div>
             </div>
           )}
-          {shown.map((c) => {
-            const isConfirming = confirmingUid === c.uid;
-            const isDeletingThis = deleteComment.isPending && deleteComment.variables?.commentUid === c.uid;
-            const deleteFailedThis = deleteComment.isError && deleteComment.variables?.commentUid === c.uid;
-            return (
-              <div key={c.uid} className={s.item}>
-                <img
-                  className={s.avatar}
-                  src={c.author.avatarUrl || getDefaultAvatar(c.author.name)}
-                  alt=""
-                  loading="lazy"
-                />
-                <div className={s.body}>
-                  <div className={s.head}>
-                    <span className={s.name}>{c.author.name}</span>
-                    {c.author.role && <span className={s.role}>· {c.author.role}</span>}
-                    <span className={s.time}>· {formatTimeAgo(c.createdAt)}</span>
-                    {c.isOwn &&
-                      (isConfirming ? (
-                        <span className={s.deleteConfirm}>
-                          Delete this comment?
-                          <button
-                            type="button"
-                            className={s.deleteConfirmBtn}
-                            disabled={isDeletingThis}
-                            onClick={() => requestDelete(c.uid)}
-                          >
-                            {isDeletingThis ? 'Deleting…' : 'Yes'}
-                          </button>
-                          <button
-                            type="button"
-                            className={s.deleteCancelBtn}
-                            disabled={isDeletingThis}
-                            onClick={() => {
-                              setConfirmingUid(null);
-                              if (deleteComment.isError) deleteComment.reset();
-                            }}
-                          >
-                            Cancel
-                          </button>
-                        </span>
-                      ) : (
-                        <button type="button" className={s.deleteBtn} onClick={() => setConfirmingUid(c.uid)}>
-                          Delete
-                        </button>
-                      ))}
-                  </div>
-                  <p className={s.text}>{c.text}</p>
-                  {deleteFailedThis && (
-                    <p className={s.error} role="alert">
-                      Couldn&apos;t delete — try again.
-                    </p>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+          {shown.map((comment) => (
+            <CommentRow
+              key={comment.uid}
+              comment={comment}
+              confirmingUid={confirmingUid}
+              onConfirmDelete={setConfirmingUid}
+              onDelete={requestDelete}
+              isDeletePending={deleteComment.isPending}
+              deletingUid={deleteComment.variables?.commentUid}
+              deleteFailed={deleteComment.isError}
+              resetDelete={deleteComment.reset}
+            />
+          ))}
           {comments.length > VISIBLE && (
             <button type="button" className={s.viewAll} onClick={() => setExpanded((v) => !v)}>
-              {expanded ? 'Show fewer comments' : `View all ${comments.length} comments`}
+              {expanded ? 'Show fewer comments' : `View all ${totalCount} comments`}
             </button>
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+interface CommentRowProps {
+  comment: IFeedComment;
+  confirmingUid: string | null;
+  onConfirmDelete: (uid: string | null) => void;
+  onDelete: (uid: string) => void;
+  isDeletePending: boolean;
+  deletingUid: string | undefined;
+  deleteFailed: boolean;
+  resetDelete: () => void;
+}
+
+/**
+ * One comment and its replies. Recursive, but bounded: the tree it renders has
+ * already been through clampDepth, so recursion is at most MAX_DEPTH deep.
+ * Delete state is passed down rather than held here — there is one delete
+ * mutation for the whole thread, and only one row may be confirming at a time.
+ */
+function CommentRow({
+  comment,
+  confirmingUid,
+  onConfirmDelete,
+  onDelete,
+  isDeletePending,
+  deletingUid,
+  deleteFailed,
+  resetDelete,
+}: CommentRowProps) {
+  const isConfirming = confirmingUid === comment.uid;
+  const isDeletingThis = isDeletePending && deletingUid === comment.uid;
+  const deleteFailedThis = deleteFailed && deletingUid === comment.uid;
+  // `name` is nullable on the wire; the fallback keeps the avatar deterministic
+  // and the row readable rather than rendering a blank byline.
+  const displayName = comment.author.name || 'Member';
+
+  return (
+    <div className={s.item}>
+      <img className={s.avatar} src={comment.author.avatarUrl || getDefaultAvatar(displayName)} alt="" loading="lazy" />
+      <div className={s.body}>
+        <div className={s.head}>
+          <span className={s.name}>{displayName}</span>
+          {comment.author.role && <span className={s.role}>· {comment.author.role}</span>}
+          <span className={s.time}>· {formatTimeAgo(comment.createdAt)}</span>
+          {comment.isOwn &&
+            (isConfirming ? (
+              <span className={s.deleteConfirm}>
+                Delete this comment?
+                <button
+                  type="button"
+                  className={s.deleteConfirmBtn}
+                  disabled={isDeletingThis}
+                  onClick={() => onDelete(comment.uid)}
+                >
+                  {isDeletingThis ? 'Deleting…' : 'Yes'}
+                </button>
+                <button
+                  type="button"
+                  className={s.deleteCancelBtn}
+                  disabled={isDeletingThis}
+                  onClick={() => {
+                    onConfirmDelete(null);
+                    if (deleteFailed) resetDelete();
+                  }}
+                >
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button type="button" className={s.deleteBtn} onClick={() => onConfirmDelete(comment.uid)}>
+                Delete
+              </button>
+            ))}
+        </div>
+        <p className={s.text}>{comment.text}</p>
+        {deleteFailedThis && (
+          <p className={s.error} role="alert">
+            Couldn&apos;t delete — try again.
+          </p>
+        )}
+
+        {comment.replies.length > 0 && (
+          <div className={s.repliesWrapper}>
+            {comment.replies.map((reply) => (
+              <CommentRow
+                key={reply.uid}
+                comment={reply}
+                confirmingUid={confirmingUid}
+                onConfirmDelete={onConfirmDelete}
+                onDelete={onDelete}
+                isDeletePending={isDeletePending}
+                deletingUid={deletingUid}
+                deleteFailed={deleteFailed}
+                resetDelete={resetDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -109,6 +109,13 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
   const comments = useMemo(() => clampDepth<IFeedComment>(items ?? [], MAX_DEPTH), [items]);
   const totalCount = useMemo(() => countComments(comments), [comments]);
 
+  // NodeBB serves one page of posts per request, so a busy topic's thread is
+  // only partly here. Saying "View all N" over a subset would be a lie; the
+  // forum link is where the rest actually is.
+  const forumTopic = data?.forumTopic;
+  const forumTopicUrl = forumTopic?.url ?? undefined;
+  const missingReplyCount = forumTopic ? Math.max(0, forumTopic.totalReplyCount - totalCount) : 0;
+
   // Oldest-first data: the most recent VISIBLE comments are the LAST ones, not
   // the first — a plain slice(0, VISIBLE) would show the oldest instead.
   const shown = expanded ? comments : comments.slice(-VISIBLE);
@@ -224,12 +231,24 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
               deletingUid={deleteComment.variables?.commentUid}
               deleteFailed={deleteComment.isError}
               resetDelete={deleteComment.reset}
+              forumTopicUrl={forumTopicUrl}
             />
           ))}
           {comments.length > VISIBLE && (
             <button type="button" className={s.viewAll} onClick={() => setExpanded((v) => !v)}>
-              {expanded ? 'Show fewer comments' : `View all ${totalCount} comments`}
+              {expanded
+                ? 'Show fewer comments'
+                : missingReplyCount > 0
+                  ? 'Show more comments'
+                  : `View all ${totalCount} comments`}
             </button>
+          )}
+          {missingReplyCount > 0 && forumTopicUrl && (
+            <a className={s.forumLink} href={forumTopicUrl} target="_blank" rel="noopener noreferrer">
+              {missingReplyCount === 1
+                ? '1 more comment on the forum →'
+                : `${missingReplyCount} more comments on the forum →`}
+            </a>
           )}
         </div>
       )}
@@ -332,6 +351,8 @@ interface CommentRowProps {
   deletingUid: string | undefined;
   deleteFailed: boolean;
   resetDelete: () => void;
+  /** Where an attachment-only comment can actually be seen (forum posts only). */
+  forumTopicUrl: string | undefined;
 }
 
 /**
@@ -362,6 +383,7 @@ function CommentRow(props: CommentRowProps) {
     deletingUid,
     deleteFailed,
     resetDelete,
+    forumTopicUrl,
   } = props;
 
   const [replyDraft, setReplyDraft] = useState('');
@@ -419,7 +441,22 @@ function CommentRow(props: CommentRowProps) {
               </button>
             ))}
         </div>
-        <p className={s.text}>{comment.text}</p>
+        {/* A forum comment that was only an image or a file strips to nothing —
+            the text is plain by contract, and the attachment isn't in it. Say so
+            and point at where it can be seen, rather than rendering a blank row. */}
+        {comment.text ? (
+          <p className={s.text}>{comment.text}</p>
+        ) : (
+          <p className={clsx(s.text, s.textAttachment)}>
+            {forumTopicUrl ? (
+              <a href={forumTopicUrl} target="_blank" rel="noopener noreferrer" className={s.forumLink}>
+                Shared an image or file — view it on the forum →
+              </a>
+            ) : (
+              'Shared an image or file.'
+            )}
+          </p>
+        )}
         {deleteFailedThis && (
           <p className={s.error} role="alert">
             Couldn’t delete — try again.

--- a/components/page/home/TeamNews/components/ForumPostCard/ForumPostCard.tsx
+++ b/components/page/home/TeamNews/components/ForumPostCard/ForumPostCard.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import clsx from 'clsx';
-import { useState } from 'react';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
-import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import { useTeamNewsAnalytics, type TeamNewsCardClickVia } from '@/analytics/team-news.analytics';
 import type { IFeedForumPost } from '@/types/feed.types';
 
 // Shared news-card shell (.card/.head/.logo/.teamName/.headline) — established
@@ -15,7 +14,6 @@ import newsCardStyles from '../NewsCard/NewsCard.module.scss';
 import { UpvoteButton } from '../NewsCard/components/UpvoteButton/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { FeedForumPostShareMenu } from '../NewsShareMenu';
-import { FeedCommentsThread } from '../FeedCommentsThread/FeedCommentsThread';
 
 import s from './ForumPostCard.module.scss';
 
@@ -37,17 +35,10 @@ interface ForumPostCardProps {
  */
 export function ForumPostCard({ post, position, onOpenDetail, onLikeToggle }: ForumPostCardProps) {
   const analytics = useTeamNewsAnalytics();
-  const [threadOpen, setThreadOpen] = useState(false);
 
-  const handleOpenDetail = () => {
-    analytics.onFeedForumPostCardClicked(post, position, 'home');
+  const handleOpenDetail = (via: TeamNewsCardClickVia = 'row') => {
+    analytics.onFeedForumPostCardClicked(post, position, 'home', via);
     onOpenDetail(post);
-  };
-
-  const handleThreadToggle = () => {
-    const next = !threadOpen;
-    setThreadOpen(next);
-    analytics.onFeedCommentThreadToggled(post.uid, 'forum', next, 'home');
   };
 
   return (
@@ -76,10 +67,10 @@ export function ForumPostCard({ post, position, onOpenDetail, onLikeToggle }: Fo
         tabIndex={0}
         data-post-uid={post.uid}
         className={s.story}
-        onClick={handleOpenDetail}
+        onClick={() => handleOpenDetail()}
         onKeyDown={(e) => {
-          // Only the row itself opens the modal — Enter/Space inside the comment
-          // composer must not (it bubbles up to this handler).
+          // Only the row itself opens the modal — Enter/Space on a nested
+          // control must not (it bubbles up to this handler).
           if (e.target !== e.currentTarget) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -98,12 +89,10 @@ export function ForumPostCard({ post, position, onOpenDetail, onLikeToggle }: Fo
           <span className={s.footerActions} onClick={(e) => e.stopPropagation()}>
             <FeedForumPostShareMenu post={post} source="home" />
             <UpvoteButton count={post.likeCount} voted={post.viewerHasLiked} onToggle={() => onLikeToggle(post)} />
-            <CommentButton itemUid={post.uid} open={threadOpen} onToggle={handleThreadToggle} />
+            {/* Opens the detail modal, where the thread lives. */}
+            <CommentButton itemUid={post.uid} onClick={() => handleOpenDetail('comment-button')} />
           </span>
         </div>
-
-        {/* Mount = expanded (the lazy comments query keys off it). */}
-        {threadOpen && <FeedCommentsThread itemUid={post.uid} kind="forum" source="home" />}
       </div>
     </div>
   );

--- a/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.tsx
+++ b/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.tsx
@@ -117,9 +117,10 @@ export function ForumPostModal({ post, onClose, onLikeToggle }: ForumPostModalPr
 
         <p className={clsx(modalStyles.content, modalStyles.contentPlain)}>{post.body}</p>
 
-        {/* Always expanded in the modal (prototype parity) — shares the card
-            thread's cache entry, so nothing refetches when both are open. */}
-        <FeedCommentsThread itemUid={post.uid} kind="forum" source="news-modal" />
+        {/* The post's real NodeBB thread. `forumMainPid` is the topic's opening
+            post — the reply target for a top-level comment — passed down so the
+            write is one request instead of a fetch-then-post. */}
+        <FeedCommentsThread itemUid={post.uid} kind="forum" source="news-modal" forumMainPid={post.mainPid} />
       </div>
 
       <div className={modalStyles.footer}>

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
@@ -30,7 +30,3 @@
     filter: brightness(0.8);
   }
 }
-
-.commentOpen {
-  color: #156ff7;
-}

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
@@ -11,6 +11,10 @@ import s from './CommentButton.module.scss';
 // as one family. Subscribes to its own uid's slot in the shared feed counts
 // cache (select-narrowed, so a count bump re-renders exactly this button, not
 // the feed); undefined means "unknown" and renders no number (never a fake "0").
+//
+// This is a count badge that OPENS the detail modal, not a disclosure toggle:
+// threads live only in the modal, where a depth-2 reply tree has room to
+// breathe. Hence no `open`/aria-expanded — there is nothing here to expand.
 
 function CommentIcon() {
   return (
@@ -25,24 +29,21 @@ function CommentIcon() {
 
 interface CommentButtonProps {
   itemUid: string;
-  open: boolean;
-  onToggle: () => void;
+  onClick: () => void;
 }
 
-export function CommentButton({ itemUid, open, onToggle }: CommentButtonProps) {
+export function CommentButton({ itemUid, onClick }: CommentButtonProps) {
   const count = useFeedCommentCount(itemUid);
   const noun = count === 1 ? 'Comment' : 'Comments';
-  const label = open ? `Hide comments` : `Show comments`;
   return (
     <button
       type="button"
-      className={clsx(s.comment, open && s.commentOpen)}
-      aria-expanded={open}
-      aria-label={label}
-      title={label}
+      className={s.comment}
+      aria-label="View comments"
+      title="View comments"
       onClick={(e) => {
         e.stopPropagation();
-        onToggle();
+        onClick();
       }}
     >
       <CommentIcon />

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import { useToggle } from 'react-use';
 import { useRouter } from 'next/navigation';
 
@@ -8,7 +8,11 @@ import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { FollowButton } from '@/components/ui/FollowButton';
 import type { ITeamNewsItem, TeamCluster } from '@/types/team-news.types';
-import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import {
+  useTeamNewsAnalytics,
+  type TeamNewsAnalyticsSource,
+  type TeamNewsCardClickVia,
+} from '@/analytics/team-news.analytics';
 import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
 import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
 import { sortAllTabItemsByEventDate } from '../../utils/sortAllTabItemsByEventDate';
@@ -16,7 +20,6 @@ import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { NewsShareMenu } from '../NewsShareMenu';
 import { SourceList } from '../SourceList/SourceList';
-import { FeedCommentsThread } from '../FeedCommentsThread/FeedCommentsThread';
 import { hasNewsSource } from '../../utils/getNewsSources';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
@@ -29,8 +32,10 @@ interface NewsGroupCardProps {
   /** Row click/Enter opens the news detail modal — the single owner of
    *  analytics + modal state + URL sync lives in TeamNews.handleStoryOpen.
    *  (The old open-the-source-in-a-new-tab behavior moved into the modal's
-   *  SOURCE links; NewsCard — team-details — still opens the source.) */
-  onStoryOpen: (item: ITeamNewsItem) => void;
+   *  SOURCE links; NewsCard — team-details — still opens the source.)
+   *  `via` distinguishes the comment badge from the row, since both now open
+   *  the same modal and only the analytics can tell them apart. */
+  onStoryOpen: (item: ITeamNewsItem, via?: TeamNewsCardClickVia) => void;
   analyticsSource?: TeamNewsAnalyticsSource;
   isFollowing?: boolean;
   onFollowToggle?: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
@@ -54,20 +59,6 @@ export function NewsGroupCard({
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
   const analytics = useTeamNewsAnalytics();
-
-  // Per-story inline threads. Local like the card's own `expanded`, so the
-  // composite-key remount on tab/category change resets open threads (and any
-  // unsent drafts — accepted, documented loss; in-flight submits still land
-  // because the mutation's cache writes live in its options callbacks).
-  const [openThreadUids, setOpenThreadUids] = useState<ReadonlySet<string>>(() => new Set());
-
-  const handleThreadToggle = (storyUid: string) => {
-    const next = new Set(openThreadUids);
-    const willOpen = !next.has(storyUid);
-    willOpen ? next.add(storyUid) : next.delete(storyUid);
-    setOpenThreadUids(next);
-    analytics.onFeedCommentThreadToggled(storyUid, 'news', willOpen, analyticsSource);
-  };
 
   const handleFollowClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -180,17 +171,10 @@ export function NewsGroupCard({
                   voted={Boolean(story.viewerHasUpvoted)}
                   onToggle={() => handleUpvoteClick(story)}
                 />
-                <CommentButton
-                  itemUid={story.uid}
-                  open={openThreadUids.has(story.uid)}
-                  onToggle={() => handleThreadToggle(story.uid)}
-                />
+                {/* Opens the detail modal, where the thread lives. */}
+                <CommentButton itemUid={story.uid} onClick={() => onStoryOpen(story, 'comment-button')} />
               </div>
             </div>
-            {/* Mount = expanded (the lazy comments query keys off it). */}
-            {openThreadUids.has(story.uid) && (
-              <FeedCommentsThread itemUid={story.uid} kind="news" source={analyticsSource} />
-            )}
           </div>
         );
       })}

--- a/components/page/home/TeamNews/constants.ts
+++ b/components/page/home/TeamNews/constants.ts
@@ -4,13 +4,26 @@ import { EVENT_TYPE_LABEL } from './utils/getEventTypeConfig';
 
 export const ALL_TAB = 'All';
 export const ALL_CAT = 'all';
-export const ACTIVE_DISCUSSIONS_CAT = 'active-discussions';
 
-export type TeamNewsCategoryId = typeof ALL_CAT | typeof ACTIVE_DISCUSSIONS_CAT | TeamNewsEventType;
+/**
+ * Everything in the feed that is a conversation rather than a story: member
+ * forum posts (the cards badged "Discussion"), plus news items that have a
+ * linked forum thread.
+ *
+ * It used to be `active-discussions`, meaning only the second of those. That
+ * left the forum-post cards with no pill at all while a similarly-named one sat
+ * next to them doing something else — and because a non-`all` category dropped
+ * forum posts entirely, clicking it actively hid the cards a member was after.
+ * The id changed with the meaning so analytics can't silently average the two
+ * definitions together.
+ */
+export const DISCUSSIONS_CAT = 'discussions';
 
-export const ACTIVE_DISCUSSIONS_CATEGORY = {
-  id: ACTIVE_DISCUSSIONS_CAT,
-  label: 'Active Discussions',
+export type TeamNewsCategoryId = typeof ALL_CAT | typeof DISCUSSIONS_CAT | TeamNewsEventType;
+
+export const DISCUSSIONS_CATEGORY = {
+  id: DISCUSSIONS_CAT,
+  label: 'Discussions',
 } as const;
 
 export const CATEGORIES: Array<{ id: TeamNewsEventType | typeof ALL_CAT; label: string }> = [

--- a/components/page/home/TeamNews/utils/matchesFeedForumPost.ts
+++ b/components/page/home/TeamNews/utils/matchesFeedForumPost.ts
@@ -1,12 +1,15 @@
 import type { IFeedForumPost } from '@/types/feed.types';
-import { ALL_CAT, ALL_TAB, type TeamNewsCategoryId } from '../constants';
+import { ALL_CAT, ALL_TAB, DISCUSSIONS_CAT, type TeamNewsCategoryId } from '../constants';
 
-// Prototype semantics (NewsfeedV0Prototype's forumPosts memo): posts join the
-// feed only under the "All" category pill (a post has no event type, so any
-// event filter necessarily excludes it — including Active Discussions, which
-// counts NodeBB-linked news, a separate system from feed comments), scoped to
-// the focus-area tabs the post is tagged with, then narrowed by the same
-// free-text search as news.
+// Where a forum post can appear: under "All categories" or under "Discussions"
+// (a post has no event type, so every event-type pill necessarily excludes it),
+// scoped to the focus-area tabs the post is tagged with, then narrowed by the
+// same free-text search as news.
+//
+// NodeBB has no focus areas, so `focusAreas` is empty in practice and posts only
+// surface on the All tab. That's also why the Discussions pill hides itself on a
+// focus tab: its count there is zero, which is how the pill has always behaved
+// when nothing matches.
 
 export function matchesFeedForumPost(post: IFeedForumPost, tab: string, lowerCaseQuery: string): boolean {
   if (tab !== ALL_TAB && !post.focusAreas.includes(tab)) return false;
@@ -19,11 +22,16 @@ export function matchesFeedForumPost(post: IFeedForumPost, tab: string, lowerCas
   );
 }
 
+/** Does this category show forum posts at all? */
+export function categoryIncludesForumPosts(category: TeamNewsCategoryId): boolean {
+  return category === ALL_CAT || category === DISCUSSIONS_CAT;
+}
+
 export function filterFeedForumPosts(
   posts: IFeedForumPost[] | undefined,
   filters: { tab: string; category: TeamNewsCategoryId; query: string },
 ): IFeedForumPost[] {
-  if (!posts || filters.category !== ALL_CAT) return [];
+  if (!posts || !categoryIncludesForumPosts(filters.category)) return [];
   const q = filters.query.trim().toLowerCase();
   return posts.filter((p) => matchesFeedForumPost(p, filters.tab, q));
 }

--- a/components/page/home/TeamNews/utils/resolveForumPostLike.ts
+++ b/components/page/home/TeamNews/utils/resolveForumPostLike.ts
@@ -1,0 +1,27 @@
+import type { IFeedForumPostLikeStatus } from '@/types/feed.types';
+
+/**
+ * Resolve a forum post's like state from the three things that can know it,
+ * in order of authority. Applied at render time only — never written back to a
+ * query cache, so the session-frozen feed can't reorder.
+ *
+ * 1. **The viewer's own toggle** (`ownToggle`), which is newer than anything a
+ *    fetch can say, and is what the optimistic overlay holds.
+ * 2. **The topic** (`topicLike`), available once its thread has been opened.
+ *    This is the only source of `viewerHasLiked`: the /api/recent listing that
+ *    builds the card carries no per-viewer vote state at all.
+ * 3. **The post itself**, whose `viewerHasLiked` is therefore always false — a
+ *    blind default, not a fact.
+ *
+ * Why this matters: without (2), a member who already liked a post sees an
+ * un-liked button, and clicking it sends a vote NodeBB ignores while the local
+ * count climbs by one. Feeding the resolved value into the toggle handler also
+ * means the correction lands in the overlay on first use and outlives the modal.
+ */
+export function resolveForumPostLike<T extends IFeedForumPostLikeStatus>(
+  post: T,
+  topicLike: IFeedForumPostLikeStatus | undefined,
+  ownToggle: IFeedForumPostLikeStatus | undefined,
+): T {
+  return { ...post, ...topicLike, ...ownToggle };
+}

--- a/prototypes/entries/news-feed/NewsFeedPrototype.tsx
+++ b/prototypes/entries/news-feed/NewsFeedPrototype.tsx
@@ -7,8 +7,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/common/Button';
 
 import {
-  ACTIVE_DISCUSSIONS_CAT,
-  ACTIVE_DISCUSSIONS_CATEGORY,
+  // Renamed in production (the pill now covers forum posts too); aliased here
+  // so this frozen prototype keeps compiling against its own semantics.
+  DISCUSSIONS_CAT as ACTIVE_DISCUSSIONS_CAT,
+  DISCUSSIONS_CATEGORY as ACTIVE_DISCUSSIONS_CATEGORY,
   ALL_TAB,
   ALL_CAT,
   CATEGORIES,

--- a/prototypes/entries/newsfeed-v0/NewsfeedV0Prototype.tsx
+++ b/prototypes/entries/newsfeed-v0/NewsfeedV0Prototype.tsx
@@ -10,8 +10,10 @@ import type { ITeamNewsItem, TeamNewsEventType } from '@/types/team-news.types';
 import { Button } from '@/components/common/Button';
 
 import {
-  ACTIVE_DISCUSSIONS_CAT,
-  ACTIVE_DISCUSSIONS_CATEGORY,
+  // Renamed in production (the pill now covers forum posts too); aliased here
+  // so this frozen prototype keeps compiling against its own semantics.
+  DISCUSSIONS_CAT as ACTIVE_DISCUSSIONS_CAT,
+  DISCUSSIONS_CATEGORY as ACTIVE_DISCUSSIONS_CATEGORY,
   ALL_TAB,
   ALL_CAT,
   CATEGORIES,

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -2,7 +2,7 @@ import { customFetch } from '@/utils/fetch-wrapper';
 import { getHeader } from '@/utils/common.utils';
 import { stripHtml } from '@/utils/forum';
 import { buildCommentTree } from '@/utils/comments';
-import { forumFetch } from '@/services/forum/forum.service';
+import { forumFetch, postForumReply } from '@/services/forum/forum.service';
 import type { Topic } from '@/services/forum/hooks/useForumPosts';
 import type { TopicResponse } from '@/services/forum/hooks/useForumPost';
 import {
@@ -192,6 +192,8 @@ export async function getFeedComments(itemUid: string, authToken?: string): Prom
 }
 
 export async function createFeedComment(request: ICreateFeedCommentRequest): Promise<IFeedComment> {
+  if (isForumPostUid(request.itemUid)) return createForumPostComment(request);
+
   const response = await customFetch(
     `${process.env.DIRECTORY_API_URL}/v1/feed/comments`,
     {
@@ -262,6 +264,57 @@ function toForumFeedComment(post: TopicPost, itemUid: ForumPostUid, mainPid: num
     isOwn: false,
     replies: [],
   };
+}
+
+function pidFromForumCommentUid(uid: string): number | undefined {
+  const pid = Number(uid.slice('fpc_'.length));
+  return uid.startsWith('fpc_') && Number.isFinite(pid) ? pid : undefined;
+}
+
+/**
+ * Post a comment on a forum post as a REAL NodeBB reply — the directory backend
+ * has no table to put it in.
+ *
+ * A top-level comment replies to the topic's opening post, a reply replies to
+ * that comment's own post. `forumMainPid` comes from the card the modal was
+ * opened from; the topic fetch is only a fallback for a caller that doesn't
+ * have it, so the common path is one request, not two.
+ */
+async function createForumPostComment(request: ICreateFeedCommentRequest): Promise<IFeedComment> {
+  const itemUid = request.itemUid as ForumPostUid;
+  const tid = tidFromForumPostUid(itemUid);
+
+  const parentPid = request.parentUid ? pidFromForumCommentUid(request.parentUid) : undefined;
+  const toPid = parentPid ?? request.forumMainPid ?? (await fetchTopicMainPid(tid));
+
+  const created = await postForumReply({ tid, toPid, content: `<p>${escapeHtml(request.text)}</p>` });
+  const post = (created?.response ?? created) as TopicPost;
+
+  return {
+    ...toForumFeedComment(post, itemUid, toPid),
+    // The mapper reads `parent.pid` off the response, which NodeBB doesn't
+    // always echo. The caller's own intent is authoritative here, and the cache
+    // patch depends on it landing the comment under the right parent.
+    parentUid: request.parentUid ?? null,
+  };
+}
+
+async function fetchTopicMainPid(tid: number): Promise<number> {
+  const response = await forumFetch(`/api/topic/${tid}`);
+  if (!response?.ok) throw new Error('Failed to post feed comment');
+
+  const topic = (await response.json()) as TopicResponse;
+  return topic.mainPid;
+}
+
+/** NodeBB stores post content as HTML, so member text must not be markup. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedCommentsResponse> {

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -1,38 +1,165 @@
 import { customFetch } from '@/utils/fetch-wrapper';
 import { getHeader } from '@/utils/common.utils';
-import type {
-  ICreateFeedCommentRequest,
-  IFeedComment,
-  IFeedCommentCountsResponse,
-  IFeedCommentDeleteResponse,
-  IFeedCommentsResponse,
-  IFeedForumPostLikeStatus,
-  IFeedForumPostsResponse,
+import { stripHtml } from '@/utils/forum';
+import { buildCommentTree } from '@/utils/comments';
+import { forumFetch } from '@/services/forum/forum.service';
+import type { Topic } from '@/services/forum/hooks/useForumPosts';
+import type { TopicResponse } from '@/services/forum/hooks/useForumPost';
+import {
+  isForumPostUid,
+  type ForumPostUid,
+  type ICreateFeedCommentRequest,
+  type IFeedComment,
+  type IFeedCommentCountsResponse,
+  type IFeedCommentDeleteResponse,
+  type IFeedCommentsResponse,
+  type IFeedForumPost,
+  type IFeedForumPostLikeStatus,
+  type IFeedForumPostsResponse,
 } from '@/types/feed.types';
 
-// Client-side fetchers for the feed's social layer, against the real
-// /v1/feed API (docs/NEWSFEED_FORUM_POSTS.md, LAB-2175).
+// Client-side fetchers for the feed's social layer, against TWO backends:
+//
+//   - team news comments → the directory backend (/v1/feed/*)
+//   - forum posts, their votes, and their comments → NodeBB directly
+//
+// The split is the backend's: BE PR #3293 deleted GET /v1/feed/forum-posts and
+// its like route, and re-pointed FeedComment at a hard TeamNewsItem foreign key,
+// so a forum post's comments can only come from the forum itself. Both are
+// mapped into types/feed.types.ts' view model here, at the boundary, so nothing
+// above this file has to know which backend a comment came from.
 //
 // Unlike the team-news SSR fetchers, these are React Query queryFns/mutationFns:
 // they THROW on failure (never return null) so isError/rollback semantics work.
 
-export async function getFeedForumPosts(): Promise<IFeedForumPostsResponse> {
-  // limit=100 (the API max) is a single bounded fetch, not true pagination —
-  // mergeFeedEntries rank-merges the whole array in one shot against a
-  // session-frozen feed, so there's no stable-append strategy to page into.
-  const response = await customFetch(
-    `${process.env.DIRECTORY_API_URL}/v1/feed/forum-posts?limit=100&page=0`,
-    { method: 'GET' },
-    true,
-  );
-  if (!response?.ok) throw new Error('Failed to fetch feed forum posts');
-  return (await response.json()) as IFeedForumPostsResponse;
+// The server rejects a batch larger than this (FeedCommentCountsRequestSchema
+// caps `uids` at 200) — one oversized request would 400 and take every count
+// badge on the page down with it.
+const COMMENT_COUNTS_BATCH_SIZE = 200;
+
+// ── Wire shapes (directory backend) ──────────────────────────────────────────
+// Deliberately local: the moment these leak upward, every component has to care
+// that news comments say `newsItemUid` and forum comments have no such concept.
+
+interface IFeedCommentWire {
+  uid: string;
+  newsItemUid: string;
+  parentUid: string | null;
+  text: string;
+  author: { uid: string; name: string | null; avatarUrl: string | null };
+  createdAt: string;
+  isOwn: boolean;
+  replies: IFeedCommentWire[];
 }
 
+function toFeedComment(wire: IFeedCommentWire): IFeedComment {
+  return {
+    uid: wire.uid,
+    itemUid: wire.newsItemUid,
+    parentUid: wire.parentUid ?? null,
+    author: {
+      uid: wire.author?.uid ?? '',
+      name: wire.author?.name ?? null,
+      avatarUrl: wire.author?.avatarUrl ?? null,
+    },
+    text: wire.text,
+    createdAt: wire.createdAt,
+    isOwn: Boolean(wire.isOwn),
+    // The backend nests to unlimited depth; capping is a display concern.
+    replies: (wire.replies ?? []).map(toFeedComment),
+  };
+}
+
+// ── Forum posts (NodeBB) ─────────────────────────────────────────────────────
+
+function tidFromForumPostUid(uid: ForumPostUid): number {
+  return Number(uid.slice('fp_'.length));
+}
+
+function toFeedForumPost(topic: Topic): IFeedForumPost {
+  const user = topic.user;
+
+  return {
+    uid: `fp_${topic.tid}`,
+    tid: topic.tid,
+    mainPid: topic.mainPid,
+    title: stripHtml(topic.titleRaw || topic.title || ''),
+    body: stripHtml(topic.teaser?.content || ''),
+    author: {
+      memberUid: user?.memberUid ?? '',
+      name: user?.displayname || user?.username || 'Unknown',
+      avatarUrl: user?.picture ?? null,
+      role: user?.teamRole ?? null,
+    },
+    // NodeBB categories don't map onto the feed's focus-area tabs, and there is
+    // no focusAreas field to map from — posts show in every tab.
+    focusAreas: [],
+    category: topic.category?.name ?? '',
+    createdAt: new Date(Number(topic.timestamp) || Date.now()).toISOString(),
+    forumTopicUrl: `/forum/topics/${topic.cid}/${topic.tid}`,
+    // postcount includes the topic's own opening post, which is the post itself
+    // rather than a comment on it.
+    commentCount: Math.max(0, (Number(topic.postcount) || 0) - 1),
+    likeCount: Number(topic.upvotes) || 0,
+    // /api/recent is a listing with no per-viewer vote state. The modal corrects
+    // this from the topic's own post once a thread is opened.
+    viewerHasLiked: false,
+  };
+}
+
+export async function getFeedForumPosts(): Promise<IFeedForumPostsResponse> {
+  const response = await forumFetch('/api/recent');
+  if (!response?.ok) throw new Error('Failed to fetch feed forum posts');
+
+  const data = await response.json();
+  const topics = Array.isArray(data?.topics) ? (data.topics as Topic[]) : [];
+
+  return { items: topics.map(toFeedForumPost) };
+}
+
+// PUT adds a vote (NodeBB write API v3), DELETE removes it — the symmetric pair
+// of services/forum/hooks/useLikePost.ts's PUT, which only ever likes. The vote
+// target is the topic's opening post, carried on the post itself.
+export async function toggleFeedForumPostLike(
+  post: Pick<IFeedForumPost, 'mainPid' | 'likeCount'>,
+  isLiked: boolean,
+): Promise<IFeedForumPostLikeStatus> {
+  const response = await forumFetch(`/api/v3/posts/${post.mainPid}/vote`, {
+    method: isLiked ? 'PUT' : 'DELETE',
+    ...(isLiked ? { body: JSON.stringify({ delta: 1 }) } : {}),
+  });
+  if (!response?.ok) throw new Error('Failed to toggle feed forum post like');
+
+  // NodeBB's vote endpoint doesn't return an updated tally, so the count is
+  // adjusted from what we last read. It is corrected on the next real fetch —
+  // the same session-frozen-list assumption useFeedForumPosts already makes.
+  return {
+    likeCount: isLiked ? post.likeCount + 1 : Math.max(0, post.likeCount - 1),
+    viewerHasLiked: isLiked,
+  };
+}
+
+// ── Comment counts ───────────────────────────────────────────────────────────
+
 // Public endpoint (signed-out visitors see news comment counts), but the token
-// is still sent when present — counts for fp_ uids are only included for
-// viewers with forum.read.
+// is still sent when present so `isOwn` and any access-scoped rows resolve.
 export async function getFeedCommentCounts(uids: string[], authToken?: string): Promise<IFeedCommentCountsResponse> {
+  // Forum-post counts come from the posts response, not from here — the
+  // directory backend only knows about news items now.
+  const newsUids = uids.filter((uid) => !isForumPostUid(uid));
+  if (newsUids.length === 0) return {};
+
+  const batches: string[][] = [];
+  for (let i = 0; i < newsUids.length; i += COMMENT_COUNTS_BATCH_SIZE) {
+    batches.push(newsUids.slice(i, i + COMMENT_COUNTS_BATCH_SIZE));
+  }
+
+  const results = await Promise.all(batches.map((batch) => fetchCommentCountBatch(batch, authToken)));
+
+  return Object.assign({}, ...results) as IFeedCommentCountsResponse;
+}
+
+async function fetchCommentCountBatch(uids: string[], authToken?: string): Promise<IFeedCommentCountsResponse> {
   // POST body, not query string — a 14-day news window can exceed URL limits.
   const response = await fetch(`${process.env.DIRECTORY_API_URL}/v1/feed/comments/counts`, {
     method: 'POST',
@@ -40,29 +167,49 @@ export async function getFeedCommentCounts(uids: string[], authToken?: string): 
     body: JSON.stringify({ uids }),
   });
   if (!response.ok) throw new Error('Failed to fetch feed comment counts');
+
   const { counts } = (await response.json()) as { counts: IFeedCommentCountsResponse };
-  return counts;
+  return counts ?? {};
 }
 
-// Public for news uids; fp_ itemUids 404 without forum.read (indistinguishable
-// from nonexistent — the UI never reaches here for posts the viewer can't see).
+// ── Comments ─────────────────────────────────────────────────────────────────
+
 export async function getFeedComments(itemUid: string, authToken?: string): Promise<IFeedCommentsResponse> {
-  const response = await fetch(
-    `${process.env.DIRECTORY_API_URL}/v1/feed/comments?itemUid=${encodeURIComponent(itemUid)}`,
-    { headers: getHeader(authToken) },
-  );
+  if (isForumPostUid(itemUid)) return getForumPostComments(itemUid);
+
+  // Both names are sent on purpose: BE #3293 renamed `itemUid` to
+  // `newsItemUid`, and both versions of the schema drop unknown keys, so this
+  // one request is valid against either — the frontend and backend can deploy
+  // in any order. Drop `itemUid` once #3293 is in production.
+  const params = new URLSearchParams({ newsItemUid: itemUid, itemUid });
+  const response = await fetch(`${process.env.DIRECTORY_API_URL}/v1/feed/comments?${params.toString()}`, {
+    headers: getHeader(authToken),
+  });
   if (!response.ok) throw new Error('Failed to fetch feed comments');
-  return (await response.json()) as IFeedCommentsResponse;
+
+  const { items } = (await response.json()) as { items: IFeedCommentWire[] };
+  return { items: (items ?? []).map(toFeedComment) };
 }
 
 export async function createFeedComment(request: ICreateFeedCommentRequest): Promise<IFeedComment> {
   const response = await customFetch(
     `${process.env.DIRECTORY_API_URL}/v1/feed/comments`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(request) },
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // Same dual-name insurance as the read above.
+      body: JSON.stringify({
+        newsItemUid: request.itemUid,
+        itemUid: request.itemUid,
+        ...(request.parentUid ? { parentUid: request.parentUid } : {}),
+        text: request.text,
+      }),
+    },
     true,
   );
   if (!response?.ok) throw new Error('Failed to post feed comment');
-  return (await response.json()) as IFeedComment;
+
+  return toFeedComment((await response.json()) as IFeedCommentWire);
 }
 
 // 404 (already deleted — e.g. a double-delete from two tabs) is mapped to the
@@ -76,15 +223,65 @@ export async function deleteFeedComment(commentUid: string): Promise<IFeedCommen
   );
   if (response?.status === 404) return { uid: commentUid, deleted: true };
   if (!response?.ok) throw new Error('Failed to delete feed comment');
+
   return (await response.json()) as IFeedCommentDeleteResponse;
 }
 
-export async function toggleFeedForumPostLike(uid: string, isLiked: boolean): Promise<IFeedForumPostLikeStatus> {
-  const response = await customFetch(
-    `${process.env.DIRECTORY_API_URL}/v1/feed/forum-posts/${encodeURIComponent(uid)}/like`,
-    { method: isLiked ? 'POST' : 'DELETE', headers: { 'Content-Type': 'application/json' } },
-    true,
-  );
-  if (!response?.ok) throw new Error('Failed to toggle feed forum post like');
-  return (await response.json()) as IFeedForumPostLikeStatus;
+// ── Forum post comments (NodeBB) ─────────────────────────────────────────────
+//
+// A forum post's comments are its REAL topic replies, read straight from the
+// forum — the directory backend refuses to store comments against forum content
+// (FeedComment hard-FKs TeamNewsItem as of BE #3293).
+
+type TopicPost = TopicResponse['posts'][number];
+
+function forumCommentUid(pid: number): string {
+  return `fpc_${pid}`;
+}
+
+function toForumFeedComment(post: TopicPost, itemUid: ForumPostUid, mainPid: number): IFeedComment {
+  const user = post.user;
+  const parentPid = post.parent?.pid;
+
+  return {
+    uid: forumCommentUid(post.pid),
+    itemUid,
+    // A reply to the topic's opening post is a top-level comment here — the
+    // opening post is the feed card, not a comment on it.
+    parentUid: parentPid && parentPid !== mainPid ? forumCommentUid(parentPid) : null,
+    author: {
+      uid: user?.memberUid ?? '',
+      name: user?.displayname || user?.username || null,
+      avatarUrl: user?.picture ?? null,
+      role: user?.teamRole ?? null,
+    },
+    text: stripHtml(post.content ?? ''),
+    createdAt: new Date(Number(post.timestamp) || Date.now()).toISOString(),
+    // Deleting a real NodeBB reply from the feed isn't implemented, so the
+    // delete affordance is never offered — regardless of who wrote it.
+    isOwn: false,
+    replies: [],
+  };
+}
+
+async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedCommentsResponse> {
+  const response = await forumFetch(`/api/topic/${tidFromForumPostUid(itemUid)}`);
+  if (!response?.ok) throw new Error('Failed to fetch feed comments');
+
+  const topic = (await response.json()) as TopicResponse;
+  const posts = Array.isArray(topic?.posts) ? topic.posts : [];
+  // posts[0] is the topic's own opening post rather than a reply to it — the
+  // same slice the /forum page takes (components/page/forum/Post/Post.tsx).
+  const replies = posts.slice(1);
+
+  return {
+    items: buildCommentTree<TopicPost, IFeedComment>({
+      items: replies,
+      idOf: (post) => post.pid,
+      // A parent that isn't in this page of replies (the opening post, or a
+      // reply further up a paginated thread) resolves to a root.
+      parentIdOf: (post) => post.parent?.pid,
+      makeNode: (post) => toForumFeedComment(post, itemUid, topic.mainPid),
+    }),
+  };
 }

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -325,7 +325,7 @@ async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedComment
   const posts = Array.isArray(topic?.posts) ? topic.posts : [];
   // posts[0] is the topic's own opening post rather than a reply to it — the
   // same slice the /forum page takes (components/page/forum/Post/Post.tsx).
-  const replies = posts.slice(1);
+  const [mainPost, ...replies] = posts;
 
   return {
     items: buildCommentTree<TopicPost, IFeedComment>({
@@ -336,5 +336,18 @@ async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedComment
       parentIdOf: (post) => post.parent?.pid,
       makeNode: (post) => toForumFeedComment(post, itemUid, topic.mainPid),
     }),
+    forumTopic: {
+      url: topic.cid ? `/forum/topics/${topic.cid}/${tidFromForumPostUid(itemUid)}` : null,
+      // NodeBB serves one page of posts per request, so `replies` is often a
+      // subset of this — the difference is what the link-out exists for.
+      totalReplyCount: Math.max(0, (Number(topic.postcount) || 0) - 1),
+      // Read off the opening post, since that's what a forum card's Like votes
+      // on. This is the only place the viewer's own vote state is available:
+      // /api/recent, which builds the card, has no per-viewer state at all.
+      like: {
+        likeCount: Number(mainPost?.upvotes) || 0,
+        viewerHasLiked: Boolean(mainPost?.upvoted),
+      },
+    },
   };
 }

--- a/services/feed/hooks/useAddFeedComment.ts
+++ b/services/feed/hooks/useAddFeedComment.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { IFeedComment, IFeedCommentCountsResponse, IFeedCommentsResponse } from '@/types/feed.types';
+import { insertCommentIntoTree } from '@/utils/comments';
 import { feedQueryKeys } from '../constants';
 import { createFeedComment } from '../feed.service';
 
@@ -22,9 +23,9 @@ import { createFeedComment } from '../feed.service';
 export function useAddFeedComment(itemUid: string) {
   const queryClient = useQueryClient();
 
-  return useMutation<IFeedComment, Error, { text: string }>({
+  return useMutation<IFeedComment, Error, { text: string; parentUid?: string }>({
     scope: { id: `feed-comment-${itemUid}` },
-    mutationFn: ({ text }) => createFeedComment({ itemUid, text }),
+    mutationFn: ({ text, parentUid }) => createFeedComment({ itemUid, parentUid, text }),
     onSuccess: async (created) => {
       // Cancel BEFORE writing — an in-flight thread/counts refetch whose server
       // snapshot predates this POST would clobber the append when it lands.
@@ -32,11 +33,12 @@ export function useAddFeedComment(itemUid: string) {
         queryClient.cancelQueries({ queryKey: feedQueryKeys.comments(itemUid) }),
         queryClient.cancelQueries({ queryKey: feedQueryKeys.commentCounts() }),
       ]);
-      // Comments are oldest-first — a fresh comment belongs at the END of the
-      // list, not the front (the mock's newest-first assumption doesn't hold
-      // against the real API).
+      // Comments are oldest-first, so a fresh one belongs at the END of its
+      // level — and a REPLY belongs under its parent at any depth, not appended
+      // to the root list (which would silently promote it to a top-level
+      // comment until the next refetch).
       queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), (old) =>
-        old ? { items: [...old.items, created] } : { items: [created] },
+        old ? { items: insertCommentIntoTree(old.items, created) } : { items: [created] },
       );
       queryClient.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), (old) =>
         old ? { ...old, [itemUid]: (old[itemUid] ?? 0) + 1 } : { [itemUid]: 1 },

--- a/services/feed/hooks/useAddFeedComment.ts
+++ b/services/feed/hooks/useAddFeedComment.ts
@@ -20,12 +20,15 @@ import { createFeedComment } from '../feed.service';
 // invalidateQueries here (or in the like toggle): a refetch racing the patch
 // is the "comment that vanishes" bug; if the real-API swap ever adds an
 // onSettled invalidation, guard it with isMutating({scope}) === 1.
-export function useAddFeedComment(itemUid: string) {
+// `forumMainPid` is the topic's opening post, which a top-level comment on a
+// forum post replies to. Passed in by the surface that already has the post so
+// the write costs one request; ignored entirely for news items.
+export function useAddFeedComment(itemUid: string, forumMainPid?: number) {
   const queryClient = useQueryClient();
 
   return useMutation<IFeedComment, Error, { text: string; parentUid?: string }>({
     scope: { id: `feed-comment-${itemUid}` },
-    mutationFn: ({ text, parentUid }) => createFeedComment({ itemUid, parentUid, text }),
+    mutationFn: ({ text, parentUid }) => createFeedComment({ itemUid, parentUid, text, forumMainPid }),
     onSuccess: async (created) => {
       // Cancel BEFORE writing — an in-flight thread/counts refetch whose server
       // snapshot predates this POST would clobber the append when it lands.

--- a/services/feed/hooks/useDeleteFeedComment.ts
+++ b/services/feed/hooks/useDeleteFeedComment.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { IFeedCommentCountsResponse, IFeedCommentDeleteResponse, IFeedCommentsResponse } from '@/types/feed.types';
+import { removeCommentFromTree } from '@/utils/comments';
 import { feedQueryKeys } from '../constants';
 import { deleteFeedComment } from '../feed.service';
 
@@ -22,12 +23,22 @@ export function useDeleteFeedComment(itemUid: string) {
         queryClient.cancelQueries({ queryKey: feedQueryKeys.comments(itemUid) }),
         queryClient.cancelQueries({ queryKey: feedQueryKeys.commentCounts() }),
       ]);
-      queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), (old) =>
-        old ? { items: old.items.filter((c) => c.uid !== commentUid) } : old,
-      );
-      queryClient.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), (old) =>
-        old ? { ...old, [itemUid]: Math.max(0, (old[itemUid] ?? 0) - 1) } : old,
-      );
+      // The backend cascades: deleting a comment deletes its replies too. So the
+      // whole subtree comes out of the thread, and the count drops by its size —
+      // decrementing by 1 would leave the badge permanently overstated.
+      // `removedCount` is 0 when the comment wasn't cached (a stale delete from
+      // another tab), which correctly leaves the count alone.
+      const cached = queryClient.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid));
+      const { items, removedCount } = cached
+        ? removeCommentFromTree(cached.items, commentUid)
+        : { items: [], removedCount: 0 };
+
+      if (cached) queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), { items });
+      if (removedCount > 0) {
+        queryClient.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), (old) =>
+          old ? { ...old, [itemUid]: Math.max(0, (old[itemUid] ?? 0) - removedCount) } : old,
+        );
+      }
     },
   });
 }

--- a/services/feed/hooks/useFeedComments.ts
+++ b/services/feed/hooks/useFeedComments.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import type { IFeedCommentsResponse } from '@/types/feed.types';
+import { skipToken, useQuery } from '@tanstack/react-query';
+import type { IFeedCommentsResponse, IFeedForumPostLikeStatus } from '@/types/feed.types';
 import { getCookiesFromClient } from '@/utils/third-party.helper';
 import { FEED_COMMENTS_STALE_TIME, feedQueryKeys } from '../constants';
 import { getFeedComments } from '../feed.service';
@@ -19,4 +19,20 @@ export function useFeedComments(itemUid: string, { enabled }: { enabled: boolean
     staleTime: FEED_COMMENTS_STALE_TIME,
     refetchOnWindowFocus: false,
   });
+}
+
+// A forum post's Like starts out blind: /api/recent builds the card and carries
+// no per-viewer vote state, so `viewerHasLiked` is false until something says
+// otherwise. Opening the thread fetches the topic, which does know — this
+// observes that same cache entry (skipToken = observe only, never fetch) and
+// narrows to the vote state with `select`, the same pattern the per-button
+// comment counts use, so the feed doesn't re-render when comments load.
+export function useFeedForumTopicLike(itemUid: string | null): IFeedForumPostLikeStatus | undefined {
+  const { data } = useQuery<IFeedCommentsResponse, Error, IFeedForumPostLikeStatus | undefined>({
+    queryKey: feedQueryKeys.comments(itemUid ?? ''),
+    queryFn: skipToken,
+    select: (response) => response.forumTopic?.like,
+    enabled: Boolean(itemUid),
+  });
+  return data;
 }

--- a/services/feed/hooks/useFeedForumPostLikeToggle.ts
+++ b/services/feed/hooks/useFeedForumPostLikeToggle.ts
@@ -1,17 +1,23 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import type { ForumPostUid, IFeedForumPostLikeStatus } from '@/types/feed.types';
+import type { IFeedForumPost, IFeedForumPostLikeStatus } from '@/types/feed.types';
 import { toggleFeedForumPostLike } from '../feed.service';
 
-// `isLiked` is the desired next state — true POSTs a like, false DELETEs it.
-export type LikeToggleAction = { uid: ForumPostUid; isLiked: boolean };
+// `isLiked` is the desired next state — true adds the vote, false removes it.
+// The whole post travels (not just its uid) because the vote goes straight to
+// NodeBB now: it needs the topic's `mainPid` as the vote target, and the current
+// `likeCount` to derive the new tally NodeBB doesn't return.
+export type LikeToggleAction = {
+  post: Pick<IFeedForumPost, 'mainPid' | 'likeCount'>;
+  isLiked: boolean;
+};
 
 // Bare mutation, mirroring useTeamNewsUpvoteToggle: optimism lives in a
 // render-time overlay in the component (never the query cache, so the
 // session-frozen post list can't reorder), rollback in the caller's onError.
 export function useFeedForumPostLikeToggle() {
   return useMutation<IFeedForumPostLikeStatus, Error, LikeToggleAction>({
-    mutationFn: ({ uid, isLiked }) => toggleFeedForumPostLike(uid, isLiked),
+    mutationFn: ({ post, isLiked }) => toggleFeedForumPostLike(post, isLiked),
   });
 }

--- a/services/forum/forum.service.ts
+++ b/services/forum/forum.service.ts
@@ -29,3 +29,56 @@ export function forumFetch(path: string, init: RequestInit = {}) {
     !token,
   );
 }
+
+export interface PostForumReplyParams {
+  tid: number;
+  /** The post being replied to: a topic's `mainPid` for a top-level reply, or
+   *  another reply's `pid` to nest under it. */
+  toPid: number;
+  /** HTML — NodeBB stores post content as markup. */
+  content: string;
+}
+
+/**
+ * Post a reply to a topic. Shared by the /forum page's composer and the /home
+ * feed's forum-post thread, which write the same reply through the same route.
+ *
+ * Throws with NodeBB's own message when it has one. Callers should route that
+ * through `forumErrorMessage` before showing it: NodeBB frequently answers with
+ * an untranslated `[[error:…]]` key.
+ */
+export async function postForumReply({ tid, toPid, content }: PostForumReplyParams) {
+  const response = await forumFetch(`/api/v3/topics/${tid}`, {
+    method: 'POST',
+    body: JSON.stringify({ content, toPid }),
+  });
+
+  if (!response?.ok) {
+    const body = await response?.json().catch(() => undefined);
+    throw new Error(body?.status?.message || 'Failed to add comment');
+  }
+
+  return await response.json();
+}
+
+/**
+ * NodeBB's rejections are often translation KEYS, not sentences —
+ * `[[error:content-too-short, Content too short]]`, `[[error:too-many-posts]]`.
+ * Showing one raw is worse than showing nothing, so anything still in that form
+ * is replaced with the caller's fallback.
+ *
+ * Two rejections members hit routinely and cannot diagnose from a generic
+ * message get spelled out instead: NodeBB's `minimumPostLength` (8 characters
+ * by default, so "nice!" is refused) and its post-rate limit.
+ */
+export function forumErrorMessage(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : '';
+  if (!raw) return fallback;
+
+  if (/content-too-short|too-short/i.test(raw)) return 'That’s too short for the forum — try a few more words.';
+  if (/too-many-posts|rate-limit/i.test(raw)) return 'You’re posting a little fast for the forum — try again shortly.';
+  if (/no-privileges|not-allowed|privileges/i.test(raw)) return 'You don’t have permission to reply on the forum.';
+
+  // Any remaining bracketed key is machine text, not a message for a member.
+  return /^\[\[.*\]\]$/.test(raw.trim()) || raw.includes('[[') ? fallback : raw;
+}

--- a/services/forum/forum.service.ts
+++ b/services/forum/forum.service.ts
@@ -39,13 +39,27 @@ export interface PostForumReplyParams {
   content: string;
 }
 
+/** A forum write that was refused, carrying the HTTP status so callers can tell
+ *  "you're not signed in to the forum" apart from "the forum didn't like this". */
+export class ForumWriteError extends Error {
+  constructor(
+    readonly status: number | undefined,
+    /** The forum's own message, when it sent one. Never invented. */
+    readonly forumMessage: string | undefined,
+  ) {
+    super(forumMessage ?? `Forum write failed${status ? ` (${status})` : ''}`);
+    this.name = 'ForumWriteError';
+  }
+}
+
 /**
  * Post a reply to a topic. Shared by the /forum page's composer and the /home
  * feed's forum-post thread, which write the same reply through the same route.
  *
- * Throws with NodeBB's own message when it has one. Callers should route that
- * through `forumErrorMessage` before showing it: NodeBB frequently answers with
- * an untranslated `[[error:…]]` key.
+ * Rejections throw a ForumWriteError; run it through `forumErrorMessage` before
+ * showing anything to a member. Not every failure comes from NodeBB itself — an
+ * auth layer in front of it answers 401 `{"error":"Invalid token"}`, which has
+ * none of NodeBB's error shape — so the status matters as much as the message.
  */
 export async function postForumReply({ tid, toPid, content }: PostForumReplyParams) {
   const response = await forumFetch(`/api/v3/topics/${tid}`, {
@@ -55,29 +69,42 @@ export async function postForumReply({ tid, toPid, content }: PostForumReplyPara
 
   if (!response?.ok) {
     const body = await response?.json().catch(() => undefined);
-    throw new Error(body?.status?.message || 'Failed to add comment');
+    throw new ForumWriteError(response?.status, body?.status?.message ?? body?.error);
   }
 
   return await response.json();
 }
 
 /**
+ * Turn a forum rejection into something worth showing a member.
+ *
  * NodeBB's rejections are often translation KEYS, not sentences —
  * `[[error:content-too-short, Content too short]]`, `[[error:too-many-posts]]`.
  * Showing one raw is worse than showing nothing, so anything still in that form
- * is replaced with the caller's fallback.
+ * is replaced with the caller's fallback, and so is any message we made up
+ * ourselves rather than received.
  *
- * Two rejections members hit routinely and cannot diagnose from a generic
- * message get spelled out instead: NodeBB's `minimumPostLength` (8 characters
- * by default, so "nice!" is refused) and its post-rate limit.
+ * Rejections members hit routinely and cannot diagnose from a generic line get
+ * spelled out: NodeBB's `minimumPostLength` (8 characters by default, so
+ * "nice!" is refused), its post-rate limit, and a rejected session — which in
+ * practice means an expired forum token, and is otherwise indistinguishable from
+ * the composer just not working.
  */
 export function forumErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ForumWriteError) {
+    if (error.status === 401) return 'The forum didn’t accept your session — try signing in again.';
+    if (error.status === 403) return 'You don’t have permission to reply on the forum.';
+    // Anything we synthesised is internal wording, not a message for a member.
+    if (!error.forumMessage) return fallback;
+  }
+
   const raw = error instanceof Error ? error.message : '';
   if (!raw) return fallback;
 
   if (/content-too-short|too-short/i.test(raw)) return 'That’s too short for the forum — try a few more words.';
   if (/too-many-posts|rate-limit/i.test(raw)) return 'You’re posting a little fast for the forum — try again shortly.';
   if (/no-privileges|not-allowed|privileges/i.test(raw)) return 'You don’t have permission to reply on the forum.';
+  if (/invalid token|unauthori[sz]ed/i.test(raw)) return 'The forum didn’t accept your session — try signing in again.';
 
   // Any remaining bracketed key is machine text, not a message for a member.
   return /^\[\[.*\]\]$/.test(raw.trim()) || raw.includes('[[') ? fallback : raw;

--- a/services/forum/forum.service.ts
+++ b/services/forum/forum.service.ts
@@ -1,0 +1,31 @@
+import { customFetch } from '@/utils/fetch-wrapper';
+
+/**
+ * One place that knows how to call NodeBB.
+ *
+ * Every forum hook was repeating the same four lines (base URL, JSON header,
+ * optional `CUSTOM_FORUM_AUTH_TOKEN` bearer, `credentials: 'include'`, and the
+ * "send the directory token only when there's no forum token" rule). The feed
+ * now calls NodeBB too — the directory backend stopped proxying forum posts in
+ * BE PR #3293 — so this is shared rather than copied a fifth time.
+ *
+ * Returns customFetch's response, which may be `undefined` when the wrapper
+ * logs the user out mid-flight: callers must guard with `response?.ok`.
+ */
+export function forumFetch(path: string, init: RequestInit = {}) {
+  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
+
+  return customFetch(
+    `${process.env.FORUM_API_URL}${path}`,
+    {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...init.headers,
+      },
+      credentials: 'include',
+    },
+    !token,
+  );
+}

--- a/services/forum/hooks/useForumPost.ts
+++ b/services/forum/hooks/useForumPost.ts
@@ -1,6 +1,6 @@
-import { customFetch } from '@/utils/fetch-wrapper';
 import { useQuery } from '@tanstack/react-query';
 import { ForumQueryKeys } from '@/services/forum/constants';
+import { forumFetch } from '@/services/forum/forum.service';
 
 export type TopicResponse = {
   tid: 0;
@@ -244,18 +244,7 @@ export type TopicResponse = {
 };
 
 export async function fetcher(tid: string) {
-  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
-  const response = await customFetch(
-    `${process.env.FORUM_API_URL}/api/topic/${tid}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      credentials: 'include',
-    },
-    !token,
-  );
+  const response = await forumFetch(`/api/topic/${tid}`);
 
   if (!response?.ok) {
     return null;

--- a/services/forum/hooks/usePostComment.ts
+++ b/services/forum/hooks/usePostComment.ts
@@ -1,46 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { customFetch } from '@/utils/fetch-wrapper';
 import { ForumQueryKeys } from '@/services/forum/constants';
+import { postForumReply, type PostForumReplyParams } from '@/services/forum/forum.service';
 
-export interface PostCommentMutationParams {
-  tid: number;
-  toPid: number;
-  content: string;
-}
-
-async function mutation({ tid, toPid, content }: PostCommentMutationParams) {
-  const token = process.env.CUSTOM_FORUM_AUTH_TOKEN;
-
-  const response = await customFetch(
-    `${process.env.FORUM_API_URL}/api/v3/topics/${tid}`,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        content,
-        toPid,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      credentials: 'include',
-    },
-    !token,
-  );
-
-  if (!response?.ok) {
-    const res = await response?.json();
-    throw new Error(res?.status.message || 'Failed to add comment');
-  }
-
-  return await response.json();
-}
+export type PostCommentMutationParams = PostForumReplyParams;
 
 export function usePostComment() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: mutation,
+    mutationFn: postForumReply,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [ForumQueryKeys.GET_TOPICS],

--- a/types/feed.types.ts
+++ b/types/feed.types.ts
@@ -112,11 +112,26 @@ export interface IFeedForumPostsResponse {
   items: IFeedForumPost[];
 }
 
+/** What the forum can tell us about a topic that its reply list alone can't.
+ *  Present only for forum posts, where the thread comes from NodeBB. */
+export interface IFeedForumTopicMeta {
+  /** In-app path to the topic, for "see the rest of this on the forum". */
+  url: string | null;
+  /** Replies the topic actually has, at any depth. NodeBB serves one page of
+   *  posts per request, so this can exceed the number in `items`. */
+  totalReplyCount: number;
+  /** The topic's own vote state, which the /api/recent listing doesn't carry —
+   *  the only way a forum card can learn whether the viewer already liked it. */
+  like: IFeedForumPostLikeStatus;
+}
+
 /** Top-level comments, oldest first, each with its own `replies`. No `total`
  *  field: every consumer derives counts from the tree rather than maintaining a
  *  second counter in lockstep. */
 export interface IFeedCommentsResponse {
   items: IFeedComment[];
+  /** Forum posts only. */
+  forumTopic?: IFeedForumTopicMeta;
 }
 
 /** Keyed by item uid. A uid the server omitted means "unknown" and must render

--- a/types/feed.types.ts
+++ b/types/feed.types.ts
@@ -1,12 +1,26 @@
-// Wire contract for the /home feed's social layer (forum posts interleaved with
-// team news + feed-only comments). Live per docs/NEWSFEED_FORUM_POSTS.md
-// (LAB-2175, memser-spaceport/pln-directory-portal) — see
-// docs/plans/2026-07-28-feat-newsfeed-forum-posts-real-api-plan.md for the
-// mock-to-real integration.
+// The /home feed's social layer: forum posts interleaved with team news, plus
+// comment threads on both.
 //
-// Field-nullability rule for this contract: `| null` = the server always sends
-// the field but it may be null; `?` is reserved for fields that genuinely don't
-// ship yet. No optional fields unless deferred.
+// These are the FRONTEND's own shapes, not a wire echo — deliberately, because
+// the feed now draws one UI from two unrelated backends:
+//
+//   - team news comments  → the directory backend (/v1/feed/comments), which
+//     returns an already-nested tree keyed on `newsItemUid`/`parentUid`
+//   - forum post comments → NodeBB directly (/api/topic/:tid), which returns a
+//     FLAT post list nested on `parent.pid`
+//
+// Neither wire shape can serve the other, so both are mapped into the types
+// below at the service boundary (services/feed/feed.service.ts). That is also
+// why the field here is `itemUid`, not the backend's `newsItemUid`: it holds a
+// news uid OR a ForumPostUid, and `newsItemUid` would be a lie for half of them.
+//
+// See docs/NEWSFEED_FORUM_POSTS.md in memser-spaceport/pln-directory-portal
+// (BE PR #3293) for the wire contract, and
+// docs/plans/2026-07-30-feat-newsfeed-forum-comments-replies-plan.md for the
+// integration.
+//
+// Field-nullability rule: `| null` = the field is always present but may be
+// null; `?` is reserved for fields that genuinely don't exist on every source.
 
 /** Contract guarantee: forum-post uids are 'fp_'-prefixed — never collide with
  *  news uids, so both kinds share one comment/deep-link namespace safely. */
@@ -16,6 +30,8 @@ export function isForumPostUid(uid: string): uid is ForumPostUid {
   return uid.startsWith('fp_');
 }
 
+/** Author of a forum POST (not a comment). NodeBB supplies the member link and
+ *  a composed role for these, so they stay richer than comment authors. */
 export interface IFeedAuthor {
   memberUid: string;
   name: string;
@@ -24,22 +40,44 @@ export interface IFeedAuthor {
   role: string | null;
 }
 
+/** Author of a COMMENT. The directory backend sends `{uid, name, avatarUrl}`
+ *  and nothing else — `name` really can be null, and there is no role. */
+export interface IFeedCommentAuthor {
+  uid: string;
+  name: string | null;
+  avatarUrl: string | null;
+  /** NodeBB-sourced comments only (from `user.teamRole`); absent on news
+   *  comments, which the directory backend gives us no role for. */
+  role?: string | null;
+}
+
 export interface IFeedForumPost {
   uid: ForumPostUid;
-  /** Server-side derived PLAIN TEXT (NodeBB HTML stripped + entities decoded).
+  /** NodeBB topic id — the uid's numeric half, kept as a field so callers never
+   *  parse the uid, and so votes/replies have a target without a lookup. */
+  tid: number;
+  /** The topic's own opening post. Vote target for the post's Like, and the
+   *  default reply target for a top-level comment. */
+  mainPid: number;
+  /** PLAIN TEXT (NodeBB HTML stripped + entities decoded by the service).
    *  Never raw or rendered HTML — rich content would be a new field with its
    *  own sanitization contract. Same rule for `body`. */
   title: string;
   body: string;
   author: IFeedAuthor;
-  /** Aligns the post with the feed's focus-area tabs (same titles as news). */
+  /** Aligns the post with the feed's focus-area tabs (same titles as news).
+   *  NodeBB has no equivalent, so this is always empty today. */
   focusAreas: string[];
   /** Forum category label, shown where news shows its event type. */
   category: string;
   createdAt: string;
-  /** Origin NodeBB topic link (display only — feed comments never sync to it).
-   *  Absolute https URL on the forum host, or null. */
+  /** In-app path to the origin topic (`/forum/topics/:cid/:tid`), for "view the
+   *  full discussion" — same form CreatePost builds. Not an absolute URL, so
+   *  it's never what gets shared; the share menu links to `/home?post=`. */
   forumTopicUrl: string | null;
+  /** Replies to the topic at any depth (NodeBB's postcount minus the opening
+   *  post). May exceed the number of comments a single page can show — see
+   *  getFeedComments. */
   commentCount: number;
   likeCount: number;
   viewerHasLiked: boolean;
@@ -49,54 +87,61 @@ export interface IFeedComment {
   uid: string;
   /** News uid or ForumPostUid the comment hangs off. */
   itemUid: string;
-  author: IFeedAuthor;
-  /** Plain text, server-capped at FEED_COMMENT_MAX_LENGTH. */
+  /** Parent comment uid, or null for a top-level comment. */
+  parentUid: string | null;
+  author: IFeedCommentAuthor;
+  /** Plain text, capped at FEED_COMMENT_MAX_LENGTH. */
   text: string;
   createdAt: string;
   /** True only for the authenticated caller's own comments (always false for
-   *  anonymous requests) — gates the delete affordance. Rendered straight off
-   *  the server payload, no overlay: unlike likes, comments never feed
+   *  anonymous requests, and always false for NodeBB-sourced comments, which
+   *  have no delete path) — gates the delete affordance. Rendered straight off
+   *  the payload, no overlay: unlike likes, comments never feed
    *  mergeFeedEntries' rank-merge, so there's no reordering risk to guard
    *  against by mutating the cache indirectly. */
   isOwn: boolean;
+  /** Direct replies, oldest first. Nesting is UNLIMITED on the wire — the
+   *  directory backend's `parentUid` is a plain self-relation — so display
+   *  depth is capped separately by clampDepth, never assumed here. */
+  replies: IFeedComment[];
 }
 
-// GET /v1/feed/forum-posts — optional auth. Anonymous or no forum.read →
-// {items: []} (200, never 403) — the client can't distinguish "no access" from
-// "no posts" and doesn't try to; both render as an empty forum-post lane.
+/** Forum posts are sourced live from NodeBB's GET /api/recent by
+ *  getFeedForumPosts — never stored or proxied by the directory backend. */
 export interface IFeedForumPostsResponse {
   items: IFeedForumPost[];
 }
 
-// GET /v1/feed/comments?itemUid=x — public for news uids; fp_ uids require
-// forum.read and 404 indistinguishably otherwise. Oldest first (thread reading
-// order) — no `total` field; every consumer derives the count from
-// `items.length` instead of maintaining a second counter in lockstep.
+/** Top-level comments, oldest first, each with its own `replies`. No `total`
+ *  field: every consumer derives counts from the tree rather than maintaining a
+ *  second counter in lockstep. */
 export interface IFeedCommentsResponse {
   items: IFeedComment[];
 }
 
-// POST /v1/feed/comments/counts { uids } — public; counts for fp_ uids are
-// omitted (not zeroed) unless the caller has forum.read. Keys are item uids.
+/** Keyed by item uid. A uid the server omitted means "unknown" and must render
+ *  as no number, never a fake 0. */
 export type IFeedCommentCountsResponse = Record<string, number>;
 
-// POST /v1/feed/comments — member JWT; fp_ itemUids additionally require
-// forum.read (visibility implies commentability). Feed-only: never creates or
-// updates a NodeBB thread reply.
+/** Internal request shape. The service translates it per backend: a
+ *  `newsItemUid`/`parentUid` body for news, a NodeBB `toPid` reply for posts. */
 export interface ICreateFeedCommentRequest {
   itemUid: string;
+  /** Reply target; omitted for a top-level comment. */
+  parentUid?: string;
   text: string;
 }
 
-// DELETE /v1/feed/comments/:commentUid — member JWT, author-only (403
-// otherwise). Idempotent from the client's perspective: a 404 (already
-// deleted, e.g. a double-delete from two tabs) is mapped to this same success
-// shape by the service layer rather than surfaced as an error.
+/** DELETE /v1/feed/comments/:commentUid — member JWT, author-only (403
+ *  otherwise), cascades to the comment's replies. Idempotent from the client's
+ *  perspective: a 404 (already deleted, e.g. a double-delete from two tabs) is
+ *  mapped to this same success shape by the service layer. */
 export interface IFeedCommentDeleteResponse {
   uid: string;
   deleted: true;
 }
 
-/** Returned by POST/DELETE /v1/feed/forum-posts/:uid/like (member JWT +
- *  forum.read, idempotent) and carried on every post. */
+/** Returned by toggleFeedForumPostLike, which votes directly on NodeBB
+ *  (PUT/DELETE {FORUM_API_URL}/api/v3/posts/:mainPid/vote), and carried on
+ *  every post. */
 export type IFeedForumPostLikeStatus = Pick<IFeedForumPost, 'likeCount' | 'viewerHasLiked'>;

--- a/types/feed.types.ts
+++ b/types/feed.types.ts
@@ -130,6 +130,10 @@ export interface ICreateFeedCommentRequest {
   /** Reply target; omitted for a top-level comment. */
   parentUid?: string;
   text: string;
+  /** Forum posts only: the topic's opening post, which a top-level comment
+   *  replies to. Supplied by the surface that already has the post so the write
+   *  costs one request; the service falls back to fetching the topic without it. */
+  forumMainPid?: number;
 }
 
 /** DELETE /v1/feed/comments/:commentUid — member JWT, author-only (403

--- a/utils/comments/buildCommentTree.ts
+++ b/utils/comments/buildCommentTree.ts
@@ -1,0 +1,69 @@
+/**
+ * Flat comment list → tree, shared by the two comment systems that render in
+ * the same UI: the forum's NodeBB posts (nested on `parent.pid`) and the feed's
+ * NodeBB-sourced comments. The directory backend already returns a tree, so it
+ * doesn't need this.
+ *
+ * Guarantees, in order of why they exist:
+ * - **Nothing disappears.** A reply whose parent isn't in `items` (paginated
+ *   away, deleted, out of window) becomes a root rather than vanishing.
+ * - **No cycles reach the renderer.** A comment whose parent chain leads back
+ *   to itself is promoted to a root instead of being attached — an attached
+ *   cycle would infinitely recurse the recursive comment component.
+ * - **Input order is preserved** at every level: callers hand us
+ *   oldest-first data and get oldest-first replies back.
+ */
+
+interface BuildCommentTreeArgs<T, N> {
+  items: readonly T[];
+  idOf: (item: T) => string | number;
+  /** `null`/`undefined` (or an id not present in `items`) ⇒ this is a root. */
+  parentIdOf: (item: T) => string | number | null | undefined;
+  /** Build the render node for one item, with an empty `replies` array. */
+  makeNode: (item: T) => N;
+}
+
+export function buildCommentTree<T, N extends { replies: N[] }>({
+  items,
+  idOf,
+  parentIdOf,
+  makeNode,
+}: BuildCommentTreeArgs<T, N>): N[] {
+  const nodes = new Map<string | number, N>();
+  for (const item of items) nodes.set(idOf(item), makeNode(item));
+
+  // Only edges whose parent is actually present count — an unknown parent is
+  // an orphan, which resolves to a root below.
+  const parentOf = new Map<string | number, string | number>();
+  for (const item of items) {
+    const parentId = parentIdOf(item);
+    if (parentId === null || parentId === undefined) continue;
+    const id = idOf(item);
+    if (parentId !== id && nodes.has(parentId)) parentOf.set(id, parentId);
+  }
+
+  const roots: N[] = [];
+  for (const item of items) {
+    const id = idOf(item);
+    const node = nodes.get(id) as N;
+    const parentId = parentOf.get(id);
+    const parent = parentId === undefined ? undefined : nodes.get(parentId);
+
+    if (parent && resolvesToRoot(id, parentOf)) parent.replies.push(node);
+    else roots.push(node);
+  }
+
+  return roots;
+}
+
+/** Walk the parent chain: false if it revisits a node (a cycle). */
+function resolvesToRoot(id: string | number, parentOf: Map<string | number, string | number>): boolean {
+  const seen = new Set<string | number>([id]);
+  let current = parentOf.get(id);
+  while (current !== undefined) {
+    if (seen.has(current)) return false;
+    seen.add(current);
+    current = parentOf.get(current);
+  }
+  return true;
+}

--- a/utils/comments/clampDepth.ts
+++ b/utils/comments/clampDepth.ts
@@ -1,0 +1,41 @@
+/**
+ * Cap a comment tree's *display* depth without dropping anything.
+ *
+ * This is deliberately separate from how the data arrives: the directory
+ * backend allows replies at unlimited depth (`parentUid` is a plain
+ * self-relation), so a component that renders whatever it's handed would indent
+ * off the edge of the card. `clampDepth` is the display contract — everything
+ * below `maxDepth` is lifted to `maxDepth`, in pre-order, so a reply-to-a-reply
+ * shows up as a sibling of the reply it answered rather than disappearing.
+ *
+ * `maxDepth` is a depth *index*, matching the forum's `CommentItem.MAX_DEPTH`:
+ * 2 means three rendered levels (comment → reply → reply-to-reply).
+ */
+export function clampDepth<N extends { replies: N[] }>(nodes: readonly N[], maxDepth: number): N[] {
+  if (maxDepth <= 0) return flatten(nodes).map(asLeaf);
+  return nodes.map((node) => clampNode(node, maxDepth));
+}
+
+/** `remaining` = how many more levels of nesting are allowed below `node`. */
+function clampNode<N extends { replies: N[] }>(node: N, remaining: number): N {
+  if (remaining <= 1) {
+    // This node sits on the last level that may still have children, so every
+    // descendant collapses onto one level of leaves beneath it.
+    return { ...node, replies: flatten(node.replies).map(asLeaf) };
+  }
+  return { ...node, replies: node.replies.map((reply) => clampNode(reply, remaining - 1)) };
+}
+
+/** Pre-order: each node immediately followed by its own descendants. */
+function flatten<N extends { replies: N[] }>(nodes: readonly N[]): N[] {
+  const out: N[] = [];
+  for (const node of nodes) {
+    out.push(node);
+    out.push(...flatten(node.replies));
+  }
+  return out;
+}
+
+function asLeaf<N extends { replies: N[] }>(node: N): N {
+  return node.replies.length === 0 ? node : { ...node, replies: [] };
+}

--- a/utils/comments/index.ts
+++ b/utils/comments/index.ts
@@ -1,0 +1,3 @@
+export { buildCommentTree } from './buildCommentTree';
+export { clampDepth } from './clampDepth';
+export { insertCommentIntoTree, removeCommentFromTree } from './mutateCommentTree';

--- a/utils/comments/mutateCommentTree.ts
+++ b/utils/comments/mutateCommentTree.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure insert/remove over a comment tree, for the feed's cache patches.
+ *
+ * These exist as functions rather than inline `setQueryData` callbacks because
+ * the tree makes both operations easy to get subtly wrong, and both bugs are
+ * invisible until a real thread has replies in it:
+ *
+ * - **Insert** has to find the parent at any depth. Appending to the root list
+ *   (what a flat list did) silently promotes every reply to a top-level comment.
+ * - **Remove** has to account for the backend's cascade: deleting a comment
+ *   deletes its replies too, so the count drops by the whole subtree, not by 1.
+ *
+ * The generic constraints are self-referential (`replies: N[]`, not
+ * `SomeNode[]`) so recursion stays in the caller's own node type — no casts.
+ */
+
+/**
+ * Append `comment` under its `parentUid`, or at the end of the root list when
+ * it's top-level. A parent that isn't in the tree (deleted, or on a page we
+ * never loaded) falls back to the root rather than dropping the comment.
+ *
+ * Order is append-only because every source gives us oldest-first threads.
+ */
+export function insertCommentIntoTree<N extends { uid: string; parentUid: string | null; replies: N[] }>(
+  items: readonly N[],
+  comment: N,
+): N[] {
+  if (comment.parentUid === null) return [...items, comment];
+
+  const { items: inserted, found } = insertUnderParent(items, comment, comment.parentUid);
+  return found ? inserted : [...items, comment];
+}
+
+function insertUnderParent<N extends { uid: string; parentUid: string | null; replies: N[] }>(
+  items: readonly N[],
+  comment: N,
+  parentUid: string,
+): { items: N[]; found: boolean } {
+  let found = false;
+
+  const next = items.map((item) => {
+    if (found) return item;
+
+    if (item.uid === parentUid) {
+      found = true;
+      return { ...item, replies: [...item.replies, comment] };
+    }
+
+    const child = insertUnderParent(item.replies, comment, parentUid);
+    if (!child.found) return item;
+
+    found = true;
+    return { ...item, replies: child.items };
+  });
+
+  return { items: next, found };
+}
+
+/**
+ * Drop the comment with `uid` and everything under it, mirroring the backend's
+ * cascade. `removedCount` is the size of the removed subtree, so callers can
+ * decrement a comment count by the right amount (0 if the comment wasn't in the
+ * tree — a stale delete must not move the count).
+ */
+export function removeCommentFromTree<N extends { uid: string; replies: N[] }>(
+  items: readonly N[],
+  uid: string,
+): { items: N[]; removedCount: number } {
+  let removedCount = 0;
+  const next: N[] = [];
+
+  for (const item of items) {
+    if (item.uid === uid) {
+      removedCount += subtreeSize(item);
+      continue;
+    }
+
+    const child = removeCommentFromTree(item.replies, uid);
+    if (child.removedCount === 0) {
+      next.push(item);
+      continue;
+    }
+
+    removedCount += child.removedCount;
+    next.push({ ...item, replies: child.items });
+  }
+
+  return { items: next, removedCount };
+}
+
+function subtreeSize<N extends { replies: N[] }>(node: N): number {
+  return 1 + node.replies.reduce((total, reply) => total + subtreeSize(reply), 0);
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -610,7 +610,6 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_FEED_FORUM_POST_MODAL_OPENED: 'team-news-feed-forum-post-modal-opened',
   TEAM_NEWS_FEED_FORUM_POST_LIKE_TOGGLED: 'team-news-feed-forum-post-like-toggled',
   TEAM_NEWS_FEED_FORUM_POST_SHARED: 'team-news-feed-forum-post-shared',
-  TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED: 'team-news-feed-comment-thread-toggled',
   TEAM_NEWS_FEED_COMMENT_SUBMITTED: 'team-news-feed-comment-submitted',
 };
 

--- a/utils/forum/stripHtml.ts
+++ b/utils/forum/stripHtml.ts
@@ -1,11 +1,22 @@
 /**
- * Strips HTML tags from a string.
+ * Strips HTML tags from a string and decodes the entities NodeBB escapes on the
+ * way in, so a post that was typed as `a < b & "quoted"` reads that way again
+ * instead of as `a &lt; b &amp; &quot;quoted&quot;`.
+ *
+ * Entity decoding happens AFTER tag stripping (so an escaped `&lt;script&gt;`
+ * can never become a live tag) and `&amp;` is decoded LAST (so a doubly-escaped
+ * `&amp;lt;` ends up as the literal text `&lt;`, not as `<`).
  */
 export function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, '')
     .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
     .replace(/&nbsp;| /g, ' ')
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }


### PR DESCRIPTION
LAB-2177. **Draft** until the one blocker below clears.

Backend: [#3293](https://github.com/memser-spaceport/pln-directory-portal/pull/3293) (LAB-2175). **Supersedes #2707.**

Comment threads move into the detail modal, gain replies, and a forum post's thread becomes its real NodeBB topic thread — read *and* written. Three commits, each independently reviewable.

## Why this is a repair, not just a feature

BE #3293 is a breaking change to the feed social layer that shipped in #2695. It deletes the forum-post proxy, renames the comment contract, and re-points `FeedComment` at a hard `TeamNewsItem` foreign key. Four things live on `develop` break the moment it deploys:

| Live FE call | After #3293 |
|---|---|
| `GET /v1/feed/forum-posts?limit=100&page=0` | **deleted** → forum posts vanish from the feed |
| `POST/DELETE /v1/feed/forum-posts/:uid/like` | **deleted** → Like on a forum card 404s |
| `GET /v1/feed/comments?itemUid=` | `newsItemUid` is zod-**required** → 400, every thread empty |
| `POST {itemUid, text}` | body requires `newsItemUid` → 400, nobody can comment |
| author `{memberUid, name, avatarUrl, role}` | `{uid, name \| null, avatarUrl}` → `author.role` renders nothing |
| flat `items[]` | threaded `items[].replies[]` → replies invisible |

Two latent defects fixed on the way past:

- **`FeedCommentCountsRequestSchema` caps `uids` at 200**, and `useFeedCommentCounts` posted the whole SSR news window unchunked. One oversized request 400s and takes *every* count badge on the page with it.
- **`FeedComment` hard-FKs `TeamNewsItem`**, so `getFeedComments('fp_…')` would 404. A forum post's comments can only come from the forum now, which is why that had to land here rather than as a follow-up.

## `cbfd64569` — contract repair

**One view model, two backends.** `IFeedComment` stops being a wire echo. No single wire shape serves both an already-nested directory tree and a flat NodeBB post list, so both are mapped at the service boundary and the field stays `itemUid` — it holds a news uid *or* an `fp_` uid, where `newsItemUid` would be a lie for half of them. Nothing above the service knows which backend a comment came from, and no component or hook churned on the rename.

**Forum posts, votes and comments come straight from NodeBB.** The vote target (`mainPid`) and `tid` ride on `IFeedForumPost`, so there's no module-level cache to miss and no hand-maintained tally to drift.

**A forum post's thread is its real topic thread**, nested on `parent.pid`. A reply to the opening post is top-level here — the opening post is the card, not a comment on it.

Correctness work the tree forced:

- Delete **cascades** server-side, so the patch removes the whole subtree and drops the count by its size. Decrementing by 1 left the badge permanently overstated.
- A reply inserts **under its parent at any depth**. Appending to the root list silently promotes replies to top-level comments until a reload — the same bug class review caught in #2695.
- Display depth is capped at 2 (the forum's `MAX_DEPTH`) by `clampDepth`, which **lifts** deeper replies instead of dropping them. The wire allows unlimited nesting, so that can't be assumed away.

`NestedComment` had to be fixed to compile: NodeBB posts already carry a `replies` field holding reply *metadata*, so `Comment & {replies: NestedComment[]}` was an intersection nothing could satisfy — which is exactly why that code was typed `any`.

## `b55d724fc` — threads move into the modal

The card's comment affordance becomes a count badge that opens the detail modal; the inline card thread is gone. A depth-2 reply tree with its own composers does not fit a card that showed two comments behind "View all".

`CommentButton` loses `open`/`onToggle` and its `aria-expanded` — it is no longer a disclosure control, so advertising one was a lie to assistive tech.

`team-news-feed-comment-thread-toggled` is retired, since nothing toggles any more. The intent it captured moves onto the card-clicked events as `via`, now the only thing distinguishing a comment-badge open from a row open.

`ForumPostCard` had no test coverage at all; it gets a suite here.

## `30a5098df` — replies

- One reply box at a time, opened per comment and focused on open. Reply disappears at the depth cap, where a further reply would render alongside the comment it answers.
- An in-flight reply renders under its own parent rather than at the top of the thread, and a failure is attributed to the composer that produced it (the first cut showed one error in both places).
- **Forum reply targets:** a top-level comment replies to the topic's opening post, a reply to that comment's own post. `mainPid` comes from the card the modal was opened from, so the write is one request; the topic fetch is only a fallback. The created comment carries the caller's own `parentUid`, since NodeBB doesn't reliably echo it and the cache patch would otherwise land the reply at the root.
- Composing on a forum post requires `forum.write` — the same gate the `/forum` composer uses. Without it the thread stays fully readable.
- **NodeBB's rejections are frequently untranslated keys** like `[[error:content-too-short]]`, which is worse than showing nothing. `forumErrorMessage` keeps them out of the UI, and spells out the two members hit routinely and cannot diagnose from a generic line: the 8-character `minimumPostLength` (so "nice!" is refused) and the post rate limit.
- `postForumReply` is now shared with the `/forum` composer instead of duplicated.

## `ca58a5831` — polish

Three cases where the feed was quietly showing something untrue.

**A forum card couldn't know whether you'd already liked the post.** `/api/recent`, which builds the card, carries no per-viewer vote state — so `viewerHasLiked` was false by default, and liking something already liked sent a vote NodeBB ignores while the local count climbed by one. The thread fetch returns the topic, which does know: `resolveForumPostLike` picks the best source at render time (the viewer's own toggle → the topic → the listing's blind default). Because the resolved value feeds the toggle handler, the correction lands in the overlay on first use and outlives the modal.

Derived during render rather than synced into state: `setState` inside an effect is a lint error in this repo, and the derived form has no ordering to get wrong.

**"View all 12 comments" could be a lie.** `/api/topic/:tid` serves one page of posts (~20), so a busy topic's thread is only partly present. The expander now says "Show more comments" when the count would understate, and a link carries the true remainder to the forum.

**A comment that was only an image rendered as a blank row**, since feed comment text is plain by contract and an attachment isn't in it. It now says so, linked to where the attachment can be seen.

## Blocker before this leaves draft

**Deploy order.** Reads and writes send **both** `itemUid` and `newsItemUid`. Both schema versions use plain `z.object`, which strips unknown keys, so one request should be valid against either backend and deploy order shouldn't matter. ⚠️ **Unverified** — a `.strict()` schema or a `forbidNonWhitelisted` pipe would reject the extra key. Needs a staging check; if it doesn't hold, this merges after #3293 and the extra key comes out.

## Testing

`npm run test` fully green — **1106 passing**, ~120 new or rewritten across 11 suites.

New pure-function suites, each covering the failure mode that motivated it:

- `buildCommentTree` — nesting, orphan promotion, and **cycle breaking** (an attached cycle would infinitely recurse the recursive comment component)
- `clampDepth` — a level-3 reply lands at depth 2 as a sibling, an arbitrarily deep chain keeps every comment, pre-order preserved
- `mutateCommentTree` — reply nests under its parent, delete counts the **whole subtree**, a stale delete moves nothing
- `stripHtml` — `&amp;` decoded last so `&amp;lt;` stays text, and an escaped tag never becomes markup
- `forumErrorMessage` — translation keys never reach a member
- `resolveForumPostLike` — precedence of own toggle over topic over listing default
- `useFeedForumTopicLike` — reads the topic's vote state off the thread's cache entry without ever fetching

Rewritten/extended: `feed.service.test.ts` (dual field names, 250-uid chunking split as 200+50, NodeBB topic → nested tree, vote via `mainPid`, reply targets, HTML escaping), reply and cascade cases on both mutation hooks, reply/gating/error-scoping cases on the thread, and badge-opens-modal on both cards.

Manually verified: a forum post's real replies render in the modal.

**Note on `lint`/`tsc`:** `develop` isn't clean to begin with (23 pre-existing `tsc` errors, 258 pre-existing lint errors, all unrelated files). Verified as a **delta** — zero new errors in touched files, prettier clean.

## Open with BE, not blocking

No comment-like endpoint exists, so #2706's per-comment Like isn't buildable for news comments. And `FeedNewsLike` is dead code from the FE's side — news Like stays on `TeamNewsUpvote`, since adopting the new table would zero every visible count.

## Supersedes #2707

Same target, and its `/api/recent` mapper and `stripHtml` fix are reused here. The gaps that made it unmergeable: it never touches the news-comment half (so news comments 400 on #3293's deploy); `posts.slice(1)` discards `post.parent.pid`, flattening the replies feature away; `commentCount = postcount-1` disagrees with a paginated `/api/topic/:tid`; the module-level `Map` throws on cache miss; `viewerHasLiked` is hardcoded `false` with no correction path; and it duplicates `useForumPost`'s fetcher plus its own escape/auth helpers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
