### PR TITLE
feat(feed): restore inline comment threads on the news feed card

### DIFF
--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -94,16 +94,49 @@ beforeEach(() => {
 });
 
 describe('FeedCommentsThread — list', () => {
-  it('caps at the 2 MOST RECENT comments (oldest-first data — last 2, not first 2) behind "View all N"', () => {
+  it('caps a CARD at the 2 MOST RECENT comments (oldest-first data — last 2, not first 2)', () => {
+    const onViewAll = jest.fn();
     mockThread([comment('c1', 'First'), comment('c2', 'Second'), comment('c3', 'Third')]);
     mockMutation(useAddFeedCommentMock);
-    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={onViewAll} />);
 
     expect(screen.queryByText('First')).not.toBeInTheDocument();
     expect(screen.getByText('Second')).toBeInTheDocument();
     expect(screen.getByText('Third')).toBeInTheDocument();
 
+    // The overflow escalates to the modal rather than growing the card.
     fireEvent.click(screen.getByRole('button', { name: 'View all 3 comments' }));
+    expect(onViewAll).toHaveBeenCalled();
+    expect(screen.queryByText('First')).not.toBeInTheDocument();
+  });
+
+  it('renders the WHOLE thread in the modal — no cap, nothing left to expand', () => {
+    mockThread([comment('c1', 'First'), comment('c2', 'Second'), comment('c3', 'Third')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="news-modal" />);
+
+    expect(screen.getByText('First')).toBeInTheDocument();
+    // Without this the card's "View all" would land on a modal showing the
+    // same two comments behind the same button.
+    expect(screen.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps a card row visible while its reply composer is open, even as the thread grows', () => {
+    const onViewAll = jest.fn();
+    mockThread([comment('c1', 'First'), comment('c2', 'Second')]);
+    mockMutation(useAddFeedCommentMock);
+    const { rerender } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={onViewAll} />);
+
+    const [firstReply] = screen.getAllByRole('button', { name: 'Reply' });
+    fireEvent.click(firstReply);
+    expect(screen.getByPlaceholderText('Reply to Author c1…')).toBeInTheDocument();
+
+    // A third comment arrives — a bare slice(-2) would drop c1 and take the
+    // open composer (and its unsent draft) with it.
+    mockThread([comment('c1', 'First'), comment('c2', 'Second'), comment('c3', 'Third')]);
+    rerender(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={onViewAll} />);
+
+    expect(screen.getByPlaceholderText('Reply to Author c1…')).toBeInTheDocument();
     expect(screen.getByText('First')).toBeInTheDocument();
   });
 
@@ -186,7 +219,7 @@ describe('FeedCommentsThread — replies', () => {
       comment('c3', 'Third'),
     ]);
     mockMutation(useAddFeedCommentMock);
-    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={jest.fn()} />);
 
     // 3 top-level + 1 reply = 4, matching what the count badge shows.
     expect(screen.getByRole('button', { name: 'View all 4 comments' })).toBeInTheDocument();
@@ -450,13 +483,26 @@ describe('FeedCommentsThread — forum posts', () => {
     expect(link).toHaveAttribute('href', '/forum/topics/5/96');
   });
 
-  it('says "Show more" rather than "View all N" when N would understate the thread', () => {
+  it('drops the number from a card’s escalation when N would understate the thread', () => {
     mockThread([comment('c1', 'One'), comment('c2', 'Two'), comment('c3', 'Three')], forumTopicMeta(50));
     mockMutation(useAddFeedCommentMock);
-    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="home" forumMainPid={263} onViewAll={jest.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'Show more comments' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View all comments' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /View all \d/ })).not.toBeInTheDocument();
+  });
+
+  it('still escalates from a card when the thread fits but NodeBB has more', () => {
+    const onViewAll = jest.fn();
+    // Under the cap, so the count alone would hide the escalation — but the
+    // card suppresses the forum link, so this would be a dead end.
+    mockThread([comment('c1', 'One'), comment('c2', 'Two')], forumTopicMeta(50));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="home" forumMainPid={263} onViewAll={onViewAll} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View all comments' }));
+    expect(onViewAll).toHaveBeenCalled();
+    expect(screen.queryByRole('link', { name: /more comments on the forum/ })).not.toBeInTheDocument();
   });
 
   it('shows no forum link when the whole thread is already here', () => {
@@ -521,5 +567,63 @@ describe('FeedCommentsThread — signed-out gate', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'sign in to comment' }));
     expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('#login'), { scroll: false });
+  });
+
+  it('prefers a card’s onSignIn over the bare #login push, so the round trip keeps its place', () => {
+    const onSignIn = jest.fn();
+    signOut();
+    mockThread([comment('c1', 'Readable while signed out')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={jest.fn()} onSignIn={onSignIn} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'sign in to comment' }));
+    expect(onSignIn).toHaveBeenCalled();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it('shows no composer before the auth store hydrates — a guest must not be able to type', () => {
+    useCurrentUserStore.setState({ currentUser: null, isHydrated: false });
+    mockThread([comment('c1', 'Readable')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={jest.fn()} />);
+
+    // Otherwise a fast guest types a comment and gets "couldn't post" instead
+    // of a login prompt.
+    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'sign in to comment' })).not.toBeInTheDocument();
+    expect(screen.getByText('Readable')).toBeInTheDocument();
+  });
+});
+
+describe('FeedCommentsThread — read-path states', () => {
+  it('shows a busy placeholder while the thread loads, not an empty box', () => {
+    useFeedCommentsMock.mockReturnValue({ isPending: true });
+    mockMutation(useAddFeedCommentMock);
+    const { container } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={jest.fn()} />);
+
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+    expect(screen.queryByText('No comments yet.')).not.toBeInTheDocument();
+  });
+
+  it('offers a retry when the thread fails to load', () => {
+    const refetch = jest.fn();
+    useFeedCommentsMock.mockReturnValue({ isError: true, refetch });
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" onViewAll={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('says the thread is empty rather than expanding to nothing', () => {
+    // A forum member with read but not write access gets no composer either,
+    // so without this the badge opens onto a blank box.
+    mockForumAccess.mockReturnValue({ canWrite: false });
+    mockThread([], forumTopicMeta(0));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="home" onViewAll={jest.fn()} />);
+
+    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+    expect(screen.getByText('No comments yet.')).toBeInTheDocument();
   });
 });

