### PR TITLE
feat(feed): links and @mentions in feed comments

### DIFF
--- a/__tests__/page/home/feed-comment-content.test.tsx
+++ b/__tests__/page/home/feed-comment-content.test.tsx
@@ -1,0 +1,129 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import {
+  FeedCommentContent,
+  hasRenderableContent,
+} from '@/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent';
+
+/** The exact anchor RichTextEditor's MentionBlot emits. */
+const MENTION =
+  '<a class="ql-mention" href="/members/m_7fa2" data-uid="m_7fa2" data-external-id="ext-1" ' +
+  'data-name="Jane Doe" target="_blank" rel="noopener noreferrer">@Jane Doe</a>';
+
+describe('FeedCommentContent — links', () => {
+  it('turns a bare URL into a link', () => {
+    render(<FeedCommentContent html="<p>see https://example.com/docs</p>" />);
+
+    const link = screen.getByRole('link', { name: 'https://example.com/docs' });
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('leaves a trailing sentence period outside the link', () => {
+    render(<FeedCommentContent html="<p>see https://example.com.</p>" />);
+
+    expect(screen.getByRole('link', { name: 'https://example.com' })).toBeInTheDocument();
+  });
+
+  it('does not double-link a URL the editor already anchored on paste', () => {
+    render(<FeedCommentContent html='<p><a href="https://example.com">https://example.com</a></p>' />);
+
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('linkifies a legacy plain-text comment with no markup at all', () => {
+    render(<FeedCommentContent html="ship it https://example.com" />);
+
+    expect(screen.getByRole('link', { name: 'https://example.com' })).toBeInTheDocument();
+  });
+});
+
+describe('FeedCommentContent — mentions', () => {
+  it('keeps the mention anchor intact, identity attributes and all', () => {
+    render(<FeedCommentContent html={`<p>thanks ${MENTION}!</p>`} />);
+
+    const mention = screen.getByRole('link', { name: '@Jane Doe' });
+    // The relative href is the reason this component can't reuse
+    // NewsDetailModal's /^https?:/i URI allowlist.
+    expect(mention).toHaveAttribute('href', '/members/m_7fa2');
+    expect(mention).toHaveAttribute('data-uid', 'm_7fa2');
+    expect(mention).toHaveClass('ql-mention');
+  });
+
+  it('does not linkify inside a mention', () => {
+    render(<FeedCommentContent html={`<p>${MENTION} https://example.com</p>`} />);
+
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: '@Jane Doe' })).toBeInTheDocument();
+  });
+});
+
+describe('FeedCommentContent — sanitizing', () => {
+  it('strips a script tag', () => {
+    const { container } = render(<FeedCommentContent html="<p>hi</p><script>alert(1)</script>" />);
+
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toBe('hi');
+  });
+
+  it('strips an inline event handler', () => {
+    const { container } = render(<FeedCommentContent html={`<p onmouseover="alert(1)">hover</p>`} />);
+
+    expect(container.querySelector('p')).not.toHaveAttribute('onmouseover');
+  });
+
+  it('drops a javascript: href', () => {
+    render(<FeedCommentContent html={`<p><a href="javascript:alert(1)">click</a></p>`} />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('refuses an href that tries to break out of the attribute', () => {
+    // URL_REGEX accepts everything up to whitespace, `"` included, so linkify
+    // has to escape before interpolating.
+    const { container } = render(<FeedCommentContent html={`<p>https://x.test/"onmouseover="alert(1)</p>`} />);
+
+    expect(container.querySelector('[onmouseover]')).toBeNull();
+  });
+
+  it('drops tags outside the three-tag allowlist, keeping their text', () => {
+    // A forum post can carry images and headings; a feed card renders neither.
+    const { container } = render(<FeedCommentContent html="<h1>Title</h1><img src='x.png'><p>body</p>" />);
+
+    expect(container.querySelector('h1')).toBeNull();
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('body');
+  });
+
+  it('renders a legacy comment containing a stray angle bracket literally', () => {
+    render(<FeedCommentContent html="a < b" />);
+
+    expect(screen.getByText('a < b')).toBeInTheDocument();
+  });
+});
+
+describe('hasRenderableContent', () => {
+  it('is false for an image-only forum comment', () => {
+    // Truthy raw, but nothing survives the allowlist — the caller must fall
+    // back to "shared an image or file" instead of rendering a blank row.
+    expect(hasRenderableContent('<img src="https://example.com/a.png">')).toBe(false);
+  });
+
+  it('is false for Quill’s empty value', () => {
+    expect(hasRenderableContent('<p><br></p>')).toBe(false);
+  });
+
+  it('is false for whitespace-only content', () => {
+    expect(hasRenderableContent('<p>&nbsp; </p>')).toBe(false);
+  });
+
+  it('is true for a comment that is only a mention', () => {
+    expect(hasRenderableContent(`<p>${MENTION}</p>`)).toBe(true);
+  });
+
+  it('is true for legacy plain text', () => {
+    expect(hasRenderableContent('just text')).toBe(true);
+  });
+});

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -21,6 +21,51 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: routerPush }),
 }));
 
