### PR TITLE
feat(feed): analytics for the comment layer's failure and drop-off paths

### DIFF
--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -839,6 +839,78 @@ describe('FeedCommentsThread — drop-off analytics', () => {
   });
 });
 
+describe('FeedCommentsThread — clicks inside a comment', () => {
+  it('reports a mention click with the member it points at', () => {
+    mockThread([comment('c1', '')]);
+    useFeedCommentsMock.mockReturnValue({
+      data: {
+        items: [
+          {
+            ...comment('c1', ''),
+            text: '<p>thanks <a class="ql-mention" href="/members/m_7fa2" data-uid="m_7fa2">@Jane</a></p>',
+          },
+        ],
+      },
+    });
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('link', { name: '@Jane' }));
+
+    expect(onFeedCommentMentionClicked).toHaveBeenCalledWith('n-1', 'news', 'home', 'm_7fa2');
+    expect(onFeedCommentLinkClicked).not.toHaveBeenCalled();
+  });
+
+  it('reports a link click with the host only', () => {
+    useFeedCommentsMock.mockReturnValue({
+      data: {
+        items: [{ ...comment('c1', ''), text: '<p>see https://docs.example.com/secret?token=abc</p>' }],
+      },
+    });
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('link', { name: /docs\.example\.com/ }));
+
+    expect(onFeedCommentLinkClicked).toHaveBeenCalledWith('n-1', 'news', 'home', {
+      linkType: 'http',
+      host: 'docs.example.com',
+    });
+    expect(JSON.stringify(onFeedCommentLinkClicked.mock.calls)).not.toContain('token=abc');
+  });
+
+  it('does NOT report the thread’s own forum chrome links', () => {
+    // "N more comments on the forum →" lives in the thread, not in a comment.
+    // A listener on the thread root would have counted it as a comment link.
+    mockThread([comment('c1', 'One'), comment('c2', 'Two')], forumTopicMeta(50));
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
+
+    fireEvent.click(screen.getByRole('link', { name: /more comments on the forum/ }));
+
+    expect(onFeedCommentLinkClicked).not.toHaveBeenCalled();
+  });
+
+  it('reports a middle-click, which fires auxclick rather than click', () => {
+    useFeedCommentsMock.mockReturnValue({
+      data: { items: [{ ...comment('c1', ''), text: '<p>see https://example.com/a</p>' }] },
+    });
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    // No fireEvent.auxClick helper in this version of testing-library.
+    fireEvent(
+      screen.getByRole('link', { name: /example\.com/ }),
+      new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 }),
+    );
+
+    expect(onFeedCommentLinkClicked).toHaveBeenCalledWith('n-1', 'news', 'home', {
+      linkType: 'http',
+      host: 'example.com',
+    });
+  });
+});
+
 describe('FeedCommentsThread — read-path states', () => {
   it('shows a busy placeholder while the thread loads, not an empty box', () => {
     useFeedCommentsMock.mockReturnValue({ isPending: true });

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -68,8 +68,23 @@ jest.mock('next/dynamic', () => () => {
 
 const onFeedCommentSubmitted = jest.fn();
 const onFeedCommentMentionSelected = jest.fn();
+const onFeedCommentFailed = jest.fn();
+const onFeedCommentSignInClicked = jest.fn();
+const onFeedCommentLoadFailed = jest.fn();
+const onFeedCommentRetryClicked = jest.fn();
+const onFeedCommentLinkClicked = jest.fn();
+const onFeedCommentMentionClicked = jest.fn();
 jest.mock('@/analytics/team-news.analytics', () => ({
-  useTeamNewsAnalytics: () => ({ onFeedCommentSubmitted, onFeedCommentMentionSelected }),
+  useTeamNewsAnalytics: () => ({
+    onFeedCommentSubmitted,
+    onFeedCommentMentionSelected,
+    onFeedCommentFailed,
+    onFeedCommentSignInClicked,
+    onFeedCommentLoadFailed,
+    onFeedCommentRetryClicked,
+    onFeedCommentLinkClicked,
+    onFeedCommentMentionClicked,
+  }),
 }));
 
 // Forum writes are gated on forum.write, the same gate the /forum composer uses.
@@ -747,6 +762,80 @@ describe('FeedCommentsThread — signed-out gate', () => {
     expect(screen.queryByPlaceholderText('Write your comment here…')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'sign in to comment' })).not.toBeInTheDocument();
     expect(screen.getByText('Readable')).toBeInTheDocument();
+  });
+});
+
+describe('FeedCommentsThread — drop-off analytics', () => {
+  it('reports the sign-in gate click — the guest→member drop-off', () => {
+    signOut();
+    mockThread([comment('c1', 'Readable')]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'sign in to comment' }));
+
+    expect(onFeedCommentSignInClicked).toHaveBeenCalledWith('n-1', 'news', 'home');
+  });
+
+  it('reports a too-long refusal ONCE, with sizes rather than content', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    const field = screen.getByPlaceholderText('Write your comment here…');
+    const oversize = `<p>${'a'.repeat(2100)}<a class="ql-mention" data-uid="m_1">@A</a></p>`;
+    fireEvent.change(field, { target: { value: oversize } });
+
+    // Submit is reachable from the form AND from Enter; repeating it on an
+    // unchanged draft must not re-report the same refusal.
+    fireEvent.submit(field.closest('form')!);
+    fireEvent.keyDown(field, { key: 'Enter' });
+    fireEvent.submit(field.closest('form')!);
+
+    expect(onFeedCommentFailed).toHaveBeenCalledTimes(1);
+    expect(onFeedCommentFailed).toHaveBeenCalledWith('n-1', 'news', 'home', false, {
+      reason: 'too-long-client',
+      length: oversize.length,
+      mentionsCount: 1,
+    });
+    // The draft itself never travels.
+    expect(JSON.stringify(onFeedCommentFailed.mock.calls)).not.toContain('aaaa');
+  });
+
+  it('reports a load failure, saying whether cached comments were on screen', () => {
+    useFeedCommentsMock.mockReturnValue({ isError: true, errorUpdatedAt: 1, refetch: jest.fn(), data: undefined });
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(onFeedCommentLoadFailed).toHaveBeenCalledWith('n-1', 'news', 'home', false);
+  });
+
+  it('reports a load failure AGAIN when a retry fails', () => {
+    const refetch = jest.fn();
+    useFeedCommentsMock.mockReturnValue({ isError: true, errorUpdatedAt: 1, refetch, data: undefined });
+    mockMutation(useAddFeedCommentMock);
+    const { rerender } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(onFeedCommentRetryClicked).toHaveBeenCalledWith('n-1', 'news', 'home');
+
+    // A failing refetch of an already-errored query never flips isError, so an
+    // effect keyed on it would fire once ever and leave the retry funnel open.
+    useFeedCommentsMock.mockReturnValue({ isError: true, errorUpdatedAt: 2, refetch, data: undefined });
+    rerender(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(onFeedCommentLoadFailed).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-report a load failure on an unrelated re-render', () => {
+    useFeedCommentsMock.mockReturnValue({ isError: true, errorUpdatedAt: 1, refetch: jest.fn(), data: undefined });
+    mockMutation(useAddFeedCommentMock);
+    const { rerender } = render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    rerender(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+    rerender(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
+
+    expect(onFeedCommentLoadFailed).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/__tests__/page/home/feed-comments-thread.test.tsx
+++ b/__tests__/page/home/feed-comments-thread.test.tsx
@@ -444,28 +444,29 @@ describe('FeedCommentsThread — composer (HTML content)', () => {
     expect(mutation.mutate).not.toHaveBeenCalled();
   });
 
-  it('reports the mention count with a submitted comment, and the selection when it is picked', () => {
+  it('forwards a picked mention to analytics without touching the draft', () => {
     mockThread([]);
     mockMutation(useAddFeedCommentMock);
     render(<FeedCommentsThread itemUid="n-1" kind="news" source="home" />);
 
     // The editor owns the dropdown; the thread only forwards the selection.
+    // (submitted/failed are reported by the mutation hook now, so they're
+    // covered in useAddFeedComment.test.tsx — the hook is mocked here.)
     mockEditorProps.mock.calls.at(-1)?.[0].onMentionSelected({ uid: 'm_7fa2', name: 'Jane Doe' });
+
     expect(onFeedCommentMentionSelected).toHaveBeenCalledWith('n-1', 'news', 'home', {
       memberUid: 'm_7fa2',
       memberName: 'Jane Doe',
     });
+  });
 
-    const mutation = useAddFeedCommentMock.mock.results[0].value;
-    const field = screen.getByPlaceholderText('Write your comment here…');
-    fireEvent.change(field, {
-      target: { value: '<p>hi <a class="ql-mention" data-uid="m_7fa2">@Jane Doe</a></p>' },
-    });
-    fireEvent.submit(field.closest('form')!);
+  it('gives the mutation hooks the surface context they report with', () => {
+    mockThread([]);
+    mockMutation(useAddFeedCommentMock);
+    render(<FeedCommentsThread itemUid="fp_96" kind="forum" source="news-modal" forumMainPid={263} />);
 
-    const { onSuccess } = mutation.mutate.mock.calls[0][1];
-    act(() => onSuccess());
-    expect(onFeedCommentSubmitted).toHaveBeenCalledWith('n-1', 'news', 'home', false, 1);
+    expect(useAddFeedCommentMock).toHaveBeenCalledWith('fp_96', 263, { kind: 'forum', source: 'news-modal' });
+    expect(useDeleteFeedCommentMock).toHaveBeenCalledWith('fp_96', { kind: 'forum', source: 'news-modal' });
   });
 
   it('refuses a comment whose markup exceeds the server’s cap, and says why', () => {

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -37,6 +37,11 @@ const mockOnUpvoteToggled = jest.fn();
 const mockOnUpvoteFailed = jest.fn();
 const mockOnForumLikeToggled = jest.fn();
 const mockOnForumLikeFailed = jest.fn();
+const mockOnPopularCardViewed = jest.fn();
+const mockOnScrollSucceeded = jest.fn();
+const mockOnFallbackOpened = jest.fn();
+const mockOnTeamsToFollowViewed = jest.fn();
+const mockOnTeamsToFollowHidden = jest.fn();
 const mockOnPopularStoryClicked = jest.fn();
 const mockOnDetailModalOpened = jest.fn();
 const mockOnShared = jest.fn();
@@ -56,6 +61,11 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsUpvoteFailed: (...a: unknown[]) => mockOnUpvoteFailed(...a),
     onFeedForumPostLikeToggled: (...a: unknown[]) => mockOnForumLikeToggled(...a),
     onFeedForumPostLikeFailed: (...a: unknown[]) => mockOnForumLikeFailed(...a),
+    onPopularCardViewed: (...a: unknown[]) => mockOnPopularCardViewed(...a),
+    onPopularStoryScrollSucceeded: (...a: unknown[]) => mockOnScrollSucceeded(...a),
+    onPopularStoryFallbackOpened: (...a: unknown[]) => mockOnFallbackOpened(...a),
+    onTeamsToFollowViewed: (...a: unknown[]) => mockOnTeamsToFollowViewed(...a),
+    onTeamsToFollowHidden: (...a: unknown[]) => mockOnTeamsToFollowHidden(...a),
   }),
 }));
 

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -34,6 +34,9 @@ const mockOnLoadMoreClicked = jest.fn();
 const mockOnCardClicked = jest.fn();
 const mockOnTeamNewsSearch = jest.fn();
 const mockOnUpvoteToggled = jest.fn();
+const mockOnUpvoteFailed = jest.fn();
+const mockOnForumLikeToggled = jest.fn();
+const mockOnForumLikeFailed = jest.fn();
 const mockOnPopularStoryClicked = jest.fn();
 const mockOnDetailModalOpened = jest.fn();
 const mockOnShared = jest.fn();
@@ -50,6 +53,9 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsDetailModalOpened: (...a: unknown[]) => mockOnDetailModalOpened(...a),
     onTeamNewsShared: (...a: unknown[]) => mockOnShared(...a),
     onTeamNewsSortChanged: jest.fn(),
+    onTeamNewsUpvoteFailed: (...a: unknown[]) => mockOnUpvoteFailed(...a),
+    onFeedForumPostLikeToggled: (...a: unknown[]) => mockOnForumLikeToggled(...a),
+    onFeedForumPostLikeFailed: (...a: unknown[]) => mockOnForumLikeFailed(...a),
   }),
 }));
 

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -832,6 +832,8 @@ describe('TeamNews', () => {
 
       expect(screen.getAllByRole('button', { name: 'Like (0)' })).toHaveLength(2);
       expect(mockOnUpvoteToggled).not.toHaveBeenCalled();
+      // A rolled-back like used to be indistinguishable from one that stuck.
+      expect(mockOnUpvoteFailed).toHaveBeenCalledWith(expect.anything(), expect.any(Number), true, 'home');
     });
 
     it('does not change followed-first cluster ordering when upvoting an unfollowed story', () => {
@@ -1324,6 +1326,10 @@ describe('TeamNews', () => {
       fireEvent.click(getRailButton('Headline ai-1'));
 
       expect(openSpy).toHaveBeenCalledWith('https://example.com/expired', '_blank', 'noopener,noreferrer');
+      // The live, previously unmeasured failure path: ranked server-side, aged
+      // out of the 14-day window before it was clicked.
+      expect(mockOnFallbackOpened).toHaveBeenCalledWith(expect.objectContaining({ uid: 'expired-uid' }), 0);
+      expect(mockOnScrollSucceeded).not.toHaveBeenCalled();
       openSpy.mockRestore();
     });
 
@@ -1334,6 +1340,8 @@ describe('TeamNews', () => {
       fireEvent.click(getRailButton('Headline ai-1'));
       const row = getFeedHeadline('Headline ai-1')!.closest('[role="button"]');
       expect(row).toHaveClass('storyHighlighted');
+      // The denominator for the fallback above.
+      expect(mockOnScrollSucceeded).toHaveBeenCalledWith(expect.objectContaining({ uid: 'ai-1' }), 0);
 
       act(() => jest.advanceTimersByTime(2000));
       expect(row).not.toHaveClass('storyHighlighted');

--- a/__tests__/page/teams/team-news-rail.test.tsx
+++ b/__tests__/page/teams/team-news-rail.test.tsx
@@ -9,6 +9,7 @@ const mockOnCardClicked = jest.fn();
 const mockOnViewAllClicked = jest.fn();
 const mockOnShowMoreClicked = jest.fn();
 const mockOnUpvoteToggled = jest.fn();
+const mockOnUpvoteFailed = jest.fn();
 const mockUpvoteMutate = jest.fn();
 const mockUseCurrentUserStore = jest.fn(() => ({ currentUser: { uid: 'm-1' }, isHydrated: true }));
 let lastModalProps: Record<string, unknown> | null = null;
@@ -19,6 +20,7 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsViewAllClicked: (...a: unknown[]) => mockOnViewAllClicked(...a),
     onTeamNewsShowMoreClicked: (...a: unknown[]) => mockOnShowMoreClicked(...a),
     onTeamNewsUpvoteToggled: (...a: unknown[]) => mockOnUpvoteToggled(...a),
+    onTeamNewsUpvoteFailed: (...a: unknown[]) => mockOnUpvoteFailed(...a),
   }),
 }));
 