--- a/__tests__/page/home/forum-post-card.test.tsx
+++ b/__tests__/page/home/forum-post-card.test.tsx
@@ -7,12 +7,24 @@ import type { ForumPostUid, IFeedForumPost } from '@/types/feed.types';
 jest.mock('@/utils/formatTimeAgo', () => ({ formatTimeAgo: () => '2d ago' }));
 
 const onFeedForumPostCardClicked = jest.fn();
+const onFeedCommentThreadToggled = jest.fn();
 jest.mock('@/analytics/team-news.analytics', () => ({
-  useTeamNewsAnalytics: () => ({ onFeedForumPostCardClicked }),
+  useTeamNewsAnalytics: () => ({ onFeedForumPostCardClicked, onFeedCommentThreadToggled }),
 }));
 
 jest.mock('@/components/page/home/TeamNews/components/NewsShareMenu', () => ({
   FeedForumPostShareMenu: () => null,
+}));
+
+// The thread's own behaviour lives in feed-comments-thread.test.tsx; this file
+// covers the card's wiring to it.
+const mockThread = jest.fn();
+jest.mock('@/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread', () => ({
+  feedThreadDomId: (uid: string) => `feed-thread-${uid}`,
+  FeedCommentsThread: (props: { itemUid: string; forumMainPid?: number; onViewAll: () => void }) => {
+    mockThread(props);
+    return <div data-testid={`thread-${props.itemUid}`} />;
+  },
 }));
 
 const post: IFeedForumPost = {
@@ -63,21 +75,38 @@ describe('ForumPostCard', () => {
     expect(onFeedForumPostCardClicked).toHaveBeenCalledWith(post, 0, 'home', 'row');
   });
 
-  it('opens the same modal from the comment badge, flagged as such for analytics', () => {
+  it('discloses the real NodeBB thread in place rather than opening the modal', () => {
     const { onOpenDetail } = renderCard();
 
-    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+    expect(screen.queryByTestId('thread-fp_96')).not.toBeInTheDocument();
 
-    expect(onOpenDetail).toHaveBeenCalledWith(post);
-    expect(onFeedForumPostCardClicked).toHaveBeenCalledWith(post, 0, 'home', 'comment-button');
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
+
+    expect(onOpenDetail).not.toHaveBeenCalled();
+    expect(screen.getByTestId('thread-fp_96')).toBeInTheDocument();
+    // The topic's opening post is what a top-level comment replies to.
+    expect(mockThread).toHaveBeenCalledWith(expect.objectContaining({ forumMainPid: 263 }));
+    expect(onFeedCommentThreadToggled).toHaveBeenCalledWith('fp_96', 'forum', true, 'home');
   });
 
-  it('never renders a thread inline on the card — the real NodeBB thread lives in the modal', () => {
+  it('collapses the thread again on a second click', () => {
     renderCard();
 
-    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Comments, hide/ }));
 
-    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('thread-fp_96')).not.toBeInTheDocument();
+    expect(onFeedCommentThreadToggled).toHaveBeenLastCalledWith('fp_96', 'forum', false, 'home');
+  });
+
+  it('escalates the inline thread to the modal, flagged as such for analytics', () => {
+    const { onOpenDetail } = renderCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
+    mockThread.mock.calls.at(-1)?.[0].onViewAll();
+
+    expect(onOpenDetail).toHaveBeenCalledWith(post);
+    expect(onFeedForumPostCardClicked).toHaveBeenCalledWith(post, 0, 'home', 'view-all-comments');
   });
 
   it('toggles the like without opening the modal', () => {

--- a/__tests__/page/home/news-group-card.test.tsx
+++ b/__tests__/page/home/news-group-card.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { NewsGroupCard } from '@/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard';
 import type { ITeamNewsItem, TeamCluster } from '@/types/team-news.types';
@@ -16,6 +16,22 @@ jest.mock('@/components/page/home/TeamNews/components/SourceList/SourceList', ()
   SourceList: (props: { position: number }) => {
     mockSourceList(props);
     return null;
+  },
+}));
+
+// Stubbed like SourceList above: the thread's own behaviour is covered in
+// feed-comments-thread.test.tsx, and this file is about the card's wiring.
+const mockThread = jest.fn();
+jest.mock('@/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread', () => ({
+  feedThreadDomId: (uid: string) => `feed-thread-${uid}`,
+  FeedCommentsThread: (props: {
+    itemUid: string;
+    source: string;
+    onViewAll: () => void;
+    onBusyChange: (busy: boolean) => void;
+  }) => {
+    mockThread(props);
+    return <div data-testid={`thread-${props.itemUid}`} />;
   },
 }));
 
@@ -186,26 +202,76 @@ describe('NewsGroupCard', () => {
     openSpy.mockRestore();
   });
 
-  it('opens the detail modal from the comment badge, flagged as such for analytics', () => {
+  it('does NOT open the modal from the comment badge — it discloses the thread in place', () => {
     const onStoryOpen = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
     render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
 
-    // The badge is not a disclosure toggle — the thread lives in the modal, and
-    // `via` is the only thing that distinguishes this from a row click.
-    expect(onStoryOpen).toHaveBeenCalledWith(item, 'comment-button');
+    expect(onStoryOpen).not.toHaveBeenCalled();
+    expect(screen.getByTestId('thread-a')).toBeInTheDocument();
   });
 
-  it('never renders a thread inline on the card', () => {
+  it('renders the thread inline, collapsed by default, and toggles it closed again', () => {
     render(
       <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'View comments' }));
+    // Mount = expanded, so nothing may be mounted before the first click.
+    expect(screen.queryByTestId('thread-a')).not.toBeInTheDocument();
 
-    expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
+    const badge = screen.getByRole('button', { name: /Comments, show/ });
+    expect(badge).toHaveAttribute('aria-expanded', 'false');
+    expect(badge).toHaveAttribute('aria-controls', 'feed-thread-a');
+
+    fireEvent.click(badge);
+    expect(screen.getByTestId('thread-a')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Comments, hide/ })).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: /Comments, hide/ }));
+    expect(screen.queryByTestId('thread-a')).not.toBeInTheDocument();
+  });
+
+  it('escalates the inline thread to the modal, flagged as such for analytics', () => {
+    const onStoryOpen = jest.fn();
+    const item = makeItem('a', '2026-05-03T00:00:00.000Z');
+    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
+    // "View all" is the only comment affordance that still reaches the modal.
+    mockThread.mock.calls.at(-1)?.[0].onViewAll();
+
+    expect(onStoryOpen).toHaveBeenCalledWith(item, 'view-all-comments');
+  });
+
+  it('opens each story’s thread independently', () => {
+    render(
+      <NewsGroupCard
+        cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z'), makeItem('b', '2026-05-02T00:00:00.000Z')])}
+        onStoryOpen={noopStoryOpen}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Comments, show/ })[0]);
+
+    expect(screen.getByTestId('thread-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('thread-b')).not.toBeInTheDocument();
+  });
+
+  it('refuses to collapse a thread holding an unsettled comment', () => {
+    render(
+      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
+    act(() => mockThread.mock.calls.at(-1)?.[0].onBusyChange(true));
+
+    fireEvent.click(screen.getByRole('button', { name: /Comments, hide/ }));
+
+    // Unmounting would discard the mutation's error state — and with it any
+    // notice that the comment failed to post.
+    expect(screen.getByTestId('thread-a')).toBeInTheDocument();
   });
 
   it('exposes rows as dialog-opening buttons with the title as accessible name', () => {

--- a/__tests__/services/feed/useAddFeedComment.test.tsx
+++ b/__tests__/services/feed/useAddFeedComment.test.tsx
@@ -113,6 +113,31 @@ describe('useAddFeedComment', () => {
     expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(2);
   });
 
+  it('preserves forumTopic on the entry — the patch must not rebuild it from items alone', async () => {
+    const itemUid = 'fp_3';
+    const forumTopic = {
+      url: '/forum/topics/5/96',
+      totalReplyCount: 40,
+      like: { likeCount: 3, viewerHasLiked: true },
+    };
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [comment('c-1', itemUid, 'First', '2026-01-01T00:00:00.000Z')],
+      forumTopic,
+    });
+
+    createFeedCommentMock.mockResolvedValue(comment('c-2', itemUid, 'Second', '2026-01-02T00:00:00.000Z'));
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ text: 'Second' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Dropping forumTopic silently kills the "N more comments on the forum"
+    // link, the escalation label's honesty about unloaded replies, and
+    // useFeedForumTopicLike's view of the vote state.
+    expect(client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.forumTopic).toEqual(forumTopic);
+  });
+
   it('nests a reply-to-a-reply under the right comment, several levels down', async () => {
     const itemUid = 'n-1';
     client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {

--- a/__tests__/services/feed/useDeleteFeedComment.test.tsx
+++ b/__tests__/services/feed/useDeleteFeedComment.test.tsx
@@ -73,6 +73,27 @@ describe('useDeleteFeedComment', () => {
     expect(client.getQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts())?.[itemUid]).toBe(0);
   });
 
+  it('preserves forumTopic on the entry — the patch must not rebuild it from items alone', async () => {
+    const itemUid = 'fp_3';
+    const forumTopic = {
+      url: '/forum/topics/5/96',
+      totalReplyCount: 40,
+      like: { likeCount: 3, viewerHasLiked: true },
+    };
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [comment('c-1', itemUid), comment('c-2', itemUid)],
+      forumTopic,
+    });
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'c-1', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment(itemUid), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.forumTopic).toEqual(forumTopic);
+  });
+
   it('removes a nested reply without disturbing its siblings', async () => {
     const itemUid = 'n-1';
     client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -14,10 +14,11 @@ export type TeamNewsAnalyticsSource = 'home' | 'team-profile-rail' | 'team-profi
  *  or navigated to the source article (team-details surfaces). */
 export type TeamNewsCardClickOutcome = 'modal' | 'source';
 
-/** Which affordance opened the card. Both the row and the comment badge open
- *  the same detail modal now that threads live only there, so this is the only
- *  thing that distinguishes "read this story" from "go to its comments". */
-export type TeamNewsCardClickVia = 'row' | 'comment-button';
+/** Which affordance opened the detail modal. The comment badge is a disclosure
+ *  toggle again, so it no longer appears here — the only way a comment intent
+ *  reaches the modal is the card thread's "View all", which is a genuinely
+ *  different signal: the member read the thread first and wanted more of it. */
+export type TeamNewsCardClickVia = 'row' | 'view-all-comments';
 
 export type TeamNewsShareNetwork = 'linkedin' | 'x' | 'copy';
 
@@ -297,9 +298,22 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
-  // No thread-toggled event: threads are always expanded in the detail modal,
-  // so there is nothing to toggle. The intent that event used to capture now
-  // rides on the card-clicked events' `via` property.
+  // Fires from the card only — the modal's thread is always expanded, so there
+  // is nothing to toggle there. This is the only signal for "opened a thread
+  // without opening the story", which is now the common path.
+  const onFeedCommentThreadToggled = (
+    itemUid: string,
+    kind: FeedItemKind,
+    open: boolean,
+    source: TeamNewsAnalyticsSource,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED, {
+      itemUid,
+      kind,
+      open,
+      source,
+    });
+  };
 
   const onFeedCommentSubmitted = (
     itemUid: string,
@@ -334,6 +348,7 @@ export const useTeamNewsAnalytics = () => {
     onFeedForumPostModalOpened,
     onFeedForumPostLikeToggled,
     onFeedForumPostShared,
+    onFeedCommentThreadToggled,
     onFeedCommentSubmitted,
   };
 };

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -1,3 +1,5 @@
+@use 'styles/media';
+
 /* Inline feed-comment thread revealed under a story / forum post. Ported from
    the approved newsfeed-v0 prototype (prototypes/entries/newsfeed-v0/
    CommentsThread.module.scss). `.inline` and `.primaryBtn` are COPIED from the
@@ -312,6 +314,29 @@
   margin-top: 14px;
   padding-left: 16px;
   min-width: 0;
+
+  @include media.mobile-only {
+    padding-left: 12px;
+  }
+}
+
+/* The reply row is input + Cancel + Reply on one line. At depth 2 on a phone
+   that leaves the input around 90px once the card padding, two indent levels,
+   the avatar and both buttons are taken out — .forumField already
+   ellipsis-truncates its own placeholder, which was the tell. Stack instead:
+   full-width input, buttons right-aligned underneath. */
+@include media.mobile-only {
+  .replyComposer .inline {
+    flex-wrap: wrap;
+  }
+
+  .replyComposer .forumField {
+    flex: 1 0 100%;
+  }
+
+  .replyComposer .replyCancelBtn {
+    margin-left: auto;
+  }
 }
 
 .avatar {

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -13,6 +13,15 @@
   margin-top: 16px; /* + the body's 16px gap = 32px above the comment field */
 }
 
+/* On a card there is no modal-body gap to add to, and the thread butts straight
+   up against the actions row — so it supplies its own separation. */
+.threadCard {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(27, 56, 96, 0.12);
+  gap: 16px;
+}
+
 .composer {
   display: flex;
   flex-direction: column;
@@ -141,6 +150,49 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+/* Read-path states. On a card these are load-bearing: the badge has already
+   promised a count, so an empty gap while the query runs reads as breakage. */
+.skeletonRow {
+  height: 40px;
+  border-radius: 6px;
+  background: var(--background-neutral-subtle, rgba(27, 56, 96, 0.06));
+  animation: skeletonPulse 1.4s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@keyframes skeletonPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.retryBtn {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  color: var(--foreground-danger-primary, #d92d20);
+  text-decoration: underline;
+}
+
+.empty {
+  margin: 0;
+  font-size: 13px;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
 }
 
 /* Quiet expander that caps a long thread ("View all N comments" / "Show fewer"). */

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
@@ -85,6 +85,11 @@ interface FeedCommentsThreadProps {
    *  open, so the round trip lands back on it. Defaults to a bare #login push,
    *  which from a card loses that context entirely. */
   onSignIn?: () => void;
+  /** Card surfaces only: "there is an unsettled write in here". Closing a modal
+   *  is a deliberate "I'm done"; clicking a disclosure badge is not, and the
+   *  mutation's error state — unlike its cache writes — does not survive
+   *  unmount, so a collapse mid-flight can drop a failed comment in silence. */
+  onBusyChange?: (busy: boolean) => void;
 }
 
 /**
@@ -138,6 +143,7 @@ export function FeedCommentsThread({
   forumMainPid,
   onViewAll,
   onSignIn,
+  onBusyChange,
 }: FeedCommentsThreadProps) {
   const router = useRouter();
   const analytics = useTeamNewsAnalytics();
@@ -236,6 +242,21 @@ export function FeedCommentsThread({
   // `null` = the failure belongs to the top-level composer; a uid = to that
   // comment's reply composer. Without this the same error renders in both.
   const errorParentUid = errorText ? (attempt?.parentUid ?? null) : undefined;
+
+  // "Latest ref" so the report below keys off the busy flag alone — callers
+  // pass an inline arrow, and depending on its identity would re-fire every
+  // render. Ref written in an effect, never during render (repo lint rule).
+  const busy = addComment.isPending || addComment.isError;
+  const onBusyChangeRef = useRef(onBusyChange);
+  useEffect(() => {
+    onBusyChangeRef.current = onBusyChange;
+  });
+  useEffect(() => {
+    onBusyChangeRef.current?.(busy);
+    // Clearing on unmount matters: a card that refused to collapse while busy
+    // would otherwise stay stuck open after a filter change remounts it.
+    return () => onBusyChangeRef.current?.(false);
+  }, [busy]);
 
   const pendingParentUid = pending?.parentUid;
 

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -36,6 +36,38 @@ function countComments(comments: readonly IFeedComment[]): number {
   return comments.reduce((total, comment) => total + 1 + countComments(comment.replies), 0);
 }
 
+/** Is `uid` this comment or anywhere in its subtree? */
+function containsUid(comment: IFeedComment, uid: string): boolean {
+  return comment.uid === uid || comment.replies.some((reply) => containsUid(reply, uid));
+}
+
+/**
+ * The last `count` top-level comments, plus any whose subtree the member is
+ * currently working in.
+ *
+ * A bare `slice(-count)` is a sliding window over a list that GROWS AT THE END
+ * (insertCommentIntoTree appends), so posting a comment silently unmounts the
+ * row above it — taking an open reply composer, its unsent draft, and any
+ * in-flight reply's pending row with it. Pinning costs one pass and makes the
+ * window stable exactly where it has to be.
+ */
+function windowWithPinned(
+  comments: readonly IFeedComment[],
+  count: number,
+  activeUids: readonly string[],
+): readonly IFeedComment[] {
+  if (comments.length <= count) return comments;
+  const tail = new Set(comments.slice(-count).map((comment) => comment.uid));
+  if (activeUids.length === 0) return comments.slice(-count);
+  return comments.filter((comment) => tail.has(comment.uid) || activeUids.some((uid) => containsUid(comment, uid)));
+}
+
+/** Stable DOM id for a thread region, so a card's badge can own `aria-controls`
+ *  without either component having to thread a generated id between them. */
+export function feedThreadDomId(itemUid: string): string {
+  return `feed-thread-${itemUid}`;
+}
+
 interface FeedCommentsThreadProps {
   itemUid: string;
   kind: FeedItemKind;
@@ -43,6 +75,16 @@ interface FeedCommentsThreadProps {
   /** Forum posts only: the topic's opening post, which a top-level comment
    *  replies to. Lets the write happen in one request instead of two. */
   forumMainPid?: number;
+  /** CARD SURFACES ONLY, and the single switch between the two layouts: its
+   *  presence caps the list at VISIBLE and turns the overflow affordance into
+   *  "open the detail modal". The modal omits it and renders the whole thread —
+   *  without that asymmetry the escalation would land on a modal showing the
+   *  same two comments behind the same button. */
+  onViewAll?: () => void;
+  /** Card surfaces only: bounce to #login recording which item's thread was
+   *  open, so the round trip lands back on it. Defaults to a bare #login push,
+   *  which from a card loses that context entirely. */
+  onSignIn?: () => void;
 }
 
 /**
@@ -54,11 +96,18 @@ interface FeedCommentsThreadProps {
  * really does appear on /forum. Both arrive as the same `IFeedComment` tree from
  * services/feed/feed.service.ts.
  *
- * Mount = expanded: the parent renders this component only while the modal is
+ * Mount = expanded: the parent renders this component only while the thread is
  * open, so the lazy comments query fetches on mount and, with no observer after
  * close, never refetches in the background. All comment text / names / roles
  * render via JSX text interpolation only — dangerouslySetInnerHTML is banned in
  * this component, and forum HTML arrives already stripped to plain text.
+ *
+ * Two surfaces, one component, told apart by `onViewAll`:
+ * - CARD (prop passed): shows the last VISIBLE top-level comments and escalates
+ *   the rest to the detail modal. The forum's "more on the forum" link is
+ *   suppressed — two competing escalations on one card is noise.
+ * - MODAL (prop omitted): renders the whole thread. There is nothing left to
+ *   expand, which is why this component has no expand state of its own.
  *
  * Composer rules (no toasts, ever):
  * - The in-flight comment renders immediately from the mutation's `variables`
@@ -82,19 +131,28 @@ interface FeedCommentsThreadProps {
  * cache patch alike. NodeBB-sourced comments always report `isOwn: false`, so
  * the affordance never appears on them.
  */
-export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: FeedCommentsThreadProps) {
+export function FeedCommentsThread({
+  itemUid,
+  kind,
+  source,
+  forumMainPid,
+  onViewAll,
+  onSignIn,
+}: FeedCommentsThreadProps) {
   const router = useRouter();
   const analytics = useTeamNewsAnalytics();
   const { currentUser, isHydrated } = useCurrentUserStore();
   const { canWrite: canWriteForum } = useForumAccess();
   const [draft, setDraft] = useState('');
-  const [expanded, setExpanded] = useState(false);
   const [confirmingUid, setConfirmingUid] = useState<string | null>(null);
   // One open reply composer at a time — a thread full of open inputs is noise,
   // and the draft belongs to whichever comment the member is answering.
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
 
-  const { data } = useFeedComments(itemUid, { enabled: true });
+  // The only difference between the card and the modal. See the prop's doc.
+  const isCard = onViewAll !== undefined;
+
+  const { data, isPending, isError, refetch } = useFeedComments(itemUid, { enabled: true });
   const addComment = useAddFeedComment(itemUid, forumMainPid);
   const deleteComment = useDeleteFeedComment(itemUid);
 
@@ -115,10 +173,6 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
   const forumTopic = data?.forumTopic;
   const forumTopicUrl = forumTopic?.url ?? undefined;
   const missingReplyCount = forumTopic ? Math.max(0, forumTopic.totalReplyCount - totalCount) : 0;
-
-  // Oldest-first data: the most recent VISIBLE comments are the LAST ones, not
-  // the first — a plain slice(0, VISIBLE) would show the oldest instead.
-  const shown = expanded ? comments : comments.slice(-VISIBLE);
 
   const requestDelete = (commentUid: string) => {
     if (deleteComment.isPending) return;
@@ -159,6 +213,13 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
   };
 
   const goToLogin = () => {
+    // A card passes onSignIn so the URL records which thread was open; without
+    // it this is a bare /home#login and the member comes back to a collapsed
+    // feed with no idea where they were.
+    if (onSignIn) {
+      onSignIn();
+      return;
+    }
     router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
   };
 
@@ -176,10 +237,35 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
   // comment's reply composer. Without this the same error renders in both.
   const errorParentUid = errorText ? (attempt?.parentUid ?? null) : undefined;
 
+  const pendingParentUid = pending?.parentUid;
+
+  // Oldest-first data: the most recent VISIBLE comments are the LAST ones, not
+  // the first — a plain slice(0, VISIBLE) would show the oldest instead. Rows
+  // the member is mid-interaction with are pinned in, so an append can't
+  // unmount one out from under an open composer.
+  const shown = useMemo(() => {
+    if (!isCard) return comments;
+    const activeUids = [replyingTo, confirmingUid, pendingParentUid].filter((uid): uid is string => Boolean(uid));
+    return windowWithPinned(comments, VISIBLE, activeUids);
+  }, [isCard, comments, replyingTo, confirmingUid, pendingParentUid]);
+
+  // A forum card whose thread fits under the cap can still have replies left on
+  // NodeBB, and its "more on the forum" link is suppressed here — so the
+  // escalation has to key off both, or that card offers no way through at all.
+  const showEscalation = isCard && (comments.length > VISIBLE || missingReplyCount > 0);
+  const hasRows = comments.length > 0 || Boolean(pendingText && !pending?.parentUid);
+
   return (
-    <div className={s.thread} onClick={(e) => e.stopPropagation()}>
-      {/* Composer sits above the list — leave a comment first, then read. */}
-      {isHydrated && !currentUser ? (
+    <div
+      id={feedThreadDomId(itemUid)}
+      className={clsx(s.thread, isCard && s.threadCard)}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Composer sits above the list — leave a comment first, then read.
+          Nothing renders before the auth store hydrates: `currentUser` is null
+          either way at that point, so showing the composer would let a guest
+          type a comment and get "couldn't post" instead of a login prompt. */}
+      {!isHydrated ? null : !currentUser ? (
         <div className={s.signedOut}>
           <span>Join the conversation —</span>
           <button type="button" className={s.signInBtn} onClick={goToLogin}>
@@ -206,7 +292,27 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
         )
       )}
 
-      {(comments.length > 0 || (pendingText && !pending?.parentUid)) && (
+      {/* On a card the badge already promised a count, so "loading" and
+          "failed" have to be visible states — silence reads as "the comments
+          are gone". In the modal these were masked by the article body. */}
+      {isPending ? (
+        <div className={s.list} aria-busy="true">
+          <div className={s.skeletonRow} />
+          <div className={s.skeletonRow} />
+        </div>
+      ) : isError ? (
+        <p className={s.error} role="alert">
+          Couldn’t load comments —{' '}
+          <button type="button" className={s.retryBtn} onClick={() => refetch()}>
+            retry
+          </button>
+        </p>
+      ) : !hasRows ? (
+        // Reachable with the composer hidden too: a forum member with read but
+        // not write access gets neither, so without this the badge expands to
+        // an empty box.
+        <p className={s.empty}>No comments yet.</p>
+      ) : (
         <div className={s.list}>
           {pendingText && !pending?.parentUid && <PendingRow text={pendingText} />}
           {shown.map((comment) => (
@@ -234,16 +340,15 @@ export function FeedCommentsThread({ itemUid, kind, source, forumMainPid }: Feed
               forumTopicUrl={forumTopicUrl}
             />
           ))}
-          {comments.length > VISIBLE && (
-            <button type="button" className={s.viewAll} onClick={() => setExpanded((v) => !v)}>
-              {expanded
-                ? 'Show fewer comments'
-                : missingReplyCount > 0
-                  ? 'Show more comments'
-                  : `View all ${totalCount} comments`}
+          {showEscalation && (
+            <button type="button" className={s.viewAll} aria-haspopup="dialog" onClick={onViewAll}>
+              {/* totalCount counts what's LOADED. On a forum post with replies
+                  still on NodeBB that understates, so drop the number rather
+                  than print a wrong one. */}
+              {missingReplyCount > 0 ? 'View all comments' : `View all ${totalCount} comments`}
             </button>
           )}
-          {missingReplyCount > 0 && forumTopicUrl && (
+          {!isCard && missingReplyCount > 0 && forumTopicUrl && (
             <a className={s.forumLink} href={forumTopicUrl} target="_blank" rel="noopener noreferrer">
               {missingReplyCount === 1
                 ? '1 more comment on the forum →'
@@ -297,6 +402,15 @@ function Composer({
         // follows the click rather than making the member click twice.
         autoFocus={autoFocus}
         onChange={(e) => onChange(e.target.value)}
+        // Escape backs out of a reply composer, which is what everyone expects
+        // of one. Only inline: inside the modal, Modal's own capture-phase
+        // listener sees Escape first and closes the whole dialog.
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' && onCancel) {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
       />
       {onCancel && (
         <button type="button" className={s.replyCancelBtn} onClick={onCancel}>

--- a/components/page/home/TeamNews/components/ForumPostCard/ForumPostCard.tsx
+++ b/components/page/home/TeamNews/components/ForumPostCard/ForumPostCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
+import { useState } from 'react';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
@@ -14,6 +15,7 @@ import newsCardStyles from '../NewsCard/NewsCard.module.scss';
 import { UpvoteButton } from '../NewsCard/components/UpvoteButton/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { FeedForumPostShareMenu } from '../NewsShareMenu';
+import { FeedCommentsThread, feedThreadDomId } from '../FeedCommentsThread/FeedCommentsThread';
 
 import s from './ForumPostCard.module.scss';
 
@@ -35,10 +37,28 @@ interface ForumPostCardProps {
  */
 export function ForumPostCard({ post, position, onOpenDetail, onLikeToggle }: ForumPostCardProps) {
   const analytics = useTeamNewsAnalytics();
+  const [threadOpen, setThreadOpen] = useState(false);
+  // See NewsGroupCard: an unsettled comment blocks collapse, because the
+  // mutation's error state does not survive the unmount its cache writes do.
+  const [threadBusy, setThreadBusy] = useState(false);
 
   const handleOpenDetail = (via: TeamNewsCardClickVia = 'row') => {
     analytics.onFeedForumPostCardClicked(post, position, 'home', via);
     onOpenDetail(post);
+  };
+
+  const handleThreadToggle = () => {
+    if (threadOpen && threadBusy) return;
+    const next = !threadOpen;
+    setThreadOpen(next);
+    analytics.onFeedCommentThreadToggled(post.uid, 'forum', next, 'home');
+    // See NewsGroupCard: `nearest` reveals a thread opened near the viewport
+    // bottom without ever scrolling the feed to the top.
+    if (next) {
+      requestAnimationFrame(() => {
+        document.getElementById(feedThreadDomId(post.uid))?.scrollIntoView({ block: 'nearest' });
+      });
+    }
   };
 
   return (
@@ -89,10 +109,26 @@ export function ForumPostCard({ post, position, onOpenDetail, onLikeToggle }: Fo
           <span className={s.footerActions} onClick={(e) => e.stopPropagation()}>
             <FeedForumPostShareMenu post={post} source="home" />
             <UpvoteButton count={post.likeCount} voted={post.viewerHasLiked} onToggle={() => onLikeToggle(post)} />
-            {/* Opens the detail modal, where the thread lives. */}
-            <CommentButton itemUid={post.uid} onClick={() => handleOpenDetail('comment-button')} />
+            <CommentButton
+              itemUid={post.uid}
+              open={threadOpen}
+              onToggle={handleThreadToggle}
+              controls={feedThreadDomId(post.uid)}
+            />
           </span>
         </div>
+
+        {/* Mount = expanded (the lazy comments query keys off it). */}
+        {threadOpen && (
+          <FeedCommentsThread
+            itemUid={post.uid}
+            kind="forum"
+            source="home"
+            forumMainPid={post.mainPid}
+            onViewAll={() => handleOpenDetail('view-all-comments')}
+            onBusyChange={setThreadBusy}
+          />
+        )}
       </div>
     </div>
   );

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
@@ -30,3 +30,7 @@
     filter: brightness(0.8);
   }
 }
+
+.commentOpen {
+  color: #156ff7;
+}

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
@@ -12,9 +12,9 @@ import s from './CommentButton.module.scss';
 // cache (select-narrowed, so a count bump re-renders exactly this button, not
 // the feed); undefined means "unknown" and renders no number (never a fake "0").
 //
-// This is a count badge that OPENS the detail modal, not a disclosure toggle:
-// threads live only in the modal, where a depth-2 reply tree has room to
-// breathe. Hence no `open`/aria-expanded — there is nothing here to expand.
+// A disclosure control for the card's inline thread — hence `aria-expanded` and
+// `aria-controls`. Long threads escalate to the detail modal from inside the
+// thread itself, not from here.
 
 function CommentIcon() {
   return (
@@ -29,25 +29,35 @@ function CommentIcon() {
 
 interface CommentButtonProps {
   itemUid: string;
-  onClick: () => void;
+  open: boolean;
+  onToggle: () => void;
+  /** id of the thread region this button discloses. */
+  controls: string;
 }
 
-export function CommentButton({ itemUid, onClick }: CommentButtonProps) {
+export function CommentButton({ itemUid, open, onToggle, controls }: CommentButtonProps) {
   const count = useFeedCommentCount(itemUid);
   const noun = count === 1 ? 'Comment' : 'Comments';
+  const visibleLabel = count !== undefined ? `${count} ${noun}` : noun;
+  // The accessible name has to CARRY the visible text, not replace it: a bare
+  // "Show comments" hides the count from screen readers and leaves voice
+  // control with no way to say what it can see.
+  const label = `${visibleLabel}, ${open ? 'hide' : 'show'}`;
   return (
     <button
       type="button"
-      className={s.comment}
-      aria-label="View comments"
-      title="View comments"
+      className={clsx(s.comment, open && s.commentOpen)}
+      aria-expanded={open}
+      aria-controls={controls}
+      aria-label={label}
+      title={label}
       onClick={(e) => {
         e.stopPropagation();
-        onClick();
+        onToggle();
       }}
     >
       <CommentIcon />
-      <span>{count !== undefined ? `${count} ${noun}` : noun}</span>
+      <span>{visibleLabel}</span>
     </button>
   );
 }

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useMemo } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 import { useRouter } from 'next/navigation';
 
@@ -20,6 +20,7 @@ import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { NewsShareMenu } from '../NewsShareMenu';
 import { SourceList } from '../SourceList/SourceList';
+import { FeedCommentsThread, feedThreadDomId } from '../FeedCommentsThread/FeedCommentsThread';
 import { hasNewsSource } from '../../utils/getNewsSources';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
@@ -33,8 +34,8 @@ interface NewsGroupCardProps {
    *  analytics + modal state + URL sync lives in TeamNews.handleStoryOpen.
    *  (The old open-the-source-in-a-new-tab behavior moved into the modal's
    *  SOURCE links; NewsCard — team-details — still opens the source.)
-   *  `via` distinguishes the comment badge from the row, since both now open
-   *  the same modal and only the analytics can tell them apart. */
+   *  The comment badge no longer routes here; the only non-row caller is the
+   *  inline thread's "View all", which `via` distinguishes. */
   onStoryOpen: (item: ITeamNewsItem, via?: TeamNewsCardClickVia) => void;
   analyticsSource?: TeamNewsAnalyticsSource;
   isFollowing?: boolean;
@@ -60,6 +61,42 @@ export function NewsGroupCard({
   const { currentUser, isHydrated } = useCurrentUserStore();
   const analytics = useTeamNewsAnalytics();
 
+  // Per-story inline threads. Local like the card's own `expanded`, so the
+  // composite-key remount on tab/category change resets open threads (and any
+  // unsent drafts — accepted, documented loss; in-flight submits still land
+  // because the mutation's cache writes live in its options callbacks).
+  const [openThreadUids, setOpenThreadUids] = useState<ReadonlySet<string>>(() => new Set());
+  // Threads holding an unsettled comment. They refuse to collapse: the write's
+  // error state dies with the unmount, so a stray badge click would drop a
+  // failed comment without ever saying so.
+  const [busyThreadUids, setBusyThreadUids] = useState<ReadonlySet<string>>(() => new Set());
+
+  const setThreadBusy = (storyUid: string, busy: boolean) => {
+    setBusyThreadUids((current) => {
+      if (current.has(storyUid) === busy) return current;
+      const next = new Set(current);
+      busy ? next.add(storyUid) : next.delete(storyUid);
+      return next;
+    });
+  };
+
+  const handleThreadToggle = (storyUid: string) => {
+    if (busyThreadUids.has(storyUid) && openThreadUids.has(storyUid)) return;
+    const next = new Set(openThreadUids);
+    const willOpen = !next.has(storyUid);
+    willOpen ? next.add(storyUid) : next.delete(storyUid);
+    setOpenThreadUids(next);
+    analytics.onFeedCommentThreadToggled(storyUid, 'news', willOpen, analyticsSource);
+    // Opening a thread on a card near the bottom of the viewport otherwise
+    // renders the whole thing off-screen — the badge just changes colour.
+    // `nearest` never scrolls the feed to the top.
+    if (willOpen) {
+      requestAnimationFrame(() => {
+        document.getElementById(feedThreadDomId(storyUid))?.scrollIntoView({ block: 'nearest' });
+      });
+    }
+  };
+
   const handleFollowClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!currentUser) {
@@ -67,6 +104,14 @@ export function NewsGroupCard({
       return;
     }
     onFollowToggle?.(cluster.teamUid, cluster.teamName, isFollowing);
+  };
+
+  // Record which thread was open before bouncing to #login, so the round trip
+  // lands back on it (the modal's Follow gate does the same with ?news=).
+  const handleThreadSignIn = (storyUid: string) => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('news', storyUid);
+    router.push(`${window.location.pathname}?${params.toString()}#login`, { scroll: false });
   };
 
   const handleUpvoteClick = (story: ITeamNewsItem) => {
@@ -171,10 +216,25 @@ export function NewsGroupCard({
                   voted={Boolean(story.viewerHasUpvoted)}
                   onToggle={() => handleUpvoteClick(story)}
                 />
-                {/* Opens the detail modal, where the thread lives. */}
-                <CommentButton itemUid={story.uid} onClick={() => onStoryOpen(story, 'comment-button')} />
+                <CommentButton
+                  itemUid={story.uid}
+                  open={openThreadUids.has(story.uid)}
+                  onToggle={() => handleThreadToggle(story.uid)}
+                  controls={feedThreadDomId(story.uid)}
+                />
               </div>
             </div>
+            {/* Mount = expanded (the lazy comments query keys off it). */}
+            {openThreadUids.has(story.uid) && (
+              <FeedCommentsThread
+                itemUid={story.uid}
+                kind="news"
+                source={analyticsSource}
+                onViewAll={() => onStoryOpen(story, 'view-all-comments')}
+                onSignIn={() => handleThreadSignIn(story.uid)}
+                onBusyChange={(busy) => setThreadBusy(story.uid, busy)}
+              />
+            )}
           </div>
         );
       })}

--- a/services/feed/hooks/useAddFeedComment.ts
+++ b/services/feed/hooks/useAddFeedComment.ts
@@ -40,8 +40,14 @@ export function useAddFeedComment(itemUid: string, forumMainPid?: number) {
       // level — and a REPLY belongs under its parent at any depth, not appended
       // to the root list (which would silently promote it to a top-level
       // comment until the next refetch).
+      //
+      // Spread `old`: the entry also carries `forumTopic` (the NodeBB topic's
+      // url / totalReplyCount / like state). Rebuilding the object from `items`
+      // alone erased it on the first post, which silently took out the "N more
+      // comments on the forum" link, the escalation label's honesty about
+      // unloaded replies, and useFeedForumTopicLike's view of the vote state.
       queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), (old) =>
-        old ? { items: insertCommentIntoTree(old.items, created) } : { items: [created] },
+        old ? { ...old, items: insertCommentIntoTree(old.items, created) } : { items: [created] },
       );
       queryClient.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), (old) =>
         old ? { ...old, [itemUid]: (old[itemUid] ?? 0) + 1 } : { [itemUid]: 1 },

--- a/services/feed/hooks/useDeleteFeedComment.ts
+++ b/services/feed/hooks/useDeleteFeedComment.ts
@@ -33,7 +33,10 @@ export function useDeleteFeedComment(itemUid: string) {
         ? removeCommentFromTree(cached.items, commentUid)
         : { items: [], removedCount: 0 };
 
-      if (cached) queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), { items });
+      // Spread `cached` for the same reason useAddFeedComment spreads `old`:
+      // `forumTopic` rides on this entry and must survive the patch.
+      if (cached)
+        queryClient.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), { ...cached, items });
       if (removedCount > 0) {
         queryClient.setQueryData<IFeedCommentCountsResponse>(feedQueryKeys.commentCounts(), (old) =>
           old ? { ...old, [itemUid]: Math.max(0, (old[itemUid] ?? 0) - removedCount) } : old,

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -610,6 +610,7 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_FEED_FORUM_POST_MODAL_OPENED: 'team-news-feed-forum-post-modal-opened',
   TEAM_NEWS_FEED_FORUM_POST_LIKE_TOGGLED: 'team-news-feed-forum-post-like-toggled',
   TEAM_NEWS_FEED_FORUM_POST_SHARED: 'team-news-feed-forum-post-shared',
+  TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED: 'team-news-feed-comment-thread-toggled',
   TEAM_NEWS_FEED_COMMENT_SUBMITTED: 'team-news-feed-comment-submitted',
 };
 


### PR DESCRIPTION
## Summary

Restores the inline comment thread on `/home` feed cards. The **Comments** badge is a disclosure control again — it expands the thread in place on a news story row or a forum card, instead of opening the detail modal.

The modal keeps its thread and stays the target of row clicks and the `?news=` / `?post=` deep links. The card's **"View all N comments"** is now the only comment affordance that reaches it.

This reverses **D1** of #2708. That decision was never checked against design: the `newsfeed-v0` prototype it came from defaults to `commentsMode = 'without'`, so "no comments on the card" was a switch, not a verdict. Its stated reason — "a depth-2 reply tree does not fit a card" — holds for an *unbounded* thread, but the card shows the last two top-level comments and hands the rest over, which is roughly the height it had in #2695. Inline had only lived ~3 days before removal.

One optional prop, `onViewAll`, is the entire fork:

| | card (`onViewAll` passed) | modal (omitted) |
|---|---|---|
| Comments shown | last 2 top-level | **all** |
| Overflow | "View all N comments" → opens the modal | none |
| Forum "N more on the forum →" | hidden | shown |

## Three things found while building this

**1. The modal's thread was also capped at 2**, so the escalation would have shipped as a visible no-op — click "View all 9 comments", land in a modal showing the same two behind the same button. The modal now renders in full, and `FeedCommentsThread` has no expand state of its own. This is what makes `onViewAll`'s asymmetry load-bearing rather than cosmetic.

**2. A live bug, fixed first in its own commit.** Both comment mutations rebuilt the cache entry from `items` alone, so the first post or delete erased `forumTopic` — taking the "N more comments on the forum" link, `missingReplyCount` (a capped thread then claimed it was complete), and `useFeedForumTopicLike`'s view of the vote state. Present on `develop` today; inline would have put it on the default feed view. Both regression tests fail without the fix.

**3. The window was a sliding one.** `slice(-VISIBLE)` runs over a list that grows at the end, so posting a comment unmounted the row above it — discarding an open reply composer, its unsent draft, and any in-flight reply's pending row. Rows the member is working in are now pinned into the window.

## Also fixed, all newly load-bearing once the thread sits on a card

- **Loading / error-with-retry / empty states.** A badge reading "5 Comments" that expands to an empty box reads as breakage; the modal masked this behind the article body. Empty is reachable with no composer at all — a member with forum read but not write access gets neither.
- **A forum card whose loaded thread fits under the cap** but has replies left on NodeBB still escalates. Its forum link is modal-only, so keying the button off comment count alone made that card a dead end.
- **The escalation drops the number** when replies are unloaded, rather than printing a total it knows is short.
- **Nothing renders before the auth store hydrates.** `currentUser` is null either way at that point, so a fast guest could type a comment and get "couldn't post" instead of a login prompt.
- **A thread holding an unsettled comment refuses to collapse.** Its cache writes survive unmount but its error state does not, so a stray badge click during a slow POST could drop a failed comment in silence.
- **`aria-expanded` / `aria-controls` are back**, and the badge's accessible name now *carries* the count instead of overriding it with a flat "View comments" — the number was invisible to screen readers, and voice control had no way to say what it could see.
- **Escape** backs out of a reply composer (inline only — inside the modal its capture-phase listener still wins).
- **Opening scrolls the thread into view** with `block: 'nearest'`; on a card near the viewport bottom the badge otherwise just changed colour.
- **The signed-out gate writes `?news=<uid>`** before bouncing to `#login`, matching the modal's Follow gate, so the round trip returns to the thread instead of a collapsed feed.
- **Reply composer wraps below the mobile breakpoint.** At depth 2 on a phone the one-line row left the input ~90px; `.forumField` already ellipsis-truncated its own placeholder, which was the tell that this was tight even at 680px.

**Analytics:** `team-news-feed-comment-thread-toggled` returns — the only signal for opening a thread without opening the story. `TeamNewsCardClickVia` swaps `'comment-button'` for `'view-all-comments'`; the badge no longer opens anything, so keeping the old value would have read on dashboards as nobody using comments.

## Testing

- Full suite: **1131 passed, 0 failed**. `npm run build` passes. All 13 touched files lint clean.
- The four guard tests asserting "never renders a thread inline" were **inverted, not deleted** — they now assert collapsed-by-default and expand-on-click.
- New coverage: card cap + `onViewAll`, modal full expand, the `missingReplyCount` escalation case, the pinned window surviving an append, loading / error / empty, the pre-hydration guest, `onSignIn` override, and the collapse-while-busy guard.
- Both Phase 0 regression tests verified to fail without their fix (stashed the source, ran, restored).

## ⚠️ Not verified visually

`/home` needs an authenticated session against a live backend, so **no screenshots were taken and I have not seen this render.** Two things were reasoned from layout arithmetic rather than observed, and want a look before merge:

1. The depth-2 reply composer at ~360px.
2. A busy feed with two or three threads open — the "does this card now dominate the feed" question.

## Follow-ups, deliberately not in this PR

- **Sequencing:** news-item replies still nest optimistically and flatten on reload — the backend has no `parentUid` on `FeedComment`. This PR moves that bug onto the default feed view, so the BE fix should land first or close behind.
- **PR #2701** (@-mention autocomplete) is unmerged and rewrites this same composer; it needs a rebase onto #2708 regardless.
- Per-card forum-like correction (`useFeedForumTopicLike` is currently observed once, for the open modal only), reconciling the count badge with the loaded thread, lifting the thread out of the `role="button"` row (a text input inside a button — faithful to the prior implementation, invalid there too), and focus restore to `activeElement` after "View all".

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