+// Quill needs a real DOM and is lazy-loaded, so it is useless in jsdom and
+// would render only its loading placeholder here. Stub it as a controlled
+// textarea with the same contract — value in, string out, Enter submits — so
+// these tests keep covering the THREAD rather than the editor. The editor's own
+// behaviour (mention anchors, toolbar off) belongs in its own suite.
+interface StubEditorProps {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  toolbarConfig?: unknown[];
+  enableMentions?: boolean;
+  maxLength?: number;
+}
+
+const mockEditorProps = jest.fn();
+jest.mock('@/components/ui/RichTextEditor/RichTextEditor', () => ({
+  __esModule: true,
+  default: (props: StubEditorProps) => {
+    mockEditorProps(props);
+    const { value, onChange, onSubmit, placeholder, disabled } = props;
+    return (
+      <textarea
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            onSubmit?.();
+          }
+        }}
+      />
+    );
+  },
+}));
+
+// next/dynamic would hand back the loading placeholder on first render; resolve
+// the one dynamic import in the module under test eagerly instead.
+jest.mock('next/dynamic', () => () => {
+  return require('@/components/ui/RichTextEditor/RichTextEditor').default;
+});
+
 // Forum writes are gated on forum.write, the same gate the /forum composer uses.
 const mockForumAccess = jest.fn();
 jest.mock('@/services/access-control/hooks/useForumAccess', () => ({
@@ -339,7 +384,68 @@ describe('FeedCommentsThread — replies', () => {
   });
 });
 
-describe('FeedCommentsThread — composer', () => {
+describe('FeedCommentsThread — composer (HTML content)', () => {
+  it('configures the editor with no toolbar — which is what keeps toasts out of the feed', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // RichTextEditor registers its imageUploader module only when the toolbar
+    // carries 'image', and that module holds the only two toast() calls in the
+    // component. An empty toolbar is therefore load-bearing, not cosmetic.
+    expect(mockEditorProps).toHaveBeenCalledWith(
+      expect.objectContaining({ toolbarConfig: [], enableMentions: true, maxLength: 2000 }),
+    );
+  });
+
+  it('treats Quill’s empty value as empty rather than as content', () => {
+    mockThread([]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // `<p><br></p>` is truthy, so the old `!value.trim()` guard would have
+    // enabled Comment and posted an empty comment.
+    fireEvent.change(screen.getByPlaceholderText('Write your comment here…'), {
+      target: { value: '<p><br></p>' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Comment' })).toBeDisabled();
+    fireEvent.submit(screen.getByPlaceholderText('Write your comment here…').closest('form')!);
+    expect(mutation.mutate).not.toHaveBeenCalled();
+  });
+
+  it('submits on Enter', () => {
+    mockThread([]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const field = screen.getByPlaceholderText('Write your comment here…');
+    fireEvent.change(field, { target: { value: '<p>ship it</p>' } });
+    fireEvent.keyDown(field, { key: 'Enter' });
+
+    expect(mutation.mutate).toHaveBeenCalledWith({ text: '<p>ship it</p>', parentUid: undefined }, expect.any(Object));
+  });
+
+  it('refuses a comment whose markup exceeds the server’s cap, and says why', () => {
+    mockThread([]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const field = screen.getByPlaceholderText('Write your comment here…');
+    // Short to read, far too long on the wire — which is what a pile of
+    // mention anchors does. The editor caps VISIBLE length, so only this
+    // guard stands between the member and a bare 400.
+    fireEvent.change(field, { target: { value: `<p>${'a'.repeat(2100)}</p>` } });
+    fireEvent.submit(field.closest('form')!);
+
+    expect(mutation.mutate).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/too long to post/i);
+
+    // Clears on the next keystroke, like every other composer error.
+    fireEvent.change(field, { target: { value: '<p>shorter</p>' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('submits the trimmed draft and clears the input only on success', () => {
     mockThread([]);
     const mutation = mockMutation(useAddFeedCommentMock);

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -148,12 +148,16 @@ describe('FeedCommentsThread — list', () => {
     expect(screen.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
   });
 
-  it('renders comment text as inert text — a script tag never executes or nests markup', () => {
-    mockThread([comment('c1', '<script>alert(1)</script>')]);
+  it('strips a script tag out of comment content entirely', () => {
+    mockThread([comment('c1', '<script>alert(1)</script>Hello')]);
     mockMutation(useAddFeedCommentMock);
     const { container } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
-    expect(screen.getByText('<script>alert(1)</script>')).toBeInTheDocument();
+
+    // Content is sanitized HTML now, so the tag is removed rather than shown
+    // literally — but it must never survive in any form.
     expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).not.toContain('alert(1)');
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('falls back to a readable byline when the author has no name (the wire allows null)', () => {
@@ -300,8 +304,10 @@ describe('FeedCommentsThread — replies', () => {
     render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
 
     const pending = screen.getByText('Sending');
-    const answeredRow = screen.getByText('Answered').closest('div');
-    const untouchedRow = screen.getByText('Untouched').closest('div');
+    // `.item` is the whole comment row. Not `.closest('div')` — comment bodies
+    // are a div-wrapped <p> now, so that would stop at the content wrapper.
+    const answeredRow = screen.getByText('Answered').closest('.item');
+    const untouchedRow = screen.getByText('Untouched').closest('.item');
 
     expect(answeredRow?.contains(pending)).toBe(true);
     expect(untouchedRow?.contains(pending)).toBe(false);

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -66,6 +66,12 @@ jest.mock('next/dynamic', () => () => {
   return require('@/components/ui/RichTextEditor/RichTextEditor').default;
 });
 
+const onFeedCommentSubmitted = jest.fn();
+const onFeedCommentMentionSelected = jest.fn();
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({ onFeedCommentSubmitted, onFeedCommentMentionSelected }),
+}));
+
 // Forum writes are gated on forum.write, the same gate the /forum composer uses.
 const mockForumAccess = jest.fn();
 jest.mock('@/services/access-control/hooks/useForumAccess', () => ({
@@ -424,6 +430,42 @@ describe('FeedCommentsThread — composer (HTML content)', () => {
     fireEvent.keyDown(field, { key: 'Enter' });
 
     expect(mutation.mutate).toHaveBeenCalledWith({ text: '<p>ship it</p>', parentUid: undefined }, expect.any(Object));
+  });
+
+  it('does not submit on Shift+Enter', () => {
+    mockThread([]);
+    const mutation = mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const field = screen.getByPlaceholderText('Write your comment here…');
+    fireEvent.change(field, { target: { value: '<p>line one</p>' } });
+    fireEvent.keyDown(field, { key: 'Enter', shiftKey: true });
+
+    expect(mutation.mutate).not.toHaveBeenCalled();
+  });
+
+  it('reports the mention count with a submitted comment, and the selection when it is picked', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // The editor owns the dropdown; the thread only forwards the selection.
+    mockEditorProps.mock.calls.at(-1)?.[0].onMentionSelected({ uid: 'm_7fa2', name: 'Jane Doe' });
+    expect(onFeedCommentMentionSelected).toHaveBeenCalledWith('n-1', 'news', 'home', {
+      memberUid: 'm_7fa2',
+      memberName: 'Jane Doe',
+    });
+
+    const mutation = useAddFeedCommentMock.mock.results[0].value;
+    const field = screen.getByPlaceholderText('Write your comment here…');
+    fireEvent.change(field, {
+      target: { value: '<p>hi <a class="ql-mention" data-uid="m_7fa2">@Jane Doe</a></p>' },
+    });
+    fireEvent.submit(field.closest('form')!);
+
+    const { onSuccess } = mutation.mutate.mock.calls[0][1];
+    act(() => onSuccess());
+    expect(onFeedCommentSubmitted).toHaveBeenCalledWith('n-1', 'news', 'home', false, 1);
   });
 
   it('refuses a comment whose markup exceeds the server’s cap, and says why', () => {

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -434,7 +434,7 @@ describe('feed.service', () => {
       expect(items[0].replies[0].parentUid).toBe('fpc_264');
     });
 
-    it('maps a NodeBB post onto the comment view model, HTML stripped', async () => {
+    it('maps a NodeBB post onto the comment view model, HTML intact', async () => {
       customFetchMock.mockResolvedValue({ ok: true, json: async () => topicResponse });
 
       const { items } = await getFeedComments('fp_96');
@@ -444,7 +444,9 @@ describe('feed.service', () => {
         itemUid: 'fp_96',
         parentUid: null,
         author: { uid: 'm-2', name: 'Lacey Wisdom', avatarUrl: null, role: 'General Partner' },
-        text: 'awesome!',
+        // Not stripped: a forum comment's own links and mentions live in this
+        // HTML. FeedCommentContent sanitizes it at render.
+        text: '<p>awesome!</p>',
         createdAt: new Date(1782906219045).toISOString(),
         isOwn: false,
         // Its own reply, asserted in full by the nesting tests above.
@@ -543,7 +545,7 @@ describe('feed.service', () => {
       expect(forumTopic?.like).toEqual({ likeCount: 0, viewerHasLiked: false });
     });
 
-    it('keeps an attachment-only reply as an empty-text comment for the UI to label', async () => {
+    it('passes an attachment-only reply through untouched, for the renderer to label', async () => {
       customFetchMock.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -556,9 +558,11 @@ describe('feed.service', () => {
 
       const { items } = await getFeedComments('fp_96');
 
-      // Not dropped, and not given fake text — the component says what it is.
+      // Not dropped, and not pre-judged here. The service no longer decides
+      // what's renderable — hasRenderableContent does, after sanitizing, which
+      // is the only place that knows the img won't survive the allowlist.
       expect(items).toHaveLength(1);
-      expect(items[0].text).toBe('');
+      expect(items[0].text).toBe('<p><img src="/x.png" /></p>');
     });
 
     it('throws when the forum is unreachable', async () => {

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -585,7 +585,7 @@ describe('feed.service', () => {
     it('replies to the topic’s opening post for a top-level comment, using the pid it was given', async () => {
       customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
 
-      await createFeedComment({ itemUid: 'fp_96', text: 'Great update!', forumMainPid: 263 });
+      await createFeedComment({ itemUid: 'fp_96', text: '<p>Great update!</p>', forumMainPid: 263 });
 
       // One request, not a fetch-the-topic-then-post pair.
       expect(customFetchMock).toHaveBeenCalledTimes(1);
@@ -593,6 +593,7 @@ describe('feed.service', () => {
         'https://forum.example.com/api/v3/topics/96',
         expect.objectContaining({
           method: 'POST',
+          // Quill already emits <p>; the service adds no wrapper of its own.
           body: JSON.stringify({ content: '<p>Great update!</p>', toPid: 263 }),
         }),
         false,
@@ -623,14 +624,38 @@ describe('feed.service', () => {
       expect(JSON.parse(customFetchMock.mock.calls[1][1].body).toPid).toBe(263);
     });
 
-    it('escapes member text — NodeBB stores content as HTML', async () => {
+    it('sends a mention through as a real anchor — escaping it made /forum show the markup', async () => {
       customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
 
-      await createFeedComment({ itemUid: 'fp_96', text: '<script>alert(1)</script> & "done"', forumMainPid: 263 });
+      const mention =
+        '<a class="ql-mention" href="/members/m_7fa2" data-uid="m_7fa2" data-name="Jane Doe">@Jane Doe</a>';
+      await createFeedComment({ itemUid: 'fp_96', text: `<p>thanks ${mention}!</p>`, forumMainPid: 263 });
 
-      expect(JSON.parse(customFetchMock.mock.calls[0][1].body).content).toBe(
-        '<p>&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;done&quot;</p>',
-      );
+      // The whole point of writing mentions in the forum's own anchor format is
+      // that NodeBB renders them. Escaping shipped `&lt;a class="ql-mention"…`
+      // as literal text on /forum.
+      const { content } = JSON.parse(customFetchMock.mock.calls[0][1].body);
+      expect(content).toContain('class="ql-mention"');
+      expect(content).toContain('data-uid="m_7fa2"');
+      expect(content).not.toContain('&lt;a');
+    });
+
+    it('sanitizes before sending — nothing executable reaches a page other members read', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => created });
+
+      await createFeedComment({
+        itemUid: 'fp_96',
+        text: '<p onclick="steal()">hi</p><script>alert(1)</script><a href="javascript:alert(1)">x</a>',
+        forumMainPid: 263,
+      });
+
+      // A forum comment becomes a real NodeBB post rendered by a pipeline we
+      // don't control, so the write boundary sanitizes as well as the read one.
+      const { content } = JSON.parse(customFetchMock.mock.calls[0][1].body);
+      expect(content).not.toContain('script');
+      expect(content).not.toContain('onclick');
+      expect(content).not.toContain('javascript:');
+      expect(content).toContain('hi');
     });
 
     it('returns the created comment carrying the caller’s parentUid, which NodeBB does not always echo', async () => {

--- a/__tests__/utils/linkifyHtml.test.ts
+++ b/__tests__/utils/linkifyHtml.test.ts
@@ -1,0 +1,41 @@
+import { linkifyHtml } from '@/utils/html';
+
+describe('linkifyHtml', () => {
+  it('wraps a bare URL in an anchor', () => {
+    expect(linkifyHtml('see https://example.com now')).toBe(
+      'see <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a> now',
+    );
+  });
+
+  it('leaves trailing sentence punctuation out of the href', () => {
+    expect(linkifyHtml('see https://example.com.')).toContain('href="https://example.com"');
+    expect(linkifyHtml('see https://example.com.')).toMatch(/<\/a>\.$/);
+  });
+
+  it('leaves a URL that is already anchored alone', () => {
+    const already = '<a href="https://example.com">https://example.com</a>';
+    expect(linkifyHtml(already)).toBe(already);
+  });
+
+  it('leaves URLs inside tag attributes alone', () => {
+    const markup = '<img src="https://example.com/a.png">';
+    expect(linkifyHtml(markup)).toBe(markup);
+  });
+
+  it('escapes a URL that would otherwise break out of the href attribute', () => {
+    // URL_REGEX matches everything up to whitespace, `"` included. QuillContent
+    // renders this function's output with NO sanitizer, so escaping here is the
+    // only thing standing between a crafted URL and an event handler.
+    const out = linkifyHtml('https://x.test/"onmouseover="alert(1)');
+
+    expect(out).not.toContain('onmouseover="alert(1)"');
+    expect(out).toContain('&quot;');
+  });
+
+  it('escapes angle brackets in the link text', () => {
+    const out = linkifyHtml('https://x.test/a&b');
+
+    expect(out).toContain('&amp;');
+    expect(out).not.toMatch(/href="[^"]*&(?!amp;)/);
+  });
+});

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -320,12 +320,29 @@ export const useTeamNewsAnalytics = () => {
     kind: FeedItemKind,
     source: TeamNewsAnalyticsSource,
     isReply = false,
+    mentionsCount = 0,
   ) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_SUBMITTED, {
       itemUid,
       kind,
       source,
       isReply,
+      mentionsCount,
+    });
+  };
+
+  // Never include comment text or the draft here — only the selection.
+  const onFeedCommentMentionSelected = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    mention: { memberUid: string; memberName: string },
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_MENTION_SELECTED, {
+      itemUid,
+      kind,
+      source,
+      ...mention,
     });
   };
 
@@ -350,5 +367,6 @@ export const useTeamNewsAnalytics = () => {
     onFeedForumPostShared,
     onFeedCommentThreadToggled,
     onFeedCommentSubmitted,
+    onFeedCommentMentionSelected,
   };
 };

--- a/app/api/members-search/route.ts
+++ b/app/api/members-search/route.ts
@@ -11,8 +11,12 @@ export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const search = searchParams.get('search') || '';
-    const page = parseInt(searchParams.get('page') || '1', 10);
-    const limit = parseInt(searchParams.get('limit') || '10', 10);
+    // Clamp paging: this route proxies the backend search unauthenticated-input
+    // first, so NaN/huge values must never be forwarded upstream.
+    const rawPage = parseInt(searchParams.get('page') || '1', 10);
+    const rawLimit = parseInt(searchParams.get('limit') || '10', 10);
+    const page = Number.isNaN(rawPage) ? 1 : Math.min(Math.max(rawPage, 1), 100);
+    const limit = Number.isNaN(rawLimit) ? 10 : Math.min(Math.max(rawLimit, 1), 25);
 
     if (isEmpty(search)) {
       return NextResponse.json({ items: [], total: 0 });
@@ -20,6 +24,12 @@ export async function GET(request: NextRequest) {
 
     const cookieStore = await cookies();
     const authToken = getParsedValue(cookieStore.get('authToken')?.value);
+
+    // Member search is a signed-in capability everywhere it's surfaced
+    // (mention pickers); without a token this is an open enumeration endpoint.
+    if (!authToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const result = await getMemberListForQuery(`search=${encodeURIComponent(search)}`, page, limit, authToken);
 

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import clsx from 'clsx';
+import { useMemo } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
+import parse from 'html-react-parser';
+
+import { isBlankHtml, linkifyHtml } from '@/utils/html';
+
+import s from './FeedCommentsThread.module.scss';
+
+/**
+ * A feed comment's body.
+ *
+ * Comment content is HTML now, from two sources that are equally untrusted:
+ * member-authored directory comments, and real NodeBB posts (which the forum's
+ * own composer wrote, and which the feed used to flatten with stripHtml). The
+ * app ships no CSP, so this sanitizer is the only defense layer — same
+ * rationale as NewsDetailModal's and PrdContent's.
+ *
+ * Pipeline order is deliberate: linkify FIRST, then sanitize. linkifyHtml emits
+ * markup, and running the sanitizer over its output means a malformed URL can
+ * never smuggle an attribute through. Sanitizing first would leave the anchors
+ * it adds unchecked.
+ *
+ * Old comments predate all of this and are plain text. They need no special
+ * case: a stray `<` is escaped by the sanitizer, and `.text` has never set
+ * `white-space: pre-wrap`, so their line breaks collapsed before too.
+ */
+
+// A no-toolbar composer can only produce paragraphs, breaks and anchors, so
+// that is the whole allowlist. Deliberately narrower than NewsDetailModal's,
+// and narrower than what NodeBB may send — a forum post's images and headings
+// are dropped here rather than rendered inside a feed card.
+const COMMENT_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: ['p', 'br', 'a'],
+  // NewsDetailModal allows `href` alone. A mention keeps its identity in
+  // `class` + `data-uid` (see RichTextEditor's MentionBlot), so both have to
+  // survive or the mention renders as an ordinary link.
+  ALLOWED_ATTR: ['href', 'class', 'target', 'rel', 'data-uid', 'data-name', 'data-external-id'],
+  // NewsDetailModal's /^https?:/i would reject a mention's own relative
+  // /members/<uid> href. Anything outside these three schemes — `javascript:`
+  // above all — still goes.
+  ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|\/members\/)/i,
+};
+
+// Registered at module scope: DOMPurify hooks are global and stack if added
+// per render. Identical to the hook NewsDetailModal and PrdContent register,
+// and idempotent alongside them — setting the same two attributes twice is a
+// no-op. Registering it here as well means this component does not depend on
+// one of those modules happening to be loaded first.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.hasAttribute('href')) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+/**
+ * Would this comment render as a visible body?
+ *
+ * Must be asked of the SANITIZED string, not the raw one: a forum comment that
+ * was only an image is a perfectly truthy `<img src=…>` that this allowlist
+ * drops to nothing. Callers use it to choose the "shared an image or file"
+ * fallback instead of rendering a blank row.
+ */
+export function hasRenderableContent(html: string): boolean {
+  return !isBlankHtml(DOMPurify.sanitize(html ?? '', COMMENT_SANITIZE_CONFIG));
+}
+
+interface FeedCommentContentProps {
+  /** Raw stored content: HTML for anything written since mentions shipped,
+   *  plain text for everything older. */
+  html: string;
+  className?: string;
+}
+
+export function FeedCommentContent({ html, className }: FeedCommentContentProps) {
+  const nodes = useMemo(() => parse(DOMPurify.sanitize(linkifyHtml(html ?? ''), COMMENT_SANITIZE_CONFIG)), [html]);
+
+  return <div className={clsx(s.text, s.richText, className)}>{nodes}</div>;
+}

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
@@ -2,10 +2,9 @@
 
 import clsx from 'clsx';
 import { useMemo } from 'react';
-import DOMPurify from 'isomorphic-dompurify';
 import parse from 'html-react-parser';
 
-import { isBlankHtml, linkifyHtml } from '@/utils/html';
+import { isBlankHtml, linkifyHtml, sanitizeCommentHtml } from '@/utils/html';
 
 import s from './FeedCommentsThread.module.scss';
 
@@ -28,34 +27,6 @@ import s from './FeedCommentsThread.module.scss';
  * `white-space: pre-wrap`, so their line breaks collapsed before too.
  */
 
-// A no-toolbar composer can only produce paragraphs, breaks and anchors, so
-// that is the whole allowlist. Deliberately narrower than NewsDetailModal's,
-// and narrower than what NodeBB may send — a forum post's images and headings
-// are dropped here rather than rendered inside a feed card.
-const COMMENT_SANITIZE_CONFIG = {
-  ALLOWED_TAGS: ['p', 'br', 'a'],
-  // NewsDetailModal allows `href` alone. A mention keeps its identity in
-  // `class` + `data-uid` (see RichTextEditor's MentionBlot), so both have to
-  // survive or the mention renders as an ordinary link.
-  ALLOWED_ATTR: ['href', 'class', 'target', 'rel', 'data-uid', 'data-name', 'data-external-id'],
-  // NewsDetailModal's /^https?:/i would reject a mention's own relative
-  // /members/<uid> href. Anything outside these three schemes — `javascript:`
-  // above all — still goes.
-  ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|\/members\/)/i,
-};
-
-// Registered at module scope: DOMPurify hooks are global and stack if added
-// per render. Identical to the hook NewsDetailModal and PrdContent register,
-// and idempotent alongside them — setting the same two attributes twice is a
-// no-op. Registering it here as well means this component does not depend on
-// one of those modules happening to be loaded first.
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if (node.tagName === 'A' && node.hasAttribute('href')) {
-    node.setAttribute('target', '_blank');
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
-
 /**
  * Would this comment render as a visible body?
  *
@@ -65,7 +36,7 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
  * fallback instead of rendering a blank row.
  */
 export function hasRenderableContent(html: string): boolean {
-  return !isBlankHtml(DOMPurify.sanitize(html ?? '', COMMENT_SANITIZE_CONFIG));
+  return !isBlankHtml(sanitizeCommentHtml(html));
 }
 
 interface FeedCommentContentProps {
@@ -76,7 +47,7 @@ interface FeedCommentContentProps {
 }
 
 export function FeedCommentContent({ html, className }: FeedCommentContentProps) {
-  const nodes = useMemo(() => parse(DOMPurify.sanitize(linkifyHtml(html ?? ''), COMMENT_SANITIZE_CONFIG)), [html]);
+  const nodes = useMemo(() => parse(sanitizeCommentHtml(linkifyHtml(html ?? ''))), [html]);
 
   return <div className={clsx(s.text, s.richText, className)}>{nodes}</div>;
 }

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -70,41 +70,51 @@
   background: var(--background-neutral-subtle, rgba(27, 56, 96, 0.06));
 }
 
-/* Composer input — reproduces the production forum FormField input (its border
-   + focus ring) at the 40px composer height. */
-.forumField {
-  flex: 1;
-  min-width: 0;
-  height: 40px; /* match the Comment button height */
-  padding: 0 14px;
-  border-radius: 8px;
-  border: 1px solid rgba(203, 213, 225, 0.5);
-  background: #fff;
-  font-family: inherit;
-  letter-spacing: -0.2px;
-  color: var(--foreground-neutral-primary, #0a0c11);
-  // Ellipsis-truncate the placeholder when it doesn't fit (e.g. narrow mobile).
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+/* RichTextEditor's own root is the field — nothing wraps it. It renders no
+   toolbar here (an empty toolbarConfig means `toolbar: false`), so .ql-container
+   IS the input and carries the full border, not just its bottom corners.
 
-  &::placeholder {
-    color: var(--foreground-neutral-tertiary, #8897ae);
-    text-overflow: ellipsis;
+   Doubled class throughout: RichTextEditor's own `.editor :global(.ql-…)` rules
+   are single-class, and CSS-module file order across chunks isn't something to
+   bet a layout on. Same trick as .commentBtn.commentBtn below. */
+.composerEditor.composerEditor {
+  :global(.ql-container) {
+    border: 1px solid rgba(203, 213, 225, 0.5);
+    border-radius: 8px;
+    background: #fff;
+    font-family: inherit;
   }
 
-  &:focus {
-    outline: none;
-    border-color: #5e718d;
-    box-shadow: 0 0 0 4px rgba(27, 56, 96, 0.12);
+  :global(.ql-editor) {
+    /* 10 + 20 line-height + 10 = the 40px the Comment button is. */
+    padding: 10px 14px;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: -0.2px;
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+
+  /* Quill's placeholder is a ::before on the blank editor, not a real
+     placeholder attribute, so it needs positioning and truncation of its own. */
+  :global(.ql-editor.ql-blank::before) {
+    left: 14px;
+    right: 14px;
+    font-style: normal;
+    color: var(--foreground-neutral-tertiary, #8897ae);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
-/* The app forces all inputs to 16px !important (`.root input`, an anti-iOS-zoom
-   rule). Beat it with a higher-specificity !important so the field text is the
-   requested 14px. */
-.forumField.forumField {
-  font-size: 14px !important;
+/* The editor sits in the composer row next to Cancel / Comment. Its root is
+   RichTextEditor's own scoped class, so it can't be named from here — but it is
+   the row's only non-button child. */
+.inline > div {
+  /* basis 0, not auto: RichTextEditor's root sets width:100%, which as a
+     flex-basis would start it at full row width and squeeze the buttons. */
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 /* A bit smaller than the forum's 50px input row, same brand styling. */
@@ -328,17 +338,17 @@
   }
 }
 
-/* The reply row is input + Cancel + Reply on one line. At depth 2 on a phone
-   that leaves the input around 90px once the card padding, two indent levels,
-   the avatar and both buttons are taken out — .forumField already
-   ellipsis-truncates its own placeholder, which was the tell. Stack instead:
-   full-width input, buttons right-aligned underneath. */
+/* The reply row is editor + Cancel + Reply on one line. At depth 2 on a phone
+   that leaves the editor around 90px once the card padding, two indent levels,
+   the avatar and both buttons are taken out — the placeholder had to
+   ellipsis-truncate, which was the tell. Stack instead: full-width editor,
+   buttons right-aligned underneath. */
 @include media.mobile-only {
   .replyComposer .inline {
     flex-wrap: wrap;
   }
 
-  .replyComposer .forumField {
+  .replyComposer .inline > div {
     flex: 1 0 100%;
   }
 

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -399,6 +399,38 @@
   color: var(--foreground-neutral-secondary, #455468);
 }
 
+/* Comment bodies are sanitized HTML now (p / br / a only). Link + mention
+   treatment copied from the forum's CommentItem.module.scss `.autoLink` rather
+   than imported — copying is the house rule for crossing page-domain
+   boundaries. `overflow-wrap` matters: a pasted URL is one unbreakable token
+   and will otherwise push a card wider than the feed. */
+.richText {
+  overflow-wrap: anywhere;
+
+  p {
+    margin: 0;
+
+    + p {
+      margin-top: 8px;
+    }
+  }
+
+  a {
+    color: var(--foreground-brand-primary, #1b4dff);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  /* A mention is a member's name, so it reads as a name first and a link
+     second — weight instead of the plain link colour's full contrast. */
+  :global(.ql-mention) {
+    font-weight: 600;
+  }
+}
+
 /* Own-comment delete affordance — quiet until hovered, matching .viewAll's
    "don't compete with the content" treatment. */
 .deleteBtn {

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.module.scss
@@ -62,6 +62,14 @@
   cursor: pointer;
 }
 
+/* Holds the editor's place while Quill lazy-loads, so the composer row doesn't
+   jump when it arrives. */
+.composerLoading {
+  height: 40px;
+  border-radius: var(--corner-radius-md, 8px);
+  background: var(--background-neutral-subtle, rgba(27, 56, 96, 0.06));
+}
+
 /* Composer input — reproduces the production forum FormField input (its border
    + focus ring) at the 40px composer height. */
 .forumField {

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import clsx from 'clsx';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { clampDepth } from '@/utils/comments';
+import { isBlankHtml } from '@/utils/html';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
 import { forumErrorMessage } from '@/services/forum/forum.service';
@@ -21,6 +23,15 @@ import { FeedCommentContent, hasRenderableContent } from './FeedCommentContent';
 
 import s from './FeedCommentsThread.module.scss';
 
+// Quill is ~100kB of editor for a one-line comment box, and most /home visits
+// never open a composer. ssr:false because it needs the DOM.
+// Imported by path, not through the barrel: `index.ts` is `export *`, which
+// does not re-export the default, so dynamic() would resolve to no component.
+const RichTextEditor = dynamic(() => import('@/components/ui/RichTextEditor/RichTextEditor'), {
+  ssr: false,
+  loading: () => <div className={s.composerLoading} />,
+});
+
 // Show at most this many TOP-LEVEL comments before capping behind "View all N …".
 const VISIBLE = 2;
 
@@ -31,6 +42,9 @@ const VISIBLE = 2;
 const MAX_DEPTH = 2;
 
 const POST_FAILED = 'Couldn’t post your comment — try again.';
+// A mention costs ~150 characters of markup behind a short name, so this can
+// fire on a comment that looks well within the limit. Name the likely cause.
+const TOO_LONG = 'That’s too long to post — try shortening it, or removing a mention.';
 
 /** Total comments in the thread, replies included — matches what the count
  *  badge shows (the backend counts every row under an item, at any depth). */
@@ -156,6 +170,10 @@ export function FeedCommentsThread({
   // One open reply composer at a time — a thread full of open inputs is noise,
   // and the draft belongs to whichever comment the member is answering.
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  // Which composer, if any, refused a submit for exceeding the server's cap on
+  // the serialised string. `undefined` = no such failure; `null` = the
+  // top-level composer, mirroring how errorParentUid reads.
+  const [oversizeParentUid, setOversizeParentUid] = useState<string | null | undefined>(undefined);
 
   // The only difference between the card and the modal. See the prop's doc.
   const isCard = onViewAll !== undefined;
@@ -194,7 +212,17 @@ export function FeedCommentsThread({
 
   const submit = (text: string, parentUid?: string) => {
     const trimmed = text.trim();
-    if (!trimmed || addComment.isPending) return false;
+    // isBlankHtml, not `!trimmed` — Quill's empty value is `<p><br></p>`.
+    if (isBlankHtml(trimmed) || addComment.isPending) return false;
+    // The composer caps VISIBLE characters, but the server caps the serialised
+    // string. A mention anchor is ~150 characters of markup behind a name, so
+    // a comment that looks well short of the limit can still be refused. Say
+    // so here rather than letting it come back as a bare 400.
+    if (trimmed.length > FEED_COMMENT_MAX_LENGTH) {
+      setOversizeParentUid(parentUid ?? null);
+      return false;
+    }
+    setOversizeParentUid(undefined);
     addComment.mutate(
       { text: trimmed, parentUid },
       {
@@ -213,6 +241,7 @@ export function FeedCommentsThread({
   const clearError = () => {
     // A stale "couldn't post" must not sit above a fresh draft.
     if (addComment.isError) addComment.reset();
+    if (oversizeParentUid !== undefined) setOversizeParentUid(undefined);
   };
 
   const handleDraftChange = (value: string) => {
@@ -240,10 +269,16 @@ export function FeedCommentsThread({
     ? isForumPost
       ? forumErrorMessage(addComment.error, POST_FAILED)
       : POST_FAILED
-    : undefined;
+    : oversizeParentUid !== undefined
+      ? TOO_LONG
+      : undefined;
   // `null` = the failure belongs to the top-level composer; a uid = to that
   // comment's reply composer. Without this the same error renders in both.
-  const errorParentUid = errorText ? (attempt?.parentUid ?? null) : undefined;
+  const errorParentUid = addComment.isError
+    ? errorText
+      ? (attempt?.parentUid ?? null)
+      : undefined
+    : oversizeParentUid;
 
   // "Latest ref" so the report below keys off the busy flag alone — callers
   // pass an inline arrow, and depending on its identity would re-fire every
@@ -395,7 +430,19 @@ interface ComposerProps {
   autoFocus?: boolean;
 }
 
-/** The composer row, shared by the thread's own input and every reply input. */
+/**
+ * The composer row, shared by the thread's own input and every reply input.
+ *
+ * A Quill editor rather than an <input>, so that a mention is written in the
+ * forum's own `ql-mention` anchor format — the only encoding that renders on
+ * both /home and /forum. Lazy-loaded: Quill stays out of the /home bundle
+ * until a member actually opens a composer.
+ *
+ * Configured down to something that looks like a text field: no toolbar, which
+ * also drops the imageUploader module (it is registered only when the toolbar
+ * carries 'image') and with it the only code path in RichTextEditor that can
+ * fire a toast — banned throughout TeamNews.
+ */
 function Composer({
   value,
   onChange,
@@ -406,7 +453,9 @@ function Composer({
   onCancel,
   autoFocus,
 }: ComposerProps) {
-  const canSubmit = Boolean(value.trim()) && !disabled;
+  // Quill's "empty" value is `<p><br></p>`, which is truthy — `value.trim()`
+  // would have happily enabled submit on an empty composer.
+  const canSubmit = !isBlankHtml(value) && !disabled;
 
   return (
     <form
@@ -415,26 +464,34 @@ function Composer({
         e.preventDefault();
         onSubmit();
       }}
+      // Escape backs out of a reply composer, which is what everyone expects of
+      // one. Only inline: inside the modal, Modal's own capture-phase listener
+      // sees Escape first and closes the whole dialog.
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && onCancel) {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
     >
-      <input
-        className={s.forumField}
-        value={value}
-        maxLength={FEED_COMMENT_MAX_LENGTH}
-        placeholder={placeholder}
-        // Opening a reply box is an explicit request to type in it, so focus
-        // follows the click rather than making the member click twice.
-        autoFocus={autoFocus}
-        onChange={(e) => onChange(e.target.value)}
-        // Escape backs out of a reply composer, which is what everyone expects
-        // of one. Only inline: inside the modal, Modal's own capture-phase
-        // listener sees Escape first and closes the whole dialog.
-        onKeyDown={(e) => {
-          if (e.key === 'Escape' && onCancel) {
-            e.preventDefault();
-            onCancel();
-          }
-        }}
-      />
+      <div className={s.forumField}>
+        <RichTextEditor
+          value={value}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          enableMentions
+          // Empty toolbar: no formatting UI, and no imageUploader module.
+          toolbarConfig={[]}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          // Counts VISIBLE characters (Quill's getLength), not markup — which
+          // is what a member perceives. The server's cap is on the serialised
+          // string, so `submit` guards that separately.
+          maxLength={FEED_COMMENT_MAX_LENGTH}
+          minHeight={40}
+        />
+      </div>
       {onCancel && (
         <button type="button" className={s.replyCancelBtn} onClick={onCancel}>
           Cancel

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -17,6 +17,8 @@ import { FEED_COMMENT_MAX_LENGTH } from '@/services/feed/constants';
 import { useTeamNewsAnalytics, type FeedItemKind, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { isForumPostUid, type IFeedComment } from '@/types/feed.types';
 
+import { FeedCommentContent, hasRenderableContent } from './FeedCommentContent';
+
 import s from './FeedCommentsThread.module.scss';
 
 // Show at most this many TOP-LEVEL comments before capping behind "View all N …".
@@ -463,7 +465,9 @@ function PendingRow({ text }: { text: string }) {
           <span className={s.name}>{name}</span>
           <span className={s.time}>· posting…</span>
         </div>
-        <p className={s.text}>{text}</p>
+        {/* Same pipeline as a landed comment, so a mention or link the member
+            just typed doesn't visibly change shape when the server confirms. */}
+        <FeedCommentContent html={text} />
       </div>
     </div>
   );
@@ -576,11 +580,12 @@ function CommentRow(props: CommentRowProps) {
               </button>
             ))}
         </div>
-        {/* A forum comment that was only an image or a file strips to nothing —
-            the text is plain by contract, and the attachment isn't in it. Say so
-            and point at where it can be seen, rather than rendering a blank row. */}
-        {comment.text ? (
-          <p className={s.text}>{comment.text}</p>
+        {/* A forum comment that was only an image or a file sanitizes to
+            nothing under the feed's three-tag allowlist. Say so and point at
+            where it can be seen, rather than rendering a blank row. Asked of
+            the sanitized string: the raw one is a truthy `<img src=…>`. */}
+        {hasRenderableContent(comment.text) ? (
+          <FeedCommentContent html={comment.text} />
         ) : (
           <p className={clsx(s.text, s.textAttachment)}>
             {forumTopicUrl ? (

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -52,6 +52,12 @@ function countComments(comments: readonly IFeedComment[]): number {
   return comments.reduce((total, comment) => total + 1 + countComments(comment.replies), 0);
 }
 
+/** How many members this comment mentions — the class MentionBlot stamps is
+ *  the only marker distinguishing a mention from an ordinary link. */
+function countMentions(html: string): number {
+  return html.match(/class="ql-mention"/g)?.length ?? 0;
+}
+
 /** Is `uid` this comment or anywhere in its subtree? */
 function containsUid(comment: IFeedComment, uid: string): boolean {
   return comment.uid === uid || comment.replies.some((reply) => containsUid(reply, uid));
@@ -119,9 +125,12 @@ interface FeedCommentsThreadProps {
  *
  * Mount = expanded: the parent renders this component only while the thread is
  * open, so the lazy comments query fetches on mount and, with no observer after
- * close, never refetches in the background. All comment text / names / roles
- * render via JSX text interpolation only — dangerouslySetInnerHTML is banned in
- * this component, and forum HTML arrives already stripped to plain text.
+ * close, never refetches in the background.
+ *
+ * Comment BODIES are HTML — they carry links and `ql-mention` anchors — and go
+ * through FeedCommentContent, which is the only place allowed to render them.
+ * Everything else here (names, roles, timestamps) is still JSX text
+ * interpolation, and forum content is no longer pre-stripped by the service.
  *
  * Two surfaces, one component, told apart by `onViewAll`:
  * - CARD (prop passed): shows the last VISIBLE top-level comments and escalates
@@ -231,11 +240,19 @@ export function FeedCommentsThread({
           // options callbacks, which survive this component unmounting.
           if (parentUid) setReplyingTo(null);
           else setDraft('');
-          analytics.onFeedCommentSubmitted(itemUid, kind, source, Boolean(parentUid));
+          analytics.onFeedCommentSubmitted(itemUid, kind, source, Boolean(parentUid), countMentions(trimmed));
         },
       },
     );
     return true;
+  };
+
+  // Only the selection, never the draft it was typed into.
+  const reportMentionSelected = (member: { uid: string; name: string }) => {
+    analytics.onFeedCommentMentionSelected(itemUid, kind, source, {
+      memberUid: member.uid,
+      memberName: member.name,
+    });
   };
 
   const clearError = () => {
@@ -340,6 +357,7 @@ export function FeedCommentsThread({
               placeholder="Write your comment here…"
               submitLabel="Comment"
               disabled={addComment.isPending}
+              onMentionSelected={reportMentionSelected}
             />
             {errorText && errorParentUid === null && (
               <p className={s.error} role="alert">
@@ -396,6 +414,7 @@ export function FeedCommentsThread({
               deleteFailed={deleteComment.isError}
               resetDelete={deleteComment.reset}
               forumTopicUrl={forumTopicUrl}
+              onMentionSelected={reportMentionSelected}
             />
           ))}
           {showEscalation && (
@@ -428,6 +447,7 @@ interface ComposerProps {
   disabled: boolean;
   onCancel?: () => void;
   autoFocus?: boolean;
+  onMentionSelected: (member: { uid: string; name: string }) => void;
 }
 
 /**
@@ -452,6 +472,7 @@ function Composer({
   disabled,
   onCancel,
   autoFocus,
+  onMentionSelected,
 }: ComposerProps) {
   // Quill's "empty" value is `<p><br></p>`, which is truthy — `value.trim()`
   // would have happily enabled submit on an empty composer.
@@ -480,6 +501,7 @@ function Composer({
           onChange={onChange}
           onSubmit={onSubmit}
           enableMentions
+          onMentionSelected={onMentionSelected}
           // Empty toolbar: no formatting UI, and no imageUploader module.
           toolbarConfig={[]}
           placeholder={placeholder}
@@ -549,6 +571,7 @@ interface CommentRowProps {
   resetDelete: () => void;
   /** Where an attachment-only comment can actually be seen (forum posts only). */
   forumTopicUrl: string | undefined;
+  onMentionSelected: (member: { uid: string; name: string }) => void;
 }
 
 /**
@@ -580,6 +603,7 @@ function CommentRow(props: CommentRowProps) {
     deleteFailed,
     resetDelete,
     forumTopicUrl,
+    onMentionSelected,
   } = props;
 
   const [replyDraft, setReplyDraft] = useState('');
@@ -680,6 +704,7 @@ function CommentRow(props: CommentRowProps) {
               placeholder={`Reply to ${displayName}…`}
               submitLabel="Reply"
               disabled={isSubmitting}
+              onMentionSelected={onMentionSelected}
             />
             {errorHere && (
               <p className={s.error} role="alert">

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -495,25 +495,28 @@ function Composer({
         }
       }}
     >
-      <div className={s.forumField}>
-        <RichTextEditor
-          value={value}
-          onChange={onChange}
-          onSubmit={onSubmit}
-          enableMentions
-          onMentionSelected={onMentionSelected}
-          // Empty toolbar: no formatting UI, and no imageUploader module.
-          toolbarConfig={[]}
-          placeholder={placeholder}
-          disabled={disabled}
-          autoFocus={autoFocus}
-          // Counts VISIBLE characters (Quill's getLength), not markup — which
-          // is what a member perceives. The server's cap is on the serialised
-          // string, so `submit` guards that separately.
-          maxLength={FEED_COMMENT_MAX_LENGTH}
-          minHeight={40}
-        />
-      </div>
+      {/* No wrapper element: RichTextEditor's own root is the field. Wrapping
+          it drew a second border around Quill's, and a fixed height on the
+          wrapper clipped the editable area so clicks landed on nothing. */}
+      <RichTextEditor
+        className={s.composerEditor}
+        value={value}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        enableMentions
+        onMentionSelected={onMentionSelected}
+        // Empty toolbar means NO toolbar element at all, and no imageUploader
+        // module — which is where RichTextEditor's only toast() calls live.
+        toolbarConfig={[]}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        // Counts VISIBLE characters (Quill's getLength), not markup — which
+        // is what a member perceives. The server's cap is on the serialised
+        // string, so `submit` guards that separately.
+        maxLength={FEED_COMMENT_MAX_LENGTH}
+        minHeight={40}
+      />
       {onCancel && (
         <button type="button" className={s.replyCancelBtn} onClick={onCancel}>
           Cancel

--- a/components/ui/QuillContent/QuillContent.tsx
+++ b/components/ui/QuillContent/QuillContent.tsx
@@ -4,45 +4,13 @@ import clsx from 'clsx';
 import { useMemo } from 'react';
 import 'react-quill-new/dist/quill.snow.css';
 
+import { linkifyHtml } from '@/utils/html';
+
 import s from './QuillContent.module.scss';
 
 interface Props {
   html: string;
   className?: string;
-}
-
-const URL_REGEX = /(https?:\/\/[^\s<]+)/g;
-// Trailing characters that are almost always punctuation, not part of the URL
-// (e.g. a sentence-ending period or a closing bracket around the link).
-const TRAILING_PUNCTUATION = /[.,;:!?)\]]+$/;
-
-/**
- * Wrap bare URLs in anchor tags so links typed into the editor (which Quill
- * leaves as plain text) render as clickable links. Only text outside of
- * existing tags and existing <a> elements is touched, so already-linked URLs
- * and tag attributes are left untouched.
- */
-function linkifyHtml(html: string): string {
-  let anchorDepth = 0;
-
-  return html
-    .split(/(<[^>]+>)/g)
-    .map((part) => {
-      if (part.startsWith('<')) {
-        if (/^<a[\s>]/i.test(part)) anchorDepth += 1;
-        else if (/^<\/a>/i.test(part)) anchorDepth = Math.max(0, anchorDepth - 1);
-        return part;
-      }
-
-      if (anchorDepth > 0) return part;
-
-      return part.replace(URL_REGEX, (url) => {
-        const trailing = url.match(TRAILING_PUNCTUATION)?.[0] ?? '';
-        const href = trailing ? url.slice(0, -trailing.length) : url;
-        return `<a href="${href}" target="_blank" rel="noopener noreferrer">${href}</a>${trailing}`;
-      });
-    })
-    .join('');
 }
 
 export function QuillContent(props: Props) {
@@ -58,9 +26,6 @@ export function QuillContent(props: Props) {
   }, [html]);
 
   return (
-    <div
-      className={clsx('ql-editor', s.content, className)}
-      dangerouslySetInnerHTML={{ __html: linkifiedHtml }}
-    />
+    <div className={clsx('ql-editor', s.content, className)} dangerouslySetInnerHTML={{ __html: linkifiedHtml }} />
   );
 }

--- a/components/ui/RichTextEditor/RichTextEditor.tsx
+++ b/components/ui/RichTextEditor/RichTextEditor.tsx
@@ -150,23 +150,29 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
     const hasImage = container.some((group) => group.includes('image'));
 
     return {
-      toolbar: {
-        container,
-        handlers: {
-          ...(hasMention && {
-            mention: function () {
-              const editor = quillRef.current?.getEditor();
-              if (editor) {
-                const selection = editor.getSelection();
-                if (selection) {
-                  editor.insertText(selection.index, '@');
-                  editor.setSelection(selection.index + 1);
-                }
-              }
+      // `false`, not an empty container: given `[]`, the snow theme still
+      // builds a toolbar element, so the caller gets an empty bordered strip
+      // above the editor that takes space and can't be clicked through.
+      toolbar:
+        container.length === 0
+          ? false
+          : {
+              container,
+              handlers: {
+                ...(hasMention && {
+                  mention: function () {
+                    const editor = quillRef.current?.getEditor();
+                    if (editor) {
+                      const selection = editor.getSelection();
+                      if (selection) {
+                        editor.insertText(selection.index, '@');
+                        editor.setSelection(selection.index + 1);
+                      }
+                    }
+                  },
+                }),
+              },
             },
-          }),
-        },
-      },
       ...(hasImage && {
         imageUploader: {
           upload: (file: File) => {

--- a/components/ui/RichTextEditor/RichTextEditor.tsx
+++ b/components/ui/RichTextEditor/RichTextEditor.tsx
@@ -37,6 +37,11 @@ interface Props {
   placeholder?: string;
   toolbarConfig?: (string | Record<string, unknown>)[][];
   minHeight?: number;
+  /** Opt in to Enter-submits / Shift+Enter-newlines, for single-message
+   *  composers rather than documents. Lives here rather than in the caller
+   *  because only this component knows whether the mention dropdown is open,
+   *  and Enter belongs to the dropdown whenever it is. */
+  onSubmit?: () => void;
 }
 
 const QL_EDITOR_CLASS = 'ql-editor';
@@ -77,6 +82,7 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
     placeholder,
     toolbarConfig,
     minHeight,
+    onSubmit,
   } = props;
 
   const quillRef = useRef<any>(null);
@@ -372,6 +378,18 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
     }
   };
 
+  // Capture phase, on the container: Quill's own keyboard module listens on
+  // the editor root, so intercepting here runs first and preventDefault stops
+  // the newline. Enter belongs to the mention dropdown whenever it is open.
+  const handleKeyDownCapture = (e: React.KeyboardEvent) => {
+    if (!onSubmit) return;
+    if (e.key !== 'Enter' || e.shiftKey) return;
+    if (enableMentions && mentionState.isOpen) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onSubmit();
+  };
+
   return (
     <div
       ref={editorContainerRef}
@@ -379,6 +397,7 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
         [s.error]: !!errorMessage,
       })}
       id={id}
+      onKeyDownCapture={onSubmit ? handleKeyDownCapture : undefined}
     >
       <ReactQuill
         ref={mergeRefs([ref, quillRef])}

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -2,6 +2,7 @@ import { customFetch } from '@/utils/fetch-wrapper';
 import { getHeader } from '@/utils/common.utils';
 import { stripHtml } from '@/utils/forum';
 import { buildCommentTree } from '@/utils/comments';
+import { sanitizeCommentHtml } from '@/utils/html';
 import { forumFetch, postForumReply } from '@/services/forum/forum.service';
 import type { Topic } from '@/services/forum/hooks/useForumPosts';
 import type { TopicResponse } from '@/services/forum/hooks/useForumPost';
@@ -291,7 +292,15 @@ async function createForumPostComment(request: ICreateFeedCommentRequest): Promi
   const parentPid = request.parentUid ? pidFromForumCommentUid(request.parentUid) : undefined;
   const toPid = parentPid ?? request.forumMainPid ?? (await fetchTopicMainPid(tid));
 
-  const created = await postForumReply({ tid, toPid, content: `<p>${escapeHtml(request.text)}</p>` });
+  // Sanitized, NOT escaped. Comment content is Quill HTML now, so escaping it
+  // shipped the markup to NodeBB as literal text — a mention arrived on /forum
+  // reading `&lt;a class="ql-mention"…&gt;@Jane Doe&lt;/a&gt;`, which defeated
+  // the entire point of writing mentions in the forum's own anchor format.
+  // Sanitizing keeps the guarantee escaping was there for (nothing executable
+  // reaches a page other members read, through a renderer we don't control)
+  // while letting mentions and links through. Quill already emits <p>, so no
+  // wrapping either.
+  const created = await postForumReply({ tid, toPid, content: sanitizeCommentHtml(request.text) });
   const post = (created?.response ?? created) as TopicPost;
 
   return {
@@ -312,15 +321,6 @@ async function fetchTopicMainPid(tid: number): Promise<number> {
 }
 
 /** NodeBB stores post content as HTML, so member text must not be markup. */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedCommentsResponse> {
   const response = await forumFetch(`/api/topic/${tidFromForumPostUid(itemUid)}`);
   if (!response?.ok) throw new Error('Failed to fetch feed comments');

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -257,7 +257,11 @@ function toForumFeedComment(post: TopicPost, itemUid: ForumPostUid, mainPid: num
       avatarUrl: user?.picture ?? null,
       role: user?.teamRole ?? null,
     },
-    text: stripHtml(post.content ?? ''),
+    // NOT stripped any more. A forum comment's own links and mentions are in
+    // this HTML, and flattening it was why they rendered as inert text in the
+    // feed while working fine on /forum. FeedCommentContent sanitizes it down
+    // to p/br/a at render — images and headings still don't reach a card.
+    text: post.content ?? '',
     createdAt: new Date(Number(post.timestamp) || Date.now()).toISOString(),
     // Deleting a real NodeBB reply from the feed isn't implemented, so the
     // delete affordance is never offered — regardless of who wrote it.

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -612,6 +612,7 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_FEED_FORUM_POST_SHARED: 'team-news-feed-forum-post-shared',
   TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED: 'team-news-feed-comment-thread-toggled',
   TEAM_NEWS_FEED_COMMENT_SUBMITTED: 'team-news-feed-comment-submitted',
+  TEAM_NEWS_FEED_COMMENT_MENTION_SELECTED: 'team-news-feed-comment-mention-selected',
 };
 
 export const FOLLOW_ANALYTICS_EVENTS = {

--- a/utils/html/index.ts
+++ b/utils/html/index.ts
@@ -1,0 +1,2 @@
+export { linkifyHtml } from './linkifyHtml';
+export { isBlankHtml } from './isBlankHtml';

--- a/utils/html/index.ts
+++ b/utils/html/index.ts
@@ -1,2 +1,3 @@
 export { linkifyHtml } from './linkifyHtml';
 export { isBlankHtml } from './isBlankHtml';
+export { sanitizeCommentHtml, COMMENT_SANITIZE_CONFIG } from './sanitizeCommentHtml';

--- a/utils/html/isBlankHtml.ts
+++ b/utils/html/isBlankHtml.ts
@@ -1,0 +1,20 @@
+/**
+ * Does this HTML render as nothing a reader can see?
+ *
+ * Two callers, two reasons:
+ * - Quill's "empty" value is `<p><br></p>`, which is truthy, so a plain
+ *   `!value.trim()` submit guard would happily post an empty comment.
+ * - A forum comment that was only an image sanitizes down to nothing under the
+ *   feed's three-tag allowlist, and has to fall back to "shared an image"
+ *   rather than render a blank row. That check has to run on the SANITIZED
+ *   string — the raw one is a perfectly truthy `<img src=…>`.
+ */
+export function isBlankHtml(html: string): boolean {
+  return (
+    (html ?? '')
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/gi, ' ')
+      // Any other entity is real content (&amp;, &lt;, an emoji escape …).
+      .trim().length === 0
+  );
+}

--- a/utils/html/linkifyHtml.ts
+++ b/utils/html/linkifyHtml.ts
@@ -1,0 +1,50 @@
+const URL_REGEX = /(https?:\/\/[^\s<]+)/g;
+// Trailing characters that are almost always punctuation, not part of the URL
+// (e.g. a sentence-ending period or a closing bracket around the link).
+const TRAILING_PUNCTUATION = /[.,;:!?)\]]+$/;
+
+/** Escape a matched URL before it goes into an attribute value or text node.
+ *  URL_REGEX accepts everything up to whitespace, `"` included, so a URL like
+ *  `https://x.test/"onmouseover="alert(1)` would otherwise close the href and
+ *  add an event handler. Callers that sanitize afterwards are covered anyway;
+ *  this makes the function safe for the ones that don't. */
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Wrap bare URLs in anchor tags so links typed into an editor (which Quill
+ * leaves as plain text) render as clickable links. Only text outside of
+ * existing tags and existing <a> elements is touched, so already-linked URLs
+ * — including mention anchors — and tag attributes are left untouched.
+ *
+ * Extracted from QuillContent, which still uses it, so the feed's comment
+ * pipeline and long-form Quill content linkify identically.
+ *
+ * Run it BEFORE sanitizing, not after: it emits markup, and letting the
+ * sanitizer see that markup means a malformed URL can't smuggle an attribute
+ * past it. (QuillContent renders the result directly with no sanitizer at all,
+ * which is why the escaping above is not optional.)
+ */
+export function linkifyHtml(html: string): string {
+  let anchorDepth = 0;
+
+  return html
+    .split(/(<[^>]+>)/g)
+    .map((part) => {
+      if (part.startsWith('<')) {
+        if (/^<a[\s>]/i.test(part)) anchorDepth += 1;
+        else if (/^<\/a>/i.test(part)) anchorDepth = Math.max(0, anchorDepth - 1);
+        return part;
+      }
+
+      if (anchorDepth > 0) return part;
+
+      return part.replace(URL_REGEX, (url) => {
+        const trailing = url.match(TRAILING_PUNCTUATION)?.[0] ?? '';
+        const href = escapeHtml(trailing ? url.slice(0, -trailing.length) : url);
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer">${href}</a>${trailing}`;
+      });
+    })
+    .join('');
+}

--- a/utils/html/sanitizeCommentHtml.ts
+++ b/utils/html/sanitizeCommentHtml.ts
@@ -1,0 +1,42 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+/**
+ * The allowlist for feed comment content, applied at BOTH boundaries: on the
+ * way out to a backend, and again on the way in to the screen.
+ *
+ * Sanitizing on write is not belt-and-braces here. A comment written on a forum
+ * card becomes a real NodeBB post that other members read on /forum, through a
+ * renderer we don't control — so whatever we send has to already be safe. And
+ * sanitizing on read is what protects us from everything NodeBB sends back,
+ * which nobody in this codebase authored.
+ *
+ * Three tags. A no-toolbar composer can't produce anything richer, and a forum
+ * post's images and headings have no business inside a feed card.
+ */
+export const COMMENT_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: ['p', 'br', 'a'],
+  // NewsDetailModal's config allows `href` alone. A mention keeps its identity
+  // in `class` + `data-uid` (see RichTextEditor's MentionBlot), so both have to
+  // survive or the mention degrades into an ordinary link.
+  ALLOWED_ATTR: ['href', 'class', 'target', 'rel', 'data-uid', 'data-name', 'data-external-id'],
+  // NewsDetailModal's /^https?:/i would reject a mention's own relative
+  // /members/<uid> href. Anything outside these three schemes — `javascript:`
+  // above all — still goes.
+  ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|\/members\/)/i,
+};
+
+// Registered at module scope: DOMPurify hooks are global and stack if added per
+// call. Identical to the hook NewsDetailModal and PrdContent register, and
+// idempotent alongside them — setting the same two attributes twice is a no-op.
+// Registering it here too means neither consumer depends on one of those
+// modules happening to load first.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.hasAttribute('href')) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+export function sanitizeCommentHtml(html: string): string {
+  return DOMPurify.sanitize(html ?? '', COMMENT_SANITIZE_CONFIG);
+}


### PR DESCRIPTION
> **Stacked on #2713.** Base is `feat/newsfeed-inline-comment-threads`, not `develop` — same files. Review/merge #2713 first; this retargets to `develop` automatically when it lands.

## Summary

Feed comments gain **clickable links** and **@mentions of members**, using the encoding the forum already uses.

- **Mentions** are the forum's `ql-mention` anchor, written by Quill's existing `MentionBlot`.
- **Links** are auto-linked at render — not stored — exactly as `/forum` does.
- **Comment content becomes HTML**, for both comment sources, through one sanitized pipeline.
- **The composer becomes `RichTextEditor`**, toolbar off, lazy-loaded.

**No backend change.** `FeedComment.text` is a Prisma `String`; the contract stays `text: z.string().trim().min(1).max(2000)`.

## Why this encoding, and not a lighter one

A reply typed on a **forum card** isn't stored by the directory at all — it's posted straight to NodeBB and becomes a real reply on `/forum`. So any encoding NodeBB doesn't understand shows up there as literal text. `ql-mention` anchors are what the forum's own composer writes, which makes matching them the only option that works on both surfaces rather than a stylistic preference.

Once forum replies must emit anchor HTML, giving news comments a second encoding buys nothing but a second serialiser and a second renderer to keep in step. One format, one pipeline.

And that decides the composer: `MentionBlot` already emits the exact anchor. Re-implementing it over the old `<input>` — which is what #2701 does — creates a second place obliged to produce a byte-identical format, with nothing to catch drift.

This supersedes **#2701**, whose mentions were FE-first against a backend that strips unknown keys, so they never survived a reload.

## A real XSS fixed on the way

`linkifyHtml` interpolated a matched URL straight into `href="..."`, and its pattern (`[^\s<]+`) permits a `"`. So `https://x.test/"onmouseover=alert(1)` closed the attribute and added an event handler. **`QuillContent` renders that output with no sanitizer at all**, so this was reachable there today, independent of this feature. The function moved to `utils/html`, gained escaping, and the two new tests fail without it.

The pipeline is also ordered deliberately — **linkify first, then sanitize**. linkify emits markup; letting the sanitizer see its output means a malformed URL can't smuggle an attribute through. Sanitizing first would leave those anchors unchecked.

## Sanitizer

Three tags: `p`, `br`, `a`. A no-toolbar composer can't produce anything richer, and a forum post's images and headings have no business inside a feed card. Two values differ from `NewsDetailModal`'s config and both are load-bearing:

- `ALLOWED_ATTR` must keep `class` + `data-uid`, or a mention degrades to an ordinary link.
- `ALLOWED_URI_REGEXP` must admit the mention's own relative `/members/<uid>` href, which `/^https?:/i` rejects.

`DOMPurify.addHook` is global; this registers the same idempotent `target`/`rel` hook `NewsDetailModal` and `PrdContent` already do, so it doesn't depend on one of them happening to load first.

## Also in here

- **Forum comments stop being flattened.** `stripHtml` threw away their links and mentions on the way into the feed, so a comment that read fine on `/forum` arrived inert on `/home`.
- **Emptiness moved after sanitizing.** An image-only forum comment is a truthy `<img src=…>` that the allowlist drops to nothing — it would have rendered a blank row instead of "shared an image or file". The same helper answers Quill's `<p><br></p>`, which is truthy and would otherwise have let empty comments post.
- **Enter submits, Shift+Enter newlines** — implemented inside `RichTextEditor` behind a new opt-in `onSubmit`, because Enter belongs to the mention dropdown whenever it's open and only the editor knows that.
- **Length.** The editor caps *visible* characters, which is what a member perceives; the server caps the serialised string, and a mention anchor is ~150 characters behind a short name. Submit guards the wire length and names the likely cause rather than letting a bare 400 come back.
- **`/api/members-search` hardened** (auth + paging clamp) — carried from #2701, independently correct. Without the auth check it's an open member-enumeration endpoint.
- **Composer chrome fixed** after review feedback: an empty `toolbarConfig` now means `toolbar: false`, because the snow theme still builds a toolbar element for an empty container — an empty bordered strip that took space and swallowed clicks. The wrapper div went too: it drew a second border around Quill's, and its fixed 40px height clipped the editable area.

## Testing

- Full suite **1160 passed, 0 failed**. `npm run build` compiles. Touched files lint clean.
- New: `feed-comment-content.test.tsx` (17) covers autolinking, no double-linking, mention attributes surviving, `<script>` / `onerror` / `javascript:` stripped, the attribute-breakout URL, legacy plain text, and `a < b` rendering literally. `linkifyHtml.test.ts` (6) covers the escaping directly, since `QuillContent` has no sanitizer behind it.
- Existing thread tests keep their intent; the editor is stubbed as a controlled textarea so they cover the **thread**, not Quill.

## ⚠️ Not verified visually

`/home` needs an authenticated session, so **I have not seen any of this render.** Everything Quill-specific is unobserved:

1. The composer looking like a plain text field now that the toolbar node is gone — including the 40px height and placeholder position, which are calculated, not observed.
2. The `@` dropdown opening, positioning, and inserting inside a feed card.
3. A mention written from a feed forum card as it renders on `/forum`.
4. Autogrow, paste, and mobile behaviour of a contenteditable in a card.

`react-quill-new` is globally mocked to render `null` in `jest.setup.js`, so no test here can assert Quill's DOM; unmocking pulls an ESM chain jest won't transform without changing `transformIgnorePatterns` for all 151 suites.

## Follow-ups

- **Open question:** the 2000-char cap now counts markup. Currently handled client-side by capping visible text plus a wire-length guard. Ask the backend to raise the cap instead?
- Mentions don't notify. Neither the directory backend nor NodeBB fires anything for an anchor-encoded mention. Worth a BE ticket.
- `QuillContent` still renders HTML with no sanitizer, and the forum's `CommentItem` passes attributes through `html-react-parser`. Both predate this PR; neither is touched beyond the escaping fix.
- Close #2701.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