--- a/__tests__/page/teams/team-news-rail.test.tsx
+++ b/__tests__/page/teams/team-news-rail.test.tsx
@@ -227,6 +227,14 @@ describe('TeamNewsRail', () => {
     const button = screen.getByRole('button', { name: 'Like (0)' });
     expect(button).toHaveTextContent('0');
     expect(mockOnUpvoteToggled).not.toHaveBeenCalled();
+    // team-profile is the OTHER call site. Wiring only /home's would have made
+    // the failure rate read 0% here while the success event covered both.
+    expect(mockOnUpvoteFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'news-1' }),
+      expect.any(Number),
+      true,
+      'team-profile-rail',
+    );
   });
 
   const summarized = (uid: string): ITeamNewsItem => ({

--- a/__tests__/services/feed/commentFailure.test.ts
+++ b/__tests__/services/feed/commentFailure.test.ts
@@ -1,0 +1,123 @@
+import { classifyCommentFailure } from '@/services/feed/commentFailure';
+import { FeedWriteError } from '@/services/feed/feed.service';
+import { ForumWriteError, classifyForumMessage, forumErrorMessage } from '@/services/forum/forum.service';
+
+jest.mock('@/utils/fetch-wrapper', () => ({ customFetch: jest.fn() }));
+
+describe('classifyCommentFailure — status mapping', () => {
+  it.each([
+    [401, 'session-expired'],
+    [403, 'no-permission'],
+    [429, 'rate-limited'],
+    [400, 'rejected'],
+    [409, 'rejected'],
+    [413, 'rejected'],
+    [500, 'server-error'],
+    [503, 'server-error'],
+  ])('maps HTTP %i to %s', (status, reason) => {
+    expect(classifyCommentFailure(new FeedWriteError('Failed to post feed comment', status)).reason).toBe(reason);
+  });
+
+  it('always carries the numeric status, so rejected and unknown stay diagnosable', () => {
+    expect(classifyCommentFailure(new FeedWriteError('nope', 409)).status).toBe(409);
+  });
+
+  it('classifies a 429 that carries no message at all — the message regexes alone would miss it', () => {
+    expect(classifyCommentFailure(new ForumWriteError(429, undefined)).reason).toBe('rate-limited');
+  });
+});
+
+describe('classifyCommentFailure — the no-status case', () => {
+  it('treats a write error with no status as session-expired, NOT unknown', () => {
+    // customFetch returns undefined only when it gave up on auth (it logs out
+    // and reloads). Filing that as `unknown` turns the unknown bucket into
+    // "logged out mid-write" and invites chasing a backend bug that isn't there.
+    expect(classifyCommentFailure(new FeedWriteError('Failed to post feed comment', undefined)).reason).toBe(
+      'session-expired',
+    );
+    expect(classifyCommentFailure(new ForumWriteError(undefined, undefined)).reason).toBe('session-expired');
+  });
+
+  it('treats a rejected fetch as network — that is the real no-response case', () => {
+    expect(classifyCommentFailure(new TypeError('Failed to fetch')).reason).toBe('network');
+  });
+});
+
+describe('classifyCommentFailure — NodeBB messages', () => {
+  it.each([
+    ['[[error:content-too-short, Content too short]]', 'too-short', 'content-too-short'],
+    ['[[error:too-many-posts, 10]]', 'rate-limited', 'too-many-posts'],
+    ['[[error:no-privileges]]', 'no-permission', 'no-privileges'],
+  ])('reads %s as %s and extracts the slug', (message, reason, errorKey) => {
+    const result = classifyCommentFailure(new ForumWriteError(400, message));
+    expect(result.reason).toBe(reason);
+    expect(result.errorKey).toBe(errorKey);
+  });
+
+  it('prefers the error key over the status — a rate limit served as 403 is not a permission problem', () => {
+    const result = classifyCommentFailure(new ForumWriteError(403, '[[error:too-many-posts, 10]]'));
+    expect(result.reason).toBe('rate-limited');
+    expect(result.status).toBe(403);
+  });
+
+  it('extracts the slug WITHOUT the arguments', () => {
+    // `[[error:content-too-short, Content too short]]` — the part after the
+    // comma is server-supplied prose and must not ride along.
+    expect(
+      classifyCommentFailure(new ForumWriteError(400, '[[error:content-too-short, Content too short]]')).errorKey,
+    ).toBe('content-too-short');
+  });
+});
+
+describe('classifyCommentFailure — nothing user-authored may escape', () => {
+  it('never echoes a server message that embeds an email address', () => {
+    // NodeBB spam/URL plugins put the offending content in the message.
+    const error = new ForumWriteError(400, 'Blocked: contact jane.doe@example.com for access');
+    const result = classifyCommentFailure(error);
+
+    expect(JSON.stringify(result)).not.toContain('jane.doe@example.com');
+    expect(result.reason).toBe('rejected');
+  });
+
+  it('never echoes a server message that embeds a URL', () => {
+    const error = new ForumWriteError(400, 'Link not allowed: https://internal.example.com/doc?token=abc123');
+    const result = classifyCommentFailure(error);
+
+    expect(JSON.stringify(result)).not.toContain('internal.example.com');
+    expect(JSON.stringify(result)).not.toContain('abc123');
+  });
+
+  it('emits no errorKey when the message carries no bracketed key', () => {
+    expect(classifyCommentFailure(new ForumWriteError(400, 'Something went sideways')).errorKey).toBeUndefined();
+  });
+
+  it('puts a bare unrecognised error in unknown, carrying nothing from it', () => {
+    const result = classifyCommentFailure(new Error('Failed to look up the forum topic'));
+    expect(result).toEqual({ reason: 'unknown', errorKey: undefined });
+  });
+
+  it('handles a non-Error throw without exploding', () => {
+    expect(classifyCommentFailure('just a string').reason).toBe('unknown');
+    expect(classifyCommentFailure(undefined).reason).toBe('unknown');
+  });
+});
+
+describe('classifyForumMessage agrees with the copy it was extracted from', () => {
+  // The regression guard for the Phase 0 extraction: every input the display
+  // tests pin must still classify to the reason that produces that copy.
+  const FALLBACK = 'Couldn’t post — try again.';
+
+  it.each([
+    ['[[error:content-too-short, Content too short]]', 'too-short', /too short for the forum/],
+    ['[[error:too-many-posts, 10]]', 'rate-limited', /posting a little fast/],
+    ['[[error:no-privileges]]', 'no-permission', /permission to reply/],
+  ])('%s', (message, reason, copy) => {
+    expect(classifyForumMessage(message)).toBe(reason);
+    expect(forumErrorMessage(new Error(message), FALLBACK)).toMatch(copy);
+  });
+
+  it('leaves an unrecognised message unclassified, which is what makes the copy fall through', () => {
+    expect(classifyForumMessage('Something went sideways')).toBeUndefined();
+    expect(forumErrorMessage(new Error('Something went sideways'), FALLBACK)).toBe('Something went sideways');
+  });
+});

--- a/__tests__/services/feed/useAddFeedComment.test.tsx
+++ b/__tests__/services/feed/useAddFeedComment.test.tsx
@@ -8,10 +8,21 @@ jest.unmock('@tanstack/react-query');
 
 import { useAddFeedComment } from '@/services/feed/hooks/useAddFeedComment';
 import { feedQueryKeys } from '@/services/feed/constants';
-import { createFeedComment } from '@/services/feed/feed.service';
+import { createFeedComment, FeedWriteError } from '@/services/feed/feed.service';
 import type { IFeedComment, IFeedCommentCountsResponse, IFeedCommentsResponse } from '@/types/feed.types';
 
-jest.mock('@/services/feed/feed.service', () => ({ createFeedComment: jest.fn() }));
+jest.mock('@/services/feed/feed.service', () => ({
+  ...jest.requireActual('@/services/feed/feed.service'),
+  createFeedComment: jest.fn(),
+}));
+
+const onFeedCommentSubmitted = jest.fn();
+const onFeedCommentFailed = jest.fn();
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({ onFeedCommentSubmitted, onFeedCommentFailed }),
+}));
+
+const CONTEXT = { kind: 'news', source: 'home' } as const;
 
 const createFeedCommentMock = createFeedComment as jest.MockedFunction<typeof createFeedComment>;
 
@@ -157,5 +168,81 @@ describe('useAddFeedComment', () => {
 
     const patched = client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid));
     expect(patched?.items[0].replies[0].replies.map((c) => c.uid)).toEqual(['c-3']);
+  });
+});
+
+describe('useAddFeedComment — analytics', () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  it('reports a submitted comment from the HOOK, so a remount cannot swallow it', async () => {
+    const itemUid = 'n-1';
+    createFeedCommentMock.mockResolvedValue(comment('c-1', itemUid, 'Hi', '2026-01-01T00:00:00.000Z'));
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid, undefined, CONTEXT), { wrapper });
+    act(() => result.current.mutate({ text: '<p>hi <a class="ql-mention" data-uid="m_7">@Jane</a></p>' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // isReply false, one mention counted off the anchor class.
+    expect(onFeedCommentSubmitted).toHaveBeenCalledWith(itemUid, 'news', 'home', false, 1);
+  });
+
+  it('reports a reply as a reply, taking isReply from the mutation variables', async () => {
+    const itemUid = 'n-1';
+    createFeedCommentMock.mockResolvedValue(comment('c-2', itemUid, 'Yes', '2026-01-02T00:00:00.000Z', 'c-1'));
+
+    const { result } = renderHook(() => useAddFeedComment(itemUid, undefined, CONTEXT), { wrapper });
+    act(() => result.current.mutate({ text: '<p>yes</p>', parentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(onFeedCommentSubmitted).toHaveBeenCalledWith(itemUid, 'news', 'home', true, 0);
+  });
+
+  it('reports a failure with a classified reason and status', async () => {
+    createFeedCommentMock.mockRejectedValue(new FeedWriteError('Failed to post feed comment', 429));
+
+    const { result } = renderHook(() => useAddFeedComment('n-1', undefined, CONTEXT), { wrapper });
+    act(() => result.current.mutate({ text: '<p>too fast</p>' }));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onFeedCommentFailed).toHaveBeenCalledWith('n-1', 'news', 'home', false, {
+      reason: 'rate-limited',
+      status: 429,
+      errorKey: undefined,
+    });
+    expect(onFeedCommentSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('fires exactly once per mutation, not once per render', async () => {
+    createFeedCommentMock.mockResolvedValue(comment('c-1', 'n-1', 'Hi', '2026-01-01T00:00:00.000Z'));
+
+    const { result, rerender } = renderHook(() => useAddFeedComment('n-1', undefined, CONTEXT), { wrapper });
+    act(() => result.current.mutate({ text: '<p>hi</p>' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender();
+    rerender();
+
+    expect(onFeedCommentSubmitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing when no surface context was given', async () => {
+    createFeedCommentMock.mockResolvedValue(comment('c-1', 'n-1', 'Hi', '2026-01-01T00:00:00.000Z'));
+
+    const { result } = renderHook(() => useAddFeedComment('n-1'), { wrapper });
+    act(() => result.current.mutate({ text: '<p>hi</p>' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(onFeedCommentSubmitted).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/feed/useDeleteFeedComment.test.tsx
+++ b/__tests__/services/feed/useDeleteFeedComment.test.tsx
@@ -6,10 +6,21 @@ jest.unmock('@tanstack/react-query');
 
 import { useDeleteFeedComment } from '@/services/feed/hooks/useDeleteFeedComment';
 import { feedQueryKeys } from '@/services/feed/constants';
-import { deleteFeedComment } from '@/services/feed/feed.service';
+import { deleteFeedComment, FeedWriteError } from '@/services/feed/feed.service';
 import type { IFeedComment, IFeedCommentCountsResponse, IFeedCommentsResponse } from '@/types/feed.types';
 
-jest.mock('@/services/feed/feed.service', () => ({ deleteFeedComment: jest.fn() }));
+jest.mock('@/services/feed/feed.service', () => ({
+  ...jest.requireActual('@/services/feed/feed.service'),
+  deleteFeedComment: jest.fn(),
+}));
+
+const onFeedCommentDeleted = jest.fn();
+const onFeedCommentDeleteFailed = jest.fn();
+jest.mock('@/analytics/team-news.analytics', () => ({
+  useTeamNewsAnalytics: () => ({ onFeedCommentDeleted, onFeedCommentDeleteFailed }),
+}));
+
+const CONTEXT = { kind: 'news', source: 'home' } as const;
 
 const deleteFeedCommentMock = deleteFeedComment as jest.MockedFunction<typeof deleteFeedComment>;
 
@@ -163,5 +174,58 @@ describe('useDeleteFeedComment', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     // Nothing removed from the cache on failure — no optimistic pre-removal.
     expect(client.getQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid))?.items).toHaveLength(1);
+  });
+});
+
+describe('useDeleteFeedComment — analytics', () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  it('reports the size of the removed subtree, not just that a delete happened', async () => {
+    const itemUid = 'n-1';
+    client.setQueryData<IFeedCommentsResponse>(feedQueryKeys.comments(itemUid), {
+      items: [comment('c-1', itemUid, null, [comment('c-2', itemUid, 'c-1'), comment('c-3', itemUid, 'c-1')])],
+    });
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'c-1', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment(itemUid, CONTEXT), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Deleting a leaf and deleting a whole conversation are different acts.
+    expect(onFeedCommentDeleted).toHaveBeenCalledWith(itemUid, 'news', 'home', 3);
+  });
+
+  it('reports removedCount 0 for a comment that was already gone', async () => {
+    // The service maps 404 to success, so a double-delete from another tab
+    // lands here. Reporting 0 keeps it from inflating the delete count.
+    deleteFeedCommentMock.mockResolvedValue({ uid: 'c-9', deleted: true });
+
+    const { result } = renderHook(() => useDeleteFeedComment('n-1', CONTEXT), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-9' }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(onFeedCommentDeleted).toHaveBeenCalledWith('n-1', 'news', 'home', 0);
+  });
+
+  it('reports a delete failure with a classified reason', async () => {
+    deleteFeedCommentMock.mockRejectedValue(new FeedWriteError('Failed to delete feed comment', undefined));
+
+    const { result } = renderHook(() => useDeleteFeedComment('n-1', CONTEXT), { wrapper });
+    act(() => result.current.mutate({ commentUid: 'c-1' }));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // No status means customFetch gave up on auth, not that nothing is known.
+    expect(onFeedCommentDeleteFailed).toHaveBeenCalledWith('n-1', 'news', 'home', { reason: 'session-expired' });
   });
 });

--- a/__tests__/utils/classifyAnchor.test.ts
+++ b/__tests__/utils/classifyAnchor.test.ts
@@ -1,0 +1,66 @@
+import { classifyAnchor } from '@/utils/html';
+
+function anchor(html: string): HTMLAnchorElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  return host.querySelector('a')!;
+}
+
+describe('classifyAnchor', () => {
+  it('reads a mention off its class and data-uid', () => {
+    const a = anchor('<a class="ql-mention" href="/members/m_7fa2" data-uid="m_7fa2">@Jane Doe</a>');
+    expect(classifyAnchor(a)).toEqual({ kind: 'mention', memberUid: 'm_7fa2' });
+  });
+
+  it('checks mentions BEFORE links — their href points at our own domain', () => {
+    // Classified generically, every mention would count as a link to us.
+    const a = anchor('<a class="ql-mention" href="/members/m_1" data-uid="m_1">@A</a>');
+    expect(classifyAnchor(a).kind).toBe('mention');
+  });
+
+  it('treats an ordinary /members link as a link, not a mention', () => {
+    const a = anchor('<a href="/members/m_1">someone’s profile</a>');
+    expect(classifyAnchor(a)).toEqual({ kind: 'link', linkType: 'http', host: 'localhost' });
+  });
+
+  it('reports the host and nothing else for a web link', () => {
+    const a = anchor('<a href="https://docs.example.com/private/doc?token=secret123">doc</a>');
+    const result = classifyAnchor(a);
+
+    // A pasted URL's path or query can carry a share token or a private id.
+    expect(result).toEqual({ kind: 'link', linkType: 'http', host: 'docs.example.com' });
+    expect(JSON.stringify(result)).not.toContain('secret123');
+    expect(JSON.stringify(result)).not.toContain('private');
+  });
+
+  it('reports a mailto with NO host — the host would be the address', () => {
+    const a = anchor('<a href="mailto:jane.doe@example.com">email</a>');
+    const result = classifyAnchor(a);
+
+    expect(result).toEqual({ kind: 'link', linkType: 'mailto' });
+    expect(JSON.stringify(result)).not.toContain('jane.doe');
+  });
+
+  it('skips an anchor whose href the sanitizer stripped', () => {
+    // DOMPurify drops hrefs outside its allowlist — NodeBB's /topic/123 among
+    // them — leaving a bare anchor. Resolving that invents an internal link.
+    expect(classifyAnchor(anchor('<a>bare</a>')).kind).toBe('skip');
+  });
+
+  it('skips a non-web scheme rather than reporting it as a link', () => {
+    // The sanitizer already refuses these; this is the second lock.
+    expect(classifyAnchor(anchor('<a href="javascript:alert(1)">x</a>')).kind).toBe('skip');
+    expect(classifyAnchor(anchor('<a href="data:text/html,hi">x</a>')).kind).toBe('skip');
+  });
+
+  it('does not throw on a href that will not parse', () => {
+    // Resolved against an origin almost anything parses, so this asserts the
+    // guard holds rather than a particular verdict.
+    expect(() => classifyAnchor(anchor('<a href="http://[::bad::]">x</a>'))).not.toThrow();
+    expect(() => classifyAnchor(anchor('<a href="%%%">x</a>'))).not.toThrow();
+  });
+
+  it('skips a mention anchor that lost its data-uid', () => {
+    expect(classifyAnchor(anchor('<a class="ql-mention">@Ghost</a>')).kind).toBe('skip');
+  });
+});

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -249,6 +249,44 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
+  /** The suggestions card appeared with real teams on it (not its loading
+   *  state). Once per appearance, not once per render. */
+  const onTeamsToFollowViewed = (suggestionCount: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_TEAMS_TO_FOLLOW_VIEWED, { suggestionCount });
+  };
+
+  /** …and it left, which in practice means the member followed all of them. */
+  const onTeamsToFollowHidden = () => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_TEAMS_TO_FOLLOW_HIDDEN, {});
+  };
+
+  /** The Popular-this-week card appeared with stories on it — the denominator
+   *  for its click-through, which was measured with no impression count. */
+  const onPopularCardViewed = (itemCount: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_CARD_VIEWED, { itemCount });
+  };
+
+  /** The popular rail's two outcomes. Its click event fires either way, so
+   *  clicked minus these two is the "flushSync should have made this
+   *  impossible" case. */
+  const onPopularStoryScrollSucceeded = (item: ITeamNewsPopularItem, position: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_STORY_SCROLL_SUCCEEDED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      position,
+    });
+  };
+
+  /** The story aged out of the 14-day window after Popular was ranked, so the
+   *  click opened the source article instead of scrolling to a card. */
+  const onPopularStoryFallbackOpened = (item: ITeamNewsPopularItem, position: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_STORY_FALLBACK_OPENED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      position,
+    });
+  };
+
   const onTeamNewsPopularStoryClicked = (item: ITeamNewsPopularItem, position: number) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_STORY_CLICKED, {
       itemUid: item.uid,
@@ -507,6 +545,11 @@ export const useTeamNewsAnalytics = () => {
     onTeamNewsUpvoteFailed,
     onFeedForumPostLikeFailed,
     onTeamNewsPopularStoryClicked,
+    onPopularCardViewed,
+    onPopularStoryScrollSucceeded,
+    onPopularStoryFallbackOpened,
+    onTeamsToFollowViewed,
+    onTeamsToFollowHidden,
     onFeedForumPostCardClicked,
     onFeedForumPostModalOpened,
     onFeedForumPostLikeToggled,

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -3,6 +3,7 @@ import { useCurrentUserStore } from '@/services/auth/store';
 import { usePostHog } from 'posthog-js/react';
 import type { ITeamNewsItem, ITeamNewsPopularItem } from '@/types/team-news.types';
 import type { IFeedForumPost } from '@/types/feed.types';
+import type { CommentFailure } from '@/services/feed/commentFailure';
 
 /** 'news' | 'forum' — typed off the FeedEntry union so analytics can't drift
  *  from the feed's own discriminator. */
@@ -331,6 +332,112 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
+  // ── Comment failures and drop-offs ────────────────────────────────────────
+  // House rule for every event below: no comment text, no draft, no full URL,
+  // no raw server message. Reasons and counts only.
+
+  const onFeedCommentFailed = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    isReply: boolean,
+    failure: CommentFailure,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_FAILED, {
+      itemUid,
+      kind,
+      source,
+      isReply,
+      ...failure,
+    });
+  };
+
+  const onFeedCommentDeleted = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    /** Rows removed including the cascaded replies — tells apart deleting a
+     *  leaf from deleting a whole conversation. */
+    removedCount: number,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_DELETED, {
+      itemUid,
+      kind,
+      source,
+      removedCount,
+    });
+  };
+
+  const onFeedCommentDeleteFailed = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    failure: CommentFailure,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_DELETE_FAILED, {
+      itemUid,
+      kind,
+      source,
+      ...failure,
+    });
+  };
+
+  // The guest→member funnel, from inside a thread. Fires before a soft #login
+  // nav, so unlike the session-expired path it delivers reliably.
+  const onFeedCommentSignInClicked = (itemUid: string, kind: FeedItemKind, source: TeamNewsAnalyticsSource) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_SIGNIN_CLICKED, { itemUid, kind, source });
+  };
+
+  const onFeedCommentLoadFailed = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    /** The thread rendered its error state while cached comments existed, so
+     *  the member saw a failure over content that was actually there. */
+    hadCachedData: boolean,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_LOAD_FAILED, {
+      itemUid,
+      kind,
+      source,
+      hadCachedData,
+    });
+  };
+
+  const onFeedCommentRetryClicked = (itemUid: string, kind: FeedItemKind, source: TeamNewsAnalyticsSource) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_RETRY_CLICKED, { itemUid, kind, source });
+  };
+
+  /** `host` ONLY — a pasted URL's path or query can carry a token or a private
+   *  document id. A mailto link reports no host at all. */
+  const onFeedCommentLinkClicked = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    link: { linkType: 'http' | 'mailto'; host?: string },
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_LINK_CLICKED, {
+      itemUid,
+      kind,
+      source,
+      ...link,
+    });
+  };
+
+  const onFeedCommentMentionClicked = (
+    itemUid: string,
+    kind: FeedItemKind,
+    source: TeamNewsAnalyticsSource,
+    targetMemberUid: string,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_COMMENT_MENTION_CLICKED, {
+      itemUid,
+      kind,
+      source,
+      targetMemberUid,
+    });
+  };
+
   // Never include comment text or the draft here — only the selection.
   const onFeedCommentMentionSelected = (
     itemUid: string,
@@ -368,5 +475,13 @@ export const useTeamNewsAnalytics = () => {
     onFeedCommentThreadToggled,
     onFeedCommentSubmitted,
     onFeedCommentMentionSelected,
+    onFeedCommentFailed,
+    onFeedCommentDeleted,
+    onFeedCommentDeleteFailed,
+    onFeedCommentSignInClicked,
+    onFeedCommentLoadFailed,
+    onFeedCommentRetryClicked,
+    onFeedCommentLinkClicked,
+    onFeedCommentMentionClicked,
   };
 };

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -212,6 +212,43 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
+  /** The rollback half of onTeamNewsUpvoteToggled. Without it the like funnel
+   *  is measured on one side only, and an optimistic like that silently rolled
+   *  back is indistinguishable from one that stuck. */
+  const onTeamNewsUpvoteFailed = (
+    item: ITeamNewsItem,
+    position: number,
+    attemptedState: boolean,
+    source: TeamNewsAnalyticsSource,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_UPVOTE_FAILED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      teamName: item.teamName,
+      attemptedState,
+      position,
+      source,
+    });
+  };
+
+  /** Its own event, not a shared one with news upvotes: the success events are
+   *  separately named, and a shared failure event makes the ratio uncomputable
+   *  for both. */
+  const onFeedForumPostLikeFailed = (
+    post: IFeedForumPost,
+    position: number,
+    attemptedState: boolean,
+    source: TeamNewsAnalyticsSource,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_FORUM_POST_LIKE_FAILED, {
+      postUid: post.uid,
+      authorMemberUid: post.author.memberUid,
+      attemptedState,
+      position,
+      source,
+    });
+  };
+
   const onTeamNewsPopularStoryClicked = (item: ITeamNewsPopularItem, position: number) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_STORY_CLICKED, {
       itemUid: item.uid,
@@ -467,6 +504,8 @@ export const useTeamNewsAnalytics = () => {
     onTeamNewsSourceLinkClicked,
     onTeamNewsSearch,
     onTeamNewsUpvoteToggled,
+    onTeamNewsUpvoteFailed,
+    onFeedForumPostLikeFailed,
     onTeamNewsPopularStoryClicked,
     onFeedForumPostCardClicked,
     onFeedForumPostModalOpened,

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -598,6 +598,7 @@ export const TeamNews = ({
     if (!fullItem) {
       // Expired/removed from the 14-day window since Popular was ranked server-side.
       // Nothing to scroll to — fall back to the old behavior instead of a dead click.
+      analytics.onPopularStoryFallbackOpened(item, position);
       window.open(item.sourceUrl, '_blank', 'noopener,noreferrer');
       return;
     }
@@ -642,8 +643,13 @@ export const TeamNews = ({
     const el = document.querySelector<HTMLElement>(selector);
     setScrollTarget(null); // one-shot signal — clear right after use so a later, unrelated remount can't replay it
 
-    if (el) revealStory(el);
-    // else: unexpected — flushSync above should guarantee `el` exists.
+    if (el) {
+      revealStory(el);
+      analytics.onPopularStoryScrollSucceeded(item, position);
+    }
+    // else: unexpected — flushSync above should guarantee `el` exists. Left
+    // unreported on purpose: clicked minus succeeded minus fallback IS this
+    // case, so it stays visible without inventing an event for it.
   };
 
   // A forum-access member with zero news in the window still gets their posts

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -5,7 +5,11 @@ import isEmpty from 'lodash/isEmpty';
 import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
 import { flushSync } from 'react-dom';
 
-import { useTeamNewsAnalytics, type TeamNewsCardClickVia } from '@/analytics/team-news.analytics';
+import {
+  useTeamNewsAnalytics,
+  type TeamNewsAnalyticsSource,
+  type TeamNewsCardClickVia,
+} from '@/analytics/team-news.analytics';
 import { useFollowAnalytics, type FollowAnalyticsSource } from '@/analytics/follow.analytics';
 import { useFollowTeam } from '@/services/follow/hooks/useFollowTeam';
 import { useSuggestedTeamsToFollow } from '@/services/follow/hooks/useSuggestedTeamsToFollow';
@@ -510,7 +514,10 @@ export const TeamNews = ({
   // Auth check + login redirect happens in the calling card component (see
   // NewsGroupCard.handleUpvoteClick), matching handleFollowToggle's split below —
   // this handler assumes an authenticated caller.
-  const handleUpvoteToggle = (item: ITeamNewsItem) => {
+  // `source` is a parameter, not the constant 'home' it used to be: this
+  // handler serves the card AND the detail modal, so hardcoding it made the
+  // dimension carry no information at all.
+  const handleUpvoteToggle = (item: ITeamNewsItem, source: TeamNewsAnalyticsSource = 'home') => {
     const wasUpvoted = Boolean(item.viewerHasUpvoted);
     const nextUpvoted = !wasUpvoted;
     const prevCount = item.upvoteCount ?? 0;
@@ -522,6 +529,8 @@ export const TeamNews = ({
       return next;
     });
 
+    // -1, not 0: a deep-linked modal item isn't in visibleEntries at all, and
+    // reporting it as position 0 makes it indistinguishable from the top card.
     const position = visibleEntries.findIndex((e) => e.kind === 'news' && e.cluster.teamUid === item.teamUid);
 
     upvoteMutate(
@@ -533,6 +542,7 @@ export const TeamNews = ({
             next.set(item.uid, { viewerHasUpvoted: wasUpvoted, upvoteCount: prevCount });
             return next;
           });
+          analytics.onTeamNewsUpvoteFailed(item, position, nextUpvoted, source);
         },
         onSuccess: (status) => {
           // Reconcile the optimistic overlay with the server's authoritative
@@ -544,7 +554,7 @@ export const TeamNews = ({
               return next;
             });
           }
-          analytics.onTeamNewsUpvoteToggled(item, position >= 0 ? position : 0, nextUpvoted, 'home');
+          analytics.onTeamNewsUpvoteToggled(item, position, nextUpvoted, source);
         },
       },
     );
@@ -554,7 +564,7 @@ export const TeamNews = ({
   // rollback on error, reconcile with the server's authoritative status). The
   // caller passes the overlay-merged post, so `viewerHasLiked` is current.
   // No signed-out branch: only access-holding (signed-in) viewers see posts.
-  const handleForumPostLikeToggle = (post: IFeedForumPost) => {
+  const handleForumPostLikeToggle = (post: IFeedForumPost, source: TeamNewsAnalyticsSource = 'home') => {
     const wasLiked = post.viewerHasLiked;
     const nextLiked = !wasLiked;
     const prevCount = post.likeCount;
@@ -569,12 +579,13 @@ export const TeamNews = ({
       {
         onError: () => {
           setPostLikeOverlay((prev) => new Map(prev).set(post.uid, { viewerHasLiked: wasLiked, likeCount: prevCount }));
+          analytics.onFeedForumPostLikeFailed(post, position, nextLiked, source);
         },
         onSuccess: (status) => {
           if (status) {
             setPostLikeOverlay((prev) => new Map(prev).set(post.uid, status));
           }
-          analytics.onFeedForumPostLikeToggled(post, position >= 0 ? position : 0, nextLiked, 'home');
+          analytics.onFeedForumPostLikeToggled(post, position, nextLiked, source);
         },
       },
     );
@@ -774,13 +785,17 @@ export const TeamNews = ({
         <NewsDetailModal
           item={activeNewsItem}
           onClose={closeNews}
-          onUpvoteToggle={handleUpvoteToggle}
+          onUpvoteToggle={(item) => handleUpvoteToggle(item, 'news-modal')}
           isFollowing={followedTeamUids.has(activeNewsItem.teamUid)}
           onFollowToggle={handleFollowToggle}
         />
       )}
       {activeForumPost && (
-        <ForumPostModal post={activeForumPost} onClose={closePost} onLikeToggle={handleForumPostLikeToggle} />
+        <ForumPostModal
+          post={activeForumPost}
+          onClose={closePost}
+          onLikeToggle={(post) => handleForumPostLikeToggle(post, 'news-modal')}
+        />
       )}
     </NewsBase>
   );

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentContent.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { useMemo } from 'react';
 import parse from 'html-react-parser';
 
-import { isBlankHtml, linkifyHtml, sanitizeCommentHtml } from '@/utils/html';
+import { classifyAnchor, isBlankHtml, linkifyHtml, sanitizeCommentHtml, type AnchorTarget } from '@/utils/html';
 
 import s from './FeedCommentsThread.module.scss';
 
@@ -44,10 +44,39 @@ interface FeedCommentContentProps {
    *  plain text for everything older. */
   html: string;
   className?: string;
+  /** Someone followed a link or a mention in this comment. A callback rather
+   *  than analytics here, so this component stays a renderer and never needs
+   *  to know which feed item, surface or kind it is inside. */
+  onAnchorClick?: (target: AnchorTarget) => void;
 }
 
-export function FeedCommentContent({ html, className }: FeedCommentContentProps) {
+export function FeedCommentContent({ html, className, onAnchorClick }: FeedCommentContentProps) {
   const nodes = useMemo(() => parse(sanitizeCommentHtml(linkifyHtml(html ?? ''))), [html]);
 
-  return <div className={clsx(s.text, s.richText, className)}>{nodes}</div>;
+  // One delegated handler on this element, not one per anchor: the content is
+  // parsed HTML, so per-anchor handlers would mean rewriting nodes during the
+  // parse. Scoped HERE rather than on the thread, which also contains the
+  // "more comments on the forum" and "view it on the forum" links — those are
+  // chrome, not something a member wrote.
+  //
+  // auxclick as well as click, or every middle-click "open in new tab" — a
+  // very normal way to follow a link — would be invisible. Never
+  // preventDefault: this observes, it does not intercept.
+  const handleAnchorClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!onAnchorClick) return;
+    const anchor = (event.target as HTMLElement | null)?.closest?.('a');
+    if (!anchor) return;
+    const target = classifyAnchor(anchor as HTMLAnchorElement);
+    if (target.kind !== 'skip') onAnchorClick(target);
+  };
+
+  return (
+    <div
+      className={clsx(s.text, s.richText, className)}
+      onClick={onAnchorClick ? handleAnchorClick : undefined}
+      onAuxClick={onAnchorClick ? handleAnchorClick : undefined}
+    >
+      {nodes}
+    </div>
+  );
 }

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -52,12 +52,6 @@ function countComments(comments: readonly IFeedComment[]): number {
   return comments.reduce((total, comment) => total + 1 + countComments(comment.replies), 0);
 }
 
-/** How many members this comment mentions — the class MentionBlot stamps is
- *  the only marker distinguishing a mention from an ordinary link. */
-function countMentions(html: string): number {
-  return html.match(/class="ql-mention"/g)?.length ?? 0;
-}
-
 /** Is `uid` this comment or anywhere in its subtree? */
 function containsUid(comment: IFeedComment, uid: string): boolean {
   return comment.uid === uid || comment.replies.some((reply) => containsUid(reply, uid));
@@ -188,8 +182,12 @@ export function FeedCommentsThread({
   const isCard = onViewAll !== undefined;
 
   const { data, isPending, isError, refetch } = useFeedComments(itemUid, { enabled: true });
-  const addComment = useAddFeedComment(itemUid, forumMainPid);
-  const deleteComment = useDeleteFeedComment(itemUid);
+  // The hooks report their own analytics, from their options callbacks — those
+  // survive the remount a tab or category change causes, which a callback
+  // passed to mutate() would not.
+  const analyticsContext = useMemo(() => ({ kind, source }), [kind, source]);
+  const addComment = useAddFeedComment(itemUid, forumMainPid, analyticsContext);
+  const deleteComment = useDeleteFeedComment(itemUid, analyticsContext);
 
   const isForumPost = isForumPostUid(itemUid);
   // Forum writes go through NodeBB, which enforces this itself; checking here
@@ -240,7 +238,6 @@ export function FeedCommentsThread({
           // options callbacks, which survive this component unmounting.
           if (parentUid) setReplyingTo(null);
           else setDraft('');
-          analytics.onFeedCommentSubmitted(itemUid, kind, source, Boolean(parentUid), countMentions(trimmed));
         },
       },
     );

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import { clampDepth } from '@/utils/comments';
-import { isBlankHtml } from '@/utils/html';
+import { countMentions, isBlankHtml } from '@/utils/html';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
 import { forumErrorMessage } from '@/services/forum/forum.service';
@@ -181,7 +181,7 @@ export function FeedCommentsThread({
   // The only difference between the card and the modal. See the prop's doc.
   const isCard = onViewAll !== undefined;
 
-  const { data, isPending, isError, refetch } = useFeedComments(itemUid, { enabled: true });
+  const { data, isPending, isError, errorUpdatedAt, refetch } = useFeedComments(itemUid, { enabled: true });
   // The hooks report their own analytics, from their options callbacks — those
   // survive the remount a tab or category change causes, which a callback
   // passed to mutate() would not.
@@ -226,7 +226,21 @@ export function FeedCommentsThread({
     // a comment that looks well short of the limit can still be refused. Say
     // so here rather than letting it come back as a bare 400.
     if (trimmed.length > FEED_COMMENT_MAX_LENGTH) {
-      setOversizeParentUid(parentUid ?? null);
+      const target = parentUid ?? null;
+      // Only on the transition: submit is reachable from the form AND from
+      // Enter, so hammering Enter on an unchanged oversize draft would
+      // otherwise report the same refusal over and over.
+      if (oversizeParentUid !== target) {
+        setOversizeParentUid(target);
+        analytics.onFeedCommentFailed(itemUid, kind, source, Boolean(parentUid), {
+          reason: 'too-long-client',
+          // Plain numbers, hard-rule safe — and the only way to tell "wrote an
+          // essay" from "added six mentions and blew the markup budget", which
+          // is the distinction TOO_LONG's copy already draws.
+          length: trimmed.length,
+          mentionsCount: countMentions(trimmed),
+        });
+      }
       return false;
     }
     setOversizeParentUid(undefined);
@@ -264,6 +278,9 @@ export function FeedCommentsThread({
   };
 
   const goToLogin = () => {
+    // The guest→member funnel's drop-off point. Fires before a soft #login nav,
+    // so unlike the session-expired path this one delivers reliably.
+    analytics.onFeedCommentSignInClicked(itemUid, kind, source);
     // A card passes onSignIn so the URL records which thread was open; without
     // it this is a bare /home#login and the member comes back to a collapsed
     // feed with no idea where they were.
@@ -293,6 +310,16 @@ export function FeedCommentsThread({
       ? (attempt?.parentUid ?? null)
       : undefined
     : oversizeParentUid;
+
+  // Keyed on errorUpdatedAt, NOT isError: in TanStack v5 a failing refetch of
+  // an already-errored query leaves status 'error' throughout, so an [isError]
+  // effect would fire once ever no matter how many retries failed — and the
+  // retry funnel would have no denominator.
+  useEffect(() => {
+    if (!isError) return;
+    analytics.onFeedCommentLoadFailed(itemUid, kind, source, Boolean(data));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errorUpdatedAt, isError]);
 
   // "Latest ref" so the report below keys off the busy flag alone — callers
   // pass an inline arrow, and depending on its identity would re-fire every
@@ -376,7 +403,14 @@ export function FeedCommentsThread({
       ) : isError ? (
         <p className={s.error} role="alert">
           Couldn’t load comments —{' '}
-          <button type="button" className={s.retryBtn} onClick={() => refetch()}>
+          <button
+            type="button"
+            className={s.retryBtn}
+            onClick={() => {
+              analytics.onFeedCommentRetryClicked(itemUid, kind, source);
+              refetch();
+            }}
+          >
             retry
           </button>
         </p>

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -18,6 +18,7 @@ import { useDeleteFeedComment } from '@/services/feed/hooks/useDeleteFeedComment
 import { FEED_COMMENT_MAX_LENGTH } from '@/services/feed/constants';
 import { useTeamNewsAnalytics, type FeedItemKind, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { isForumPostUid, type IFeedComment } from '@/types/feed.types';
+import type { AnchorTarget } from '@/utils/html';
 
 import { FeedCommentContent, hasRenderableContent } from './FeedCommentContent';
 
@@ -258,6 +259,19 @@ export function FeedCommentsThread({
     return true;
   };
 
+  // Someone followed something a member wrote. host only for links — a pasted
+  // URL's path or query can carry a token or a private document id.
+  const reportAnchorClick = (target: AnchorTarget) => {
+    if (target.kind === 'mention') {
+      analytics.onFeedCommentMentionClicked(itemUid, kind, source, target.memberUid);
+    } else if (target.kind === 'link') {
+      analytics.onFeedCommentLinkClicked(itemUid, kind, source, {
+        linkType: target.linkType,
+        ...(target.linkType === 'http' ? { host: target.host } : {}),
+      });
+    }
+  };
+
   // Only the selection, never the draft it was typed into.
   const reportMentionSelected = (member: { uid: string; name: string }) => {
     analytics.onFeedCommentMentionSelected(itemUid, kind, source, {
@@ -446,6 +460,7 @@ export function FeedCommentsThread({
               resetDelete={deleteComment.reset}
               forumTopicUrl={forumTopicUrl}
               onMentionSelected={reportMentionSelected}
+              onAnchorClick={reportAnchorClick}
             />
           ))}
           {showEscalation && (
@@ -579,7 +594,9 @@ function PendingRow({ text }: { text: string }) {
           <span className={s.time}>· posting…</span>
         </div>
         {/* Same pipeline as a landed comment, so a mention or link the member
-            just typed doesn't visibly change shape when the server confirms. */}
+            just typed doesn't visibly change shape when the server confirms.
+            No onAnchorClick: this is the member's own unsent comment, and
+            counting them clicking their own link would inflate the metric. */}
         <FeedCommentContent html={text} />
       </div>
     </div>
@@ -606,6 +623,7 @@ interface CommentRowProps {
   /** Where an attachment-only comment can actually be seen (forum posts only). */
   forumTopicUrl: string | undefined;
   onMentionSelected: (member: { uid: string; name: string }) => void;
+  onAnchorClick: (target: AnchorTarget) => void;
 }
 
 /**
@@ -638,6 +656,7 @@ function CommentRow(props: CommentRowProps) {
     resetDelete,
     forumTopicUrl,
     onMentionSelected,
+    onAnchorClick,
   } = props;
 
   const [replyDraft, setReplyDraft] = useState('');
@@ -700,7 +719,7 @@ function CommentRow(props: CommentRowProps) {
             where it can be seen, rather than rendering a blank row. Asked of
             the sanitized string: the raw one is a truthy `<img src=…>`. */}
         {hasRenderableContent(comment.text) ? (
-          <FeedCommentContent html={comment.text} />
+          <FeedCommentContent html={comment.text} onAnchorClick={onAnchorClick} />
         ) : (
           <p className={clsx(s.text, s.textAttachment)}>
             {forumTopicUrl ? (

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -9,6 +9,7 @@ import { useCurrentUserStore } from '@/services/auth/store';
 import { useGetForumDigestSettings, type ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
 import { useSettingsAnalytics } from '@/analytics/settings.analytics';
+import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
 import type { FollowAnalyticsSource } from '@/analytics/follow.analytics';
 import type { ISuggestedTeam, ITeamNewsPopularItem } from '@/types/team-news.types';
 
@@ -173,6 +174,7 @@ export function NewsRail({
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
   const analytics = useSettingsAnalytics();
+  const teamNewsAnalytics = useTeamNewsAnalytics();
   const { mutate } = useUpdateForumDigestSettings();
   const visibleSuggestions = useDelayedHideFollowedSuggestions(suggestedTeams, followedTeamUids);
 
@@ -213,6 +215,30 @@ export function NewsRail({
   // the rail smoothly reflow into the space that frees up, rather than jumping.
   const showTeamsToFollow = Boolean(onFollowToggle) && (isLoadingSuggestedTeams || visibleSuggestions.length > 0);
   const showPopular = popularItems.length > 0;
+
+  // Two constants for this card were declared and never fired. Wired off the
+  // mount decision above, which is the only place that knows both outcomes:
+  // the card appearing with real suggestions, and it leaving — which happens
+  // when the member has followed every one, the completion of this funnel.
+  const suggestionsShown = showTeamsToFollow && !isLoadingSuggestedTeams ? visibleSuggestions.length : 0;
+  const wasShownRef = useRef(false);
+  useEffect(() => {
+    if (suggestionsShown > 0 && !wasShownRef.current) {
+      wasShownRef.current = true;
+      teamNewsAnalytics.onTeamsToFollowViewed(suggestionsShown);
+    } else if (suggestionsShown === 0 && wasShownRef.current && !isLoadingSuggestedTeams) {
+      wasShownRef.current = false;
+      teamNewsAnalytics.onTeamsToFollowHidden();
+    }
+  }, [suggestionsShown, isLoadingSuggestedTeams, teamNewsAnalytics]);
+
+  // Popular-this-week's click-through had a numerator and no denominator.
+  const popularShownRef = useRef(false);
+  useEffect(() => {
+    if (!showPopular || popularShownRef.current) return;
+    popularShownRef.current = true;
+    teamNewsAnalytics.onPopularCardViewed(popularItems.length);
+  }, [showPopular, popularItems.length, teamNewsAnalytics]);
 
   return (
     <aside className={s.rail} aria-label="News feed sidebar">

--- a/components/page/team-details/TeamNews/TeamNewsRail.tsx
+++ b/components/page/team-details/TeamNews/TeamNewsRail.tsx
@@ -37,8 +37,13 @@ export function mergeUpvoteOverlay(items: ITeamNewsItem[], overlay: TeamNewsUpvo
 export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailProps) {
   const [modalState, setModalState] = useState<NewsModalState>({ isOpen: false });
   const isMobile = useIsMobile();
-  const { onTeamNewsCardClicked, onTeamNewsViewAllClicked, onTeamNewsShowMoreClicked, onTeamNewsUpvoteToggled } =
-    useTeamNewsAnalytics();
+  const {
+    onTeamNewsCardClicked,
+    onTeamNewsViewAllClicked,
+    onTeamNewsShowMoreClicked,
+    onTeamNewsUpvoteToggled,
+    onTeamNewsUpvoteFailed,
+  } = useTeamNewsAnalytics();
   const { mutate: upvoteMutate } = useTeamNewsUpvoteToggle();
 
   const searchParams = useSearchParams();
@@ -73,6 +78,10 @@ export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailPro
               next.set(item.uid, { viewerHasUpvoted: wasUpvoted, upvoteCount: prevCount });
               return next;
             });
+            // The other half of the funnel. Wiring only /home's copy of this
+            // handler would have made the failure rate read 0% for every
+            // team-profile surface, while the success event covers them all.
+            onTeamNewsUpvoteFailed(item, position, nextUpvoted, source);
           },
           onSuccess: (status) => {
             // Reconcile with the server's authoritative count/state (e.g.
@@ -89,7 +98,7 @@ export function TeamNewsRail({ teamUid, teamName, initialData }: TeamNewsRailPro
         },
       );
     },
-    [onTeamNewsUpvoteToggled, upvoteMutate],
+    [onTeamNewsUpvoteToggled, onTeamNewsUpvoteFailed, upvoteMutate],
   );
 
   const total = initialData.total;

--- a/services/feed/commentFailure.ts
+++ b/services/feed/commentFailure.ts
@@ -29,6 +29,12 @@ export interface CommentFailure {
    *  chose to send, and NodeBB's spam and URL plugins embed the offending
    *  content in it, so nothing else from that string may reach analytics. */
   errorKey?: string;
+  /** `too-long-client` only: the serialised length that breached the cap, and
+   *  how much of it was mention markup. Plain numbers — no content. Without
+   *  them there is no telling a long comment from a mention-heavy short one,
+   *  which is the whole question that reason raises. */
+  length?: number;
+  mentionsCount?: number;
 }
 
 const ERROR_KEY = /\[\[error:([a-z0-9_-]+)/i;

--- a/services/feed/commentFailure.ts
+++ b/services/feed/commentFailure.ts
@@ -1,0 +1,90 @@
+import { ForumWriteError, classifyForumMessage } from '@/services/forum/forum.service';
+import { FeedWriteError } from './feed.service';
+
+/**
+ * Why a comment write failed, in terms a dashboard can group on.
+ *
+ * `too-long-client` never reaches a backend — it is our own wire-length guard,
+ * and it is worth counting separately because it is the one failure that is
+ * ours rather than the server's.
+ */
+export type CommentFailureReason =
+  | 'too-long-client'
+  | 'too-short'
+  | 'rate-limited'
+  | 'no-permission'
+  | 'session-expired'
+  | 'rejected'
+  | 'server-error'
+  | 'network'
+  | 'unknown';
+
+export interface CommentFailure {
+  reason: CommentFailureReason;
+  /** HTTP status when there was a response. Always emitted when known, so
+   *  `rejected` and `unknown` stay diagnosable without a code change. */
+  status?: number;
+  /** NodeBB's error SLUG only — `content-too-short`, never the arguments and
+   *  never the message. `ForumWriteError.forumMessage` is whatever the server
+   *  chose to send, and NodeBB's spam and URL plugins embed the offending
+   *  content in it, so nothing else from that string may reach analytics. */
+  errorKey?: string;
+}
+
+const ERROR_KEY = /\[\[error:([a-z0-9_-]+)/i;
+
+function statusToReason(status: number): CommentFailureReason {
+  if (status === 401) return 'session-expired';
+  if (status === 403) return 'no-permission';
+  if (status === 429) return 'rate-limited';
+  if (status >= 500) return 'server-error';
+  // 400 / 409 / 413 and friends: refused on the merits, not broken. `rejected`
+  // rather than `server-error`, which would point the finger at the backend.
+  if (status >= 400) return 'rejected';
+  return 'unknown';
+}
+
+/**
+ * Classify a comment write failure for analytics.
+ *
+ * The one non-obvious rule: a `*WriteError` with no status means `customFetch`
+ * gave up on auth and returned nothing — it logs out and reloads the page. A
+ * genuine network failure makes `fetch` REJECT, which arrives here as a
+ * TypeError instead. So "no status" is `session-expired`, not `unknown`;
+ * leaving it in `unknown` turns that bucket into "logged out mid-write" and
+ * invites diagnosing a backend problem that isn't there.
+ */
+export function classifyCommentFailure(error: unknown): CommentFailure {
+  const isWriteError = error instanceof ForumWriteError || error instanceof FeedWriteError;
+
+  if (isWriteError && error.status === undefined) {
+    return { reason: 'session-expired' };
+  }
+
+  const raw = error instanceof Error ? error.message : '';
+  const errorKey = ERROR_KEY.exec(raw)?.[1];
+
+  // NodeBB says WHY in the message far more often than in the status, so the
+  // key wins where it is recognisable — a rate limit served as 403 should not
+  // be filed as a permission problem.
+  //
+  // This DIVERGES from forumErrorMessage on purpose: the copy a member sees
+  // checks status first, so a 403-served rate limit reads as "no permission"
+  // there. Reordering the copy would change shipped wording, which does not
+  // belong in an analytics change — but the recorded reason should still be
+  // the true one. The two agree on every input the display tests pin, since
+  // those carry no status at all.
+  const fromMessage = classifyForumMessage(raw);
+  if (fromMessage) {
+    return { reason: fromMessage, status: isWriteError ? error.status : undefined, errorKey };
+  }
+
+  if (isWriteError && error.status !== undefined) {
+    return { reason: statusToReason(error.status), status: error.status, errorKey };
+  }
+
+  // fetch itself rejected: no response was ever produced.
+  if (error instanceof TypeError) return { reason: 'network' };
+
+  return { reason: 'unknown', errorKey };
+}

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -38,6 +38,25 @@ import {
 // badge on the page down with it.
 const COMMENT_COUNTS_BATCH_SIZE = 200;
 
+/**
+ * A directory-backend write that came back not-ok, carrying the status so a
+ * failure can be classified rather than lumped into "something went wrong".
+ * Mirrors ForumWriteError, which does the same for the NodeBB side.
+ *
+ * `status` is undefined only when customFetch gave up on auth and returned
+ * nothing — a genuine network failure makes fetch REJECT, so it never reaches
+ * here. classifyCommentFailure relies on that distinction.
+ */
+export class FeedWriteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | undefined,
+  ) {
+    super(message);
+    this.name = 'FeedWriteError';
+  }
+}
+
 // ── Wire shapes (directory backend) ──────────────────────────────────────────
 // Deliberately local: the moment these leak upward, every component has to care
 // that news comments say `newsItemUid` and forum comments have no such concept.
@@ -210,7 +229,8 @@ export async function createFeedComment(request: ICreateFeedCommentRequest): Pro
     },
     true,
   );
-  if (!response?.ok) throw new Error('Failed to post feed comment');
+  // Same message as before (a test pins it); the status is what's new.
+  if (!response?.ok) throw new FeedWriteError('Failed to post feed comment', response?.status);
 
   return toFeedComment((await response.json()) as IFeedCommentWire);
 }
@@ -225,7 +245,7 @@ export async function deleteFeedComment(commentUid: string): Promise<IFeedCommen
     true,
   );
   if (response?.status === 404) return { uid: commentUid, deleted: true };
-  if (!response?.ok) throw new Error('Failed to delete feed comment');
+  if (!response?.ok) throw new FeedWriteError('Failed to delete feed comment', response?.status);
 
   return (await response.json()) as IFeedCommentDeleteResponse;
 }
@@ -314,7 +334,10 @@ async function createForumPostComment(request: ICreateFeedCommentRequest): Promi
 
 async function fetchTopicMainPid(tid: number): Promise<number> {
   const response = await forumFetch(`/api/topic/${tid}`);
-  if (!response?.ok) throw new Error('Failed to post feed comment');
+  // Its own message: sharing the POST's made two unrelated causes — the
+  // directory rejecting a comment, and a NodeBB topic lookup failing — land in
+  // one analytics row with no way to tell them apart.
+  if (!response?.ok) throw new FeedWriteError('Failed to look up the forum topic', response?.status);
 
   const topic = (await response.json()) as TopicResponse;
   return topic.mainPid;

--- a/services/feed/hooks/useAddFeedComment.ts
+++ b/services/feed/hooks/useAddFeedComment.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { IFeedComment, IFeedCommentCountsResponse, IFeedCommentsResponse } from '@/types/feed.types';
 import { insertCommentIntoTree } from '@/utils/comments';
+import { countMentions } from '@/utils/html';
 import { useTeamNewsAnalytics, type FeedItemKind, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { feedQueryKeys } from '../constants';
 import { classifyCommentFailure } from '../commentFailure';
@@ -12,12 +13,6 @@ import { createFeedComment } from '../feed.service';
 export interface FeedCommentContext {
   kind: FeedItemKind;
   source: TeamNewsAnalyticsSource;
-}
-
-/** Mentions are the only thing in a comment worth counting, and the class
- *  MentionBlot stamps is what distinguishes one from an ordinary link. */
-function countMentions(html: string): number {
-  return html.match(/class="ql-mention"/g)?.length ?? 0;
 }
 
 // Per-item mutation (itemUid bound at hook creation so `scope` can serialize

--- a/services/feed/hooks/useAddFeedComment.ts
+++ b/services/feed/hooks/useAddFeedComment.ts
@@ -3,8 +3,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { IFeedComment, IFeedCommentCountsResponse, IFeedCommentsResponse } from '@/types/feed.types';
 import { insertCommentIntoTree } from '@/utils/comments';
+import { useTeamNewsAnalytics, type FeedItemKind, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import { feedQueryKeys } from '../constants';
+import { classifyCommentFailure } from '../commentFailure';
 import { createFeedComment } from '../feed.service';
+
+/** Which surface a write came from, so its analytics can say. */
+export interface FeedCommentContext {
+  kind: FeedItemKind;
+  source: TeamNewsAnalyticsSource;
+}
+
+/** Mentions are the only thing in a comment worth counting, and the class
+ *  MentionBlot stamps is what distinguishes one from an ordinary link. */
+function countMentions(html: string): number {
+  return html.match(/class="ql-mention"/g)?.length ?? 0;
+}
 
 // Per-item mutation (itemUid bound at hook creation so `scope` can serialize
 // rapid submits across surfaces — the card composer and the modal composer are
@@ -23,13 +37,42 @@ import { createFeedComment } from '../feed.service';
 // `forumMainPid` is the topic's opening post, which a top-level comment on a
 // forum post replies to. Passed in by the surface that already has the post so
 // the write costs one request; ignored entirely for news items.
-export function useAddFeedComment(itemUid: string, forumMainPid?: number) {
+export function useAddFeedComment(itemUid: string, forumMainPid?: number, context?: FeedCommentContext) {
   const queryClient = useQueryClient();
+  const analytics = useTeamNewsAnalytics();
 
   return useMutation<IFeedComment, Error, { text: string; parentUid?: string }>({
     scope: { id: `feed-comment-${itemUid}` },
     mutationFn: ({ text, parentUid }) => createFeedComment({ itemUid, parentUid, text, forumMainPid }),
-    onSuccess: async (created) => {
+    // Analytics live here with the cache writes, for the same reason: a tab or
+    // category change remounts the card mid-flight, and a mutate()-level
+    // callback would simply not run. Submitted used to be reported from the
+    // component and was therefore already silently lossy — putting the failure
+    // event anywhere else would make the failure RATE wrong, in a direction
+    // nobody could work out from the data.
+    onError: (error, { parentUid }) => {
+      if (!context) return;
+      // `parentUid` comes from the mutation's own variables, never component
+      // state: the member can close a reply composer while the write is in
+      // flight, and `replyingTo` would then describe the wrong thing.
+      analytics.onFeedCommentFailed(
+        itemUid,
+        context.kind,
+        context.source,
+        Boolean(parentUid),
+        classifyCommentFailure(error),
+      );
+    },
+    onSuccess: async (created, { text, parentUid }) => {
+      if (context) {
+        analytics.onFeedCommentSubmitted(
+          itemUid,
+          context.kind,
+          context.source,
+          Boolean(parentUid),
+          countMentions(text),
+        );
+      }
       // Cancel BEFORE writing — an in-flight thread/counts refetch whose server
       // snapshot predates this POST would clobber the append when it lands.
       await Promise.all([

--- a/services/feed/hooks/useDeleteFeedComment.ts
+++ b/services/feed/hooks/useDeleteFeedComment.ts
@@ -3,8 +3,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { IFeedCommentCountsResponse, IFeedCommentDeleteResponse, IFeedCommentsResponse } from '@/types/feed.types';
 import { removeCommentFromTree } from '@/utils/comments';
+import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
 import { feedQueryKeys } from '../constants';
+import { classifyCommentFailure } from '../commentFailure';
 import { deleteFeedComment } from '../feed.service';
+import type { FeedCommentContext } from './useAddFeedComment';
 
 // Mirrors useAddFeedComment's shape exactly (same scope, same cancel-then-write
 // ordering, same "cache writes live in options callbacks" rule) — delete is
@@ -12,12 +15,20 @@ import { deleteFeedComment } from '../feed.service';
 // pre-removal: the row shows a pending/disabled state during the request
 // instead, same "nothing touches the cache until the server confirms" rule
 // useAddFeedComment already follows.
-export function useDeleteFeedComment(itemUid: string) {
+export function useDeleteFeedComment(itemUid: string, context?: FeedCommentContext) {
   const queryClient = useQueryClient();
+  const analytics = useTeamNewsAnalytics();
 
   return useMutation<IFeedCommentDeleteResponse, Error, { commentUid: string }>({
     scope: { id: `feed-comment-${itemUid}` },
     mutationFn: ({ commentUid }) => deleteFeedComment(commentUid),
+    // Same reasoning as useAddFeedComment: reported here so a remount can't
+    // swallow it, and so `removedCount` — which only this callback knows — can
+    // ride along.
+    onError: (error) => {
+      if (!context) return;
+      analytics.onFeedCommentDeleteFailed(itemUid, context.kind, context.source, classifyCommentFailure(error));
+    },
     onSuccess: async (_, { commentUid }) => {
       await Promise.all([
         queryClient.cancelQueries({ queryKey: feedQueryKeys.comments(itemUid) }),
@@ -42,6 +53,11 @@ export function useDeleteFeedComment(itemUid: string) {
           old ? { ...old, [itemUid]: Math.max(0, (old[itemUid] ?? 0) - removedCount) } : old,
         );
       }
+
+      // `removedCount` is 0 for a comment that wasn't cached — a stale delete
+      // from another tab, which the service maps 404→success. Reporting it
+      // keeps that case visible instead of inflating the delete count.
+      if (context) analytics.onFeedCommentDeleted(itemUid, context.kind, context.source, removedCount);
     },
   });
 }

--- a/services/feed/hooks/useFeedComments.ts
+++ b/services/feed/hooks/useFeedComments.ts
@@ -18,6 +18,12 @@ export function useFeedComments(itemUid: string, { enabled }: { enabled: boolean
     enabled,
     staleTime: FEED_COMMENTS_STALE_TIME,
     refetchOnWindowFocus: false,
+    // One retry, not the provider's default three. This is a foreground fetch
+    // a member is waiting on with an open thread: three attempts with backoff
+    // means the error state — and the retry button, and the analytics that go
+    // with it — arrive around seven seconds late, by which point most people
+    // have collapsed the thread and become invisible.
+    retry: 1,
   });
 }
 

--- a/services/forum/forum.service.ts
+++ b/services/forum/forum.service.ts
@@ -101,11 +101,34 @@ export function forumErrorMessage(error: unknown, fallback: string): string {
   const raw = error instanceof Error ? error.message : '';
   if (!raw) return fallback;
 
-  if (/content-too-short|too-short/i.test(raw)) return 'That’s too short for the forum — try a few more words.';
-  if (/too-many-posts|rate-limit/i.test(raw)) return 'You’re posting a little fast for the forum — try again shortly.';
-  if (/no-privileges|not-allowed|privileges/i.test(raw)) return 'You don’t have permission to reply on the forum.';
-  if (/invalid token|unauthori[sz]ed/i.test(raw)) return 'The forum didn’t accept your session — try signing in again.';
+  switch (classifyForumMessage(raw)) {
+    case 'too-short':
+      return 'That’s too short for the forum — try a few more words.';
+    case 'rate-limited':
+      return 'You’re posting a little fast for the forum — try again shortly.';
+    case 'no-permission':
+      return 'You don’t have permission to reply on the forum.';
+    case 'session-expired':
+      return 'The forum didn’t accept your session — try signing in again.';
+  }
 
   // Any remaining bracketed key is machine text, not a message for a member.
   return /^\[\[.*\]\]$/.test(raw.trim()) || raw.includes('[[') ? fallback : raw;
+}
+
+/** What a forum rejection actually was, for analytics and for the copy above.
+ *  `undefined` = the message says nothing recognisable. */
+export type ForumMessageReason = 'too-short' | 'rate-limited' | 'no-permission' | 'session-expired';
+
+/**
+ * The message half of classifying a forum rejection — shared so the reason a
+ * member is shown and the reason we record can never drift apart. Order is
+ * load-bearing and matches what forumErrorMessage did before it was extracted.
+ */
+export function classifyForumMessage(raw: string): ForumMessageReason | undefined {
+  if (/content-too-short|too-short/i.test(raw)) return 'too-short';
+  if (/too-many-posts|rate-limit/i.test(raw)) return 'rate-limited';
+  if (/no-privileges|not-allowed|privileges/i.test(raw)) return 'no-permission';
+  if (/invalid token|unauthori[sz]ed/i.test(raw)) return 'session-expired';
+  return undefined;
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -613,6 +613,17 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_FEED_COMMENT_THREAD_TOGGLED: 'team-news-feed-comment-thread-toggled',
   TEAM_NEWS_FEED_COMMENT_SUBMITTED: 'team-news-feed-comment-submitted',
   TEAM_NEWS_FEED_COMMENT_MENTION_SELECTED: 'team-news-feed-comment-mention-selected',
+  // Failure and drop-off paths. Every other feed event fires on a completed
+  // action, so without these the members the product refuses are invisible.
+  TEAM_NEWS_FEED_COMMENT_FAILED: 'team-news-feed-comment-failed',
+  TEAM_NEWS_FEED_COMMENT_DELETED: 'team-news-feed-comment-deleted',
+  TEAM_NEWS_FEED_COMMENT_DELETE_FAILED: 'team-news-feed-comment-delete-failed',
+  TEAM_NEWS_FEED_COMMENT_SIGNIN_CLICKED: 'team-news-feed-comment-signin-clicked',
+  TEAM_NEWS_FEED_COMMENT_LOAD_FAILED: 'team-news-feed-comment-load-failed',
+  TEAM_NEWS_FEED_COMMENT_RETRY_CLICKED: 'team-news-feed-comment-retry-clicked',
+  TEAM_NEWS_FEED_COMMENT_LINK_CLICKED: 'team-news-feed-comment-link-clicked',
+  TEAM_NEWS_FEED_COMMENT_MENTION_CLICKED: 'team-news-feed-comment-mention-clicked',
+  TEAM_NEWS_FEED_FORUM_POST_LIKE_FAILED: 'team-news-feed-forum-post-like-failed',
 };
 
 export const FOLLOW_ANALYTICS_EVENTS = {

--- a/utils/html/classifyAnchor.ts
+++ b/utils/html/classifyAnchor.ts
@@ -1,0 +1,44 @@
+export type AnchorTarget =
+  | { kind: 'mention'; memberUid: string }
+  | { kind: 'link'; linkType: 'http'; host: string }
+  | { kind: 'link'; linkType: 'mailto' }
+  | { kind: 'skip' };
+
+/**
+ * What did someone just click inside a comment?
+ *
+ * Deliberately reports the HOST and nothing else for a web link. A pasted URL's
+ * path or query can carry a share token or a private document id, and neither
+ * belongs in analytics — while the host answers the actual question, which is
+ * what people link to.
+ *
+ * Three cases that are easy to get wrong:
+ * - Mentions are checked FIRST. Their href is our own `/members/<uid>`, so the
+ *   generic branch would count every mention as a link to our own domain.
+ * - `mailto:` reports no host at all. The comment sanitizer permits it and
+ *   NodeBB-authored comments carry real ones; `new URL(…).host` is empty for
+ *   them, so any "fall back to the href" branch would put an email address on
+ *   the event.
+ * - No href means skip. DOMPurify strips hrefs outside its allowlist — NodeBB's
+ *   own `/topic/123` links among them — leaving a bare anchor. Resolving that
+ *   would invent an internal-link count out of nothing.
+ */
+export function classifyAnchor(anchor: HTMLAnchorElement): AnchorTarget {
+  const memberUid = anchor.getAttribute('data-uid');
+  if (anchor.classList.contains('ql-mention') && memberUid) {
+    return { kind: 'mention', memberUid };
+  }
+
+  const href = anchor.getAttribute('href');
+  if (!href) return { kind: 'skip' };
+
+  try {
+    const url = new URL(href, window.location.origin);
+    if (url.protocol === 'mailto:') return { kind: 'link', linkType: 'mailto' };
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return { kind: 'skip' };
+    return { kind: 'link', linkType: 'http', host: url.host };
+  } catch {
+    // A malformed href is not worth a broken click handler.
+    return { kind: 'skip' };
+  }
+}

--- a/utils/html/countMentions.ts
+++ b/utils/html/countMentions.ts
@@ -1,0 +1,5 @@
+/** How many members a comment mentions. The class RichTextEditor's MentionBlot
+ *  stamps is the only thing distinguishing a mention from an ordinary link. */
+export function countMentions(html: string): number {
+  return html.match(/class="ql-mention"/g)?.length ?? 0;
+}

--- a/utils/html/index.ts
+++ b/utils/html/index.ts
@@ -1,3 +1,4 @@
 export { linkifyHtml } from './linkifyHtml';
 export { isBlankHtml } from './isBlankHtml';
 export { sanitizeCommentHtml, COMMENT_SANITIZE_CONFIG } from './sanitizeCommentHtml';
+export { countMentions } from './countMentions';

--- a/utils/html/index.ts
+++ b/utils/html/index.ts
@@ -2,3 +2,4 @@ export { linkifyHtml } from './linkifyHtml';
 export { isBlankHtml } from './isBlankHtml';
 export { sanitizeCommentHtml, COMMENT_SANITIZE_CONFIG } from './sanitizeCommentHtml';
 export { countMentions } from './countMentions';
+export { classifyAnchor, type AnchorTarget } from './classifyAnchor';


### PR DESCRIPTION
> **Third in a stack.** Base is `feat/feed-comment-links-and-mentions` (#2714), which sits on `feat/newsfeed-inline-comment-threads` (#2713). Review in order; each retargets automatically as the one below lands.

## Summary

PostHog coverage for the feed comment layer's **failure and drop-off paths** — the members the product turns away, who currently leave no trace anywhere.

An audit first, because the ask overlapped heavily with what exists: like/unlike (both news and forum, each already carrying `nextState`), comment, reply (`isReply`), category, tab, sort, search and share are **all instrumented today** — 21 functions. Nothing was re-added. The comment thread itself fired exactly **two** events.

Every existing feed event fires on a *completed* action. That's the gap.

## The biggest change isn't an event

`comment-submitted` was reported at `mutate()` level. Those callbacks **do not survive unmount** — the hook says so in its own header, which is why the cache writes live in the options — so a tab, category or sort change during a slow POST simply dropped it. It was already silently lossy.

Adding `comment-failed` anywhere else would have been worse than lossy: an asymmetric loss between numerator and denominator makes the failure *rate* wrong, in a direction nobody could reconstruct. Both now report from the hook's options, and delete gets the same treatment.

That also buys, for free: fires exactly once per mutation with no dependence on an error state persisting across renders; a card thread and a modal thread mounted for the same item can't double-count, since only the instance that called `mutate` reports; and `removedCount` rides along with `comment-deleted`, which only that callback knows.

## New events

| Event | Notes |
|---|---|
| `comment-failed` | normalised `reason` + numeric `status` + NodeBB `errorKey` |
| `comment-deleted` / `comment-delete-failed` | deleted carries `removedCount`, and `0` for an already-deleted row (the service maps 404→success) |
| `comment-signin-clicked` | the guest→member drop-off, from inside a thread |
| `comment-load-failed` / `comment-retry-clicked` | |
| `comment-link-clicked` / `comment-mention-clicked` | host only; mention by target member uid |
| `upvote-failed`, `forum-post-like-failed` | |
| plus the four other dead constants, all now fired |

## Four rules that are easy to get backwards

**`status === undefined` is `session-expired`, not `unknown`.** `customFetch` returns nothing only when it gave up on auth — it logs out and reloads. A genuine network failure makes `fetch` *reject*, arriving as a `TypeError`. Left in `unknown`, that bucket quietly becomes "logged out mid-write" and invites chasing a backend bug that isn't there.

**`errorUpdatedAt`, not `isError`, for load failures.** In TanStack v5 a failing refetch of an already-errored query leaves `status: 'error'` throughout, so an `[isError]` effect fires **once ever** however many retries fail — the retry funnel would have had no denominator.

**`errorKey` is the slug alone.** `ForumWriteError.forumMessage` is `body?.status?.message ?? body?.error`, entirely server-controlled, and NodeBB's spam and URL plugins embed the offending content in it. Tests assert an embedded email address and an embedded URL cannot escape.

**Host only for links.** A pasted URL's path or query can carry a share token or a private document id. `mailto:` reports no host at all, because there the host *is* the address.

## Also fixed while in there

- **429 was unclassifiable.** Rate limits were detected by message regex only, so a plain HTTP 429 from either backend matched nothing.
- **`forumErrorMessage` held the classification logic** for the copy a member reads. Extracted and shared rather than duplicated, so the reason shown and the reason recorded can't drift. Copy untouched; its pinned tests pass unmodified and are the regression guard.
- **`upvote-failed` has two call sites** — `TeamNews.tsx` and team-details' `TeamNewsRail`. Wiring only the first would have made the failure rate read 0% for every team-profile surface while the success event covered them all.
- **`source` on both like events was hardcoded `'home'`** although the handlers serve the card *and* the modal — the dimension carried no information. `position` reported a deep-linked modal item as `0`, indistinguishable from the genuine top card; it reports `-1`.
- **`useFeedComments` inherited `retry: 3`**, so the error state, the retry button and these events all arrived ~7s in — after the members being measured have closed the thread. Now `retry: 1`.
- **`fetchTopicMainPid` threw the POST's error message**, so two unrelated causes landed in one row.
- **Six dead constants**, not the two I first found. Two of them name a live, unmeasured failure path: a Popular-this-week story can age out of the 14-day window between being ranked and being clicked, so it opens the source article instead of scrolling. `TEAM_NEWS_ANALYTICS_EVENTS` is now **36 constants, 0 dead** (scripted check).

## Testing

- **1214 passed, 0 failed.** Build compiles. Touched files lint clean — the one `react-hooks/refs` error in `NewsRail` is pre-existing, confirmed by linting that file at the parent commit.
- The risk lives in pure functions, so that's where the tests are: `classifyCommentFailure` (26 cases — every status, `undefined`, `TypeError`, slug extraction, and messages embedding an email and a URL asserted *not* echoed) and `classifyAnchor` (9 — mention-before-link, mailto, stripped href, non-web schemes).
- A paired assertion that `classifyForumMessage` and `forumErrorMessage` still agree on every input the display tests pin — the guard for the extraction.
- Behavioural: submitted/failed fire from the hook and exactly once; too-long fires once per draft, not per Enter; load-failed re-fires on a failed retry but not on a re-render; the delegated listener does **not** catch the thread's own "more comments on the forum" chrome.

## No user-visible change

Nothing about the feed looks or behaves differently. `captureEvent` already try/catches, so analytics cannot break a comment from posting.

## Two things to know

**`session-expired` can only ever be a floor.** `customFetch` calls `window.location.reload()` immediately after logout, so that capture races a synchronous reload — and `logoutUser()` has already cleared the store `captureEvent` reads identity from, so events that do land look like guest events. Worth a note on any dashboard using it.

**A deliberate divergence.** `classifyCommentFailure` prefers NodeBB's error key over the HTTP status; `forumErrorMessage` still prefers the status. NodeBB serves some rate limits as 403, so those are now *recorded* as `rate-limited` while still *reading* as "no permission" to the member. Reordering shipped copy didn't belong in an analytics change — but the copy is arguably wrong, and that's worth its own ticket.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
