### PR TITLE
feat(feed): window forum posts in the news feed to the last 14 days

### DIFF
--- a/__tests__/page/home/feed-forum-post-window.test.ts
+++ b/__tests__/page/home/feed-forum-post-window.test.ts
@@ -1,0 +1,80 @@
+import type { ForumPostUid, IFeedForumPost } from '@/types/feed.types';
+import {
+  feedWindowCutoffIso,
+  withinFeedWindow,
+} from '@/components/page/home/TeamNews/utils/feedForumPostWindow';
+
+const NOW = Date.parse('2026-07-31T12:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): string {
+  return new Date(NOW - days * DAY).toISOString();
+}
+
+function post(uid: string, createdAt: string, lastActivityAt = createdAt): IFeedForumPost {
+  return {
+    uid: uid as ForumPostUid,
+    tid: 1,
+    mainPid: 10,
+    title: `Post ${uid}`,
+    body: 'Body',
+    author: { memberUid: 'm1', name: 'Mira Chen', avatarUrl: null, role: null },
+    focusAreas: [],
+    category: 'Compute',
+    createdAt,
+    lastActivityAt,
+    forumTopicUrl: null,
+    commentCount: 0,
+    likeCount: 0,
+    viewerHasLiked: false,
+  };
+}
+
+describe('feedWindowCutoffIso', () => {
+  it('is exactly N days before the supplied instant', () => {
+    expect(feedWindowCutoffIso(14, NOW)).toBe('2026-07-17T12:00:00.000Z');
+  });
+});
+
+describe('withinFeedWindow', () => {
+  const cutoff = feedWindowCutoffIso(14, NOW);
+
+  it('keeps a recently created topic', () => {
+    expect(withinFeedWindow([post('fp_1', daysAgo(2))], cutoff)).toHaveLength(1);
+  });
+
+  it('drops a topic whose last activity predates the window', () => {
+    expect(withinFeedWindow([post('fp_1', daysAgo(40))], cutoff)).toEqual([]);
+  });
+
+  // The reason the window measures lastActivityAt at all: /api/recent surfaces
+  // this topic BECAUSE it is being discussed, so creation date must not evict it.
+  it('keeps an old topic that was replied to inside the window', () => {
+    const revived = post('fp_1', daysAgo(40), daysAgo(2));
+
+    expect(withinFeedWindow([revived], cutoff)).toEqual([revived]);
+  });
+
+  it('includes a post sitting exactly on the boundary', () => {
+    expect(withinFeedWindow([post('fp_1', cutoff)], cutoff)).toHaveLength(1);
+  });
+
+  it('excludes a post one millisecond older than the boundary', () => {
+    const justOutside = new Date(Date.parse(cutoff) - 1).toISOString();
+
+    expect(withinFeedWindow([post('fp_1', justOutside)], cutoff)).toEqual([]);
+  });
+
+  it('preserves the order /api/recent returned', () => {
+    const kept = [post('fp_1', daysAgo(1)), post('fp_2', daysAgo(5)), post('fp_3', daysAgo(3))];
+    const result = withinFeedWindow([kept[0], post('fp_old', daysAgo(90)), kept[1], kept[2]], cutoff);
+
+    expect(result?.map((p) => p.uid)).toEqual(['fp_1', 'fp_2', 'fp_3']);
+  });
+
+  // undefined means "news-only feed" — collapsing it to [] would read as
+  // "loaded, and there are none", which drives a different empty state.
+  it('passes undefined through rather than returning an empty list', () => {
+    expect(withinFeedWindow(undefined, cutoff)).toBeUndefined();
+  });
+});

--- a/__tests__/page/home/feed-forum-post-window.test.ts
+++ b/__tests__/page/home/feed-forum-post-window.test.ts
@@ -1,8 +1,5 @@
 import type { ForumPostUid, IFeedForumPost } from '@/types/feed.types';
-import {
-  feedWindowCutoffIso,
-  withinFeedWindow,
-} from '@/components/page/home/TeamNews/utils/feedForumPostWindow';
+import { feedWindowCutoffIso, withinFeedWindow } from '@/components/page/home/TeamNews/utils/feedForumPostWindow';
 
 const NOW = Date.parse('2026-07-31T12:00:00.000Z');
 const DAY = 24 * 60 * 60 * 1000;

--- a/__tests__/page/home/forum-post-card.test.tsx
+++ b/__tests__/page/home/forum-post-card.test.tsx
@@ -37,6 +37,7 @@ const post: IFeedForumPost = {
   focusAreas: [],
   category: 'Intros',
   createdAt: '2026-07-01T00:00:00.000Z',
+  lastActivityAt: '2026-07-01T00:00:00.000Z',
   forumTopicUrl: '/forum/topics/5/96',
   commentCount: 2,
   likeCount: 5,

--- a/__tests__/page/home/merge-feed-entries.test.ts
+++ b/__tests__/page/home/merge-feed-entries.test.ts
@@ -41,6 +41,9 @@ function post(uid: string, likeCount: number, createdAt: string, focusAreas: str
     focusAreas,
     category: 'Compute',
     createdAt,
+    // The merge ranks on createdAt, never on activity — mirrored here so these
+    // fixtures can't imply otherwise.
+    lastActivityAt: createdAt,
     forumTopicUrl: null,
     commentCount: 0,
     likeCount,

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -375,6 +375,7 @@ describe('TeamNews', () => {
         focusAreas: [],
         category: 'Intros',
         createdAt: '2026-07-01T00:00:00.000Z',
+        lastActivityAt: '2026-07-01T00:00:00.000Z',
         forumTopicUrl: '/forum/topics/5/96',
         commentCount: 2,
         likeCount: 5,

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -45,6 +45,7 @@ const mockOnTeamsToFollowHidden = jest.fn();
 const mockOnPopularStoryClicked = jest.fn();
 const mockOnDetailModalOpened = jest.fn();
 const mockOnShared = jest.fn();
+const mockOnForumPostModalOpened = jest.fn();
 
 jest.mock('@/analytics/team-news.analytics', () => ({
   useTeamNewsAnalytics: () => ({
@@ -61,6 +62,7 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamNewsUpvoteFailed: (...a: unknown[]) => mockOnUpvoteFailed(...a),
     onFeedForumPostLikeToggled: (...a: unknown[]) => mockOnForumLikeToggled(...a),
     onFeedForumPostLikeFailed: (...a: unknown[]) => mockOnForumLikeFailed(...a),
+    onFeedForumPostModalOpened: (...a: unknown[]) => mockOnForumPostModalOpened(...a),
     onPopularCardViewed: (...a: unknown[]) => mockOnPopularCardViewed(...a),
     onPopularStoryScrollSucceeded: (...a: unknown[]) => mockOnScrollSucceeded(...a),
     onPopularStoryFallbackOpened: (...a: unknown[]) => mockOnFallbackOpened(...a),
@@ -72,10 +74,18 @@ jest.mock('@/analytics/team-news.analytics', () => ({
 // Forum posts reach the feed through this hook. Default: none, which is what the
 // globally-mocked useQuery already produced — so every other test in this file
 // behaves exactly as before.
-type FeedSocialResult = { forumPosts: IFeedForumPost[] | undefined; hasAccess: boolean; deepLinkSettled: boolean };
-const mockUseFeedSocial = jest.fn(
-  (): FeedSocialResult => ({ forumPosts: undefined, hasAccess: false, deepLinkSettled: true }),
-);
+type FeedSocialResult = {
+  forumPosts: IFeedForumPost[] | undefined;
+  unwindowedForumPosts: IFeedForumPost[] | undefined;
+  hasAccess: boolean;
+  deepLinkSettled: boolean;
+};
+/** The ordinary case: every post is inside the 14-day window, so both arrays
+ *  agree. Tests that care about the window pass the two separately. */
+function feedSocial(posts: IFeedForumPost[] | undefined, hasAccess: boolean): FeedSocialResult {
+  return { forumPosts: posts, unwindowedForumPosts: posts, hasAccess, deepLinkSettled: true };
+}
+const mockUseFeedSocial = jest.fn((): FeedSocialResult => feedSocial(undefined, false));
 jest.mock('@/components/page/home/TeamNews/hooks/useFeedSocial', () => ({
   useFeedSocial: (...a: unknown[]) => mockUseFeedSocial(...(a as [])),
 }));
@@ -169,7 +179,7 @@ describe('TeamNews', () => {
     mockUseSuggestedTeamsToFollow.mockReturnValue({ suggestions: [], isLoading: false });
     // clearAllMocks clears calls, NOT return values — without this, a describe
     // that supplies forum posts leaks them into every later test's feed.
-    mockUseFeedSocial.mockReturnValue({ forumPosts: undefined, hasAccess: false, deepLinkSettled: true });
+    mockUseFeedSocial.mockReturnValue(feedSocial(undefined, false));
     // useNewsDeepLink reads the real jsdom URL on mount — reset it so a
     // ?news= param written by one test can't open the modal in the next.
     window.history.replaceState(null, '', '/home');
@@ -383,7 +393,7 @@ describe('TeamNews', () => {
       };
 
       beforeEach(() => {
-        mockUseFeedSocial.mockReturnValue({ forumPosts: [forumPost], hasAccess: true, deepLinkSettled: true });
+        mockUseFeedSocial.mockReturnValue(feedSocial([forumPost], true));
       });
 
       it('offers the Discussions pill for forum posts alone, with no threaded news items', () => {
@@ -418,6 +428,38 @@ describe('TeamNews', () => {
         fireEvent.click(screen.getByRole('button', { name: /Funding/ }));
 
         expect(screen.queryByText('Willow Is Live!')).not.toBeInTheDocument();
+      });
+
+      // A post older than the 14-day window is absent from `forumPosts` but
+      // still present in `unwindowedForumPosts` — the split that lets an old
+      // shared link work without letting a stale post into the feed.
+      describe('when the post falls outside the 14-day window', () => {
+        beforeEach(() => {
+          mockUseFeedSocial.mockReturnValue({
+            forumPosts: [],
+            unwindowedForumPosts: [forumPost],
+            hasAccess: true,
+            deepLinkSettled: true,
+          });
+        });
+
+        it('keeps it out of the feed, and out of the Discussions pill', () => {
+          renderTeamNews(<TeamNews groups={groups} />);
+
+          expect(screen.queryByText('Willow Is Live!')).not.toBeInTheDocument();
+          expect(screen.queryByRole('button', { name: /Discussions/ })).not.toBeInTheDocument();
+        });
+
+        it('still opens it from a ?post= deep link, rather than stripping the param', () => {
+          window.history.replaceState(null, '', '/home?post=fp_96');
+
+          renderTeamNews(<TeamNews groups={groups} />);
+
+          // Resolving from the windowed list would leave the modal empty and
+          // silently drop the param — the exact regression this guards.
+          expect(mockOnForumPostModalOpened).toHaveBeenCalled();
+          expect(window.location.search).toBe('?post=fp_96');
+        });
       });
     });
   });

--- a/__tests__/page/home/use-forum-post-deep-link.test.tsx
+++ b/__tests__/page/home/use-forum-post-deep-link.test.tsx
@@ -21,6 +21,7 @@ function post(uid: string): IFeedForumPost {
     focusAreas: [],
     category: 'Compute',
     createdAt: '2026-07-01T00:00:00.000Z',
+    lastActivityAt: '2026-07-01T00:00:00.000Z',
     forumTopicUrl: null,
     commentCount: 0,
     likeCount: 0,

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -39,6 +39,8 @@ const TOPIC = {
   teaser: { content: '<p>Hi Protocol Labs</p>' },
   category: { name: 'Intros' },
   timestamp: 1782891482999,
+  // A reply landed after the topic was created — /api/recent orders on this.
+  lastposttime: 1782906219045,
   postcount: 3,
   upvotes: 5,
   user: {
@@ -106,6 +108,28 @@ describe('feed.service', () => {
           viewerHasLiked: false,
         }),
       ]);
+    });
+
+    it('carries last activity separately from creation, so the feed window can use it', async () => {
+      customFetchMock.mockResolvedValue({ ok: true, json: async () => ({ topics: [TOPIC] }) });
+
+      const { items } = await getFeedForumPosts();
+
+      expect(items[0].createdAt).toBe(new Date(1782891482999).toISOString());
+      expect(items[0].lastActivityAt).toBe(new Date(1782906219045).toISOString());
+    });
+
+    it('falls back to creation when lastposttime is missing or zero, never epoch 0', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ topics: [{ ...TOPIC, lastposttime: 0 }, { ...TOPIC, lastposttime: undefined }] }),
+      });
+
+      const { items } = await getFeedForumPosts();
+
+      // Windowing on a bogus 1970 timestamp would silently hide a fresh topic.
+      expect(items[0].lastActivityAt).toBe(items[0].createdAt);
+      expect(items[1].lastActivityAt).toBe(items[1].createdAt);
     });
 
     it('counts replies as postcount minus the topic’s own opening post', async () => {

--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -122,7 +122,12 @@ describe('feed.service', () => {
     it('falls back to creation when lastposttime is missing or zero, never epoch 0', async () => {
       customFetchMock.mockResolvedValue({
         ok: true,
-        json: async () => ({ topics: [{ ...TOPIC, lastposttime: 0 }, { ...TOPIC, lastposttime: undefined }] }),
+        json: async () => ({
+          topics: [
+            { ...TOPIC, lastposttime: 0 },
+            { ...TOPIC, lastposttime: undefined },
+          ],
+        }),
       });
 
       const { items } = await getFeedForumPosts();

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -159,7 +159,12 @@ export const TeamNews = ({
 
   // The feed's social layer (forum posts + comment counts), flag- and
   // access-gated in one hook. `forumPosts` undefined ⇒ news-only feed.
-  const { forumPosts, hasAccess, deepLinkSettled } = useFeedSocial({ newsUids });
+  //
+  // `forumPosts` is trimmed to the last 14 days and is what everything below
+  // renders and counts. `unwindowedForumPosts` is the same access-gated list
+  // with only that trim lifted, and has exactly two consumers — both on the
+  // ?post= deep-link path, so a shared link to an older topic still opens.
+  const { forumPosts, unwindowedForumPosts, hasAccess, deepLinkSettled } = useFeedSocial({ newsUids });
 
   // Optimistic like state for forum posts — the exact upvoteOverlay pattern:
   // a render-time overlay the buttons read, never written to the query cache,
@@ -306,16 +311,20 @@ export const TeamNews = ({
   // asynchronously (hydration → access → posts) — the hook holds the param
   // while pending and strips it silently once settled-invalid. Deep-link
   // analytics ride the resolver's single 'valid' transition.
+  // Resolves against the UNWINDOWED list on purpose: a link someone shared
+  // three weeks ago should still open the thread it points at, even though that
+  // thread no longer earns a slot in the feed.
   const { activePostUid, openPost, closePost } = useForumPostDeepLink({
-    posts: forumPosts,
+    posts: unwindowedForumPosts,
     isSettled: deepLinkSettled,
     onDeepLinkOpen: (post) => analytics.onFeedForumPostModalOpened(post),
   });
 
   // Resolved fresh each render with the like overlay merged (same contract as
-  // activeNewsItem: modal and row can never disagree). `forumPosts` going
-  // undefined — e.g. mid-session access revocation — nulls this out and the
-  // modal unmounts; the effect below also strips the URL param.
+  // activeNewsItem: modal and row can never disagree). The post list going
+  // undefined — e.g. mid-session access revocation, which empties both the
+  // windowed and unwindowed arrays — nulls this out and the modal unmounts;
+  // the effect below also strips the URL param.
   // A forum card can't know whether the viewer already liked the post: the
   // /api/recent listing it's built from has no per-viewer vote state, so
   // `viewerHasLiked` is false by default and a "like" on something already liked
@@ -335,11 +344,14 @@ export const TeamNews = ({
     [activePostUid, activePostTopicLike, postLikeOverlay],
   );
 
+  // Unwindowed for the same reason as the resolver above — and it must match
+  // it: this is what the modal actually renders, so resolving from the windowed
+  // list would let a valid deep link open an empty modal.
   const activeForumPost = useMemo(() => {
     if (!activePostUid) return null;
-    const post = forumPosts?.find((p) => p.uid === activePostUid);
+    const post = unwindowedForumPosts?.find((p) => p.uid === activePostUid);
     return post ? resolvePostLike(post) : null;
-  }, [activePostUid, forumPosts, resolvePostLike]);
+  }, [activePostUid, unwindowedForumPosts, resolvePostLike]);
 
   useEffect(() => {
     if (activePostUid && !hasAccess) closePost();

--- a/components/page/home/TeamNews/hooks/useFeedSocial.ts
+++ b/components/page/home/TeamNews/hooks/useFeedSocial.ts
@@ -101,7 +101,10 @@ export function useFeedSocial({ newsUids }: { newsUids: string[] }): UseFeedSoci
   // whole purpose is to keep the feed merge from re-running on unrelated
   // renders (upvote-overlay writes). A fresh .filter() every render would
   // silently defeat that.
-  const forumPosts = useMemo(() => withinFeedWindow(unwindowedForumPosts, cutoffIso), [unwindowedForumPosts, cutoffIso]);
+  const forumPosts = useMemo(
+    () => withinFeedWindow(unwindowedForumPosts, cutoffIso),
+    [unwindowedForumPosts, cutoffIso],
+  );
 
   return {
     forumPosts,

--- a/components/page/home/TeamNews/hooks/useFeedSocial.ts
+++ b/components/page/home/TeamNews/hooks/useFeedSocial.ts
@@ -1,18 +1,26 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { IFeedCommentCountsResponse, IFeedForumPost } from '@/types/feed.types';
 import { useCurrentUserStore } from '@/services/auth/store';
 import { useForumAccess } from '@/services/access-control/hooks/useForumAccess';
 import { useFeedForumPosts } from '@/services/feed/hooks/useFeedForumPosts';
 import { useFeedCommentCounts } from '@/services/feed/hooks/useFeedCommentCounts';
-import { feedQueryKeys } from '@/services/feed/constants';
+import { FEED_FORUM_POST_WINDOW_DAYS, feedQueryKeys } from '@/services/feed/constants';
+import { feedWindowCutoffIso, withinFeedWindow } from '../utils/feedForumPostWindow';
 
 interface UseFeedSocialResult {
-  /** Access-gated, ready-to-merge posts; undefined = news-only (not loaded,
-   *  no access, error — the caller never needs to know which). */
+  /** Access-gated, ready-to-merge posts, trimmed to the last
+   *  FEED_FORUM_POST_WINDOW_DAYS; undefined = news-only (not loaded, no access,
+   *  error — the caller never needs to know which). This is the default for ALL
+   *  rendering, counting, merging and analytics. */
   forumPosts: IFeedForumPost[] | undefined;
+  /** The same access-gated list with only the date window lifted — NOT the
+   *  access gate, which applies identically to both. Exists solely so a shared
+   *  ?post= link to an older topic still resolves and renders; anything that
+   *  decides what the feed SHOWS must use `forumPosts` instead. */
+  unwindowedForumPosts: IFeedForumPost[] | undefined;
   hasAccess: boolean;
   /** True once a ?post= deep link can be resolved conclusively — every async
    *  gate (store hydration, access query, posts query) has settled. Built on
@@ -77,8 +85,27 @@ export function useFeedSocial({ newsUids }: { newsUids: string[] }): UseFeedSoci
   const postsGatePending = hasAccess && postsQuery.isPending && !postsQuery.isError;
   const deepLinkSettled = isHydrated && !accessGatePending && !postsGatePending;
 
+  // Mount-time cutoff (setter-less useState, the same idiom useForumPostDeepLink
+  // uses and what this repo's react-hooks/refs rule requires instead of reading
+  // the clock in the render body). Fixed once because the posts query is
+  // session-frozen: a cutoff recomputed each render would creep forward and
+  // could drop a post out from under someone mid-read.
+  //
+  // No hydration risk from the clock read: on the server the user store is
+  // unhydrated, so hasAccess is false and forumPosts is undefined — the cutoff
+  // never reaches rendered output.
+  const [cutoffIso] = useState(() => feedWindowCutoffIso(FEED_FORUM_POST_WINDOW_DAYS, Date.now()));
+
+  const unwindowedForumPosts = hasAccess ? postsQuery.data?.items : undefined;
+  // Memoized, not just tidy: TeamNews feeds this array into useMemo deps whose
+  // whole purpose is to keep the feed merge from re-running on unrelated
+  // renders (upvote-overlay writes). A fresh .filter() every render would
+  // silently defeat that.
+  const forumPosts = useMemo(() => withinFeedWindow(unwindowedForumPosts, cutoffIso), [unwindowedForumPosts, cutoffIso]);
+
   return {
-    forumPosts: hasAccess ? postsQuery.data?.items : undefined,
+    forumPosts,
+    unwindowedForumPosts,
     hasAccess,
     deepLinkSettled,
   };

--- a/components/page/home/TeamNews/utils/feedForumPostWindow.ts
+++ b/components/page/home/TeamNews/utils/feedForumPostWindow.ts
@@ -1,0 +1,31 @@
+import type { IFeedForumPost } from '@/types/feed.types';
+
+// The feed's 14-day window for forum posts, kept as pure functions so the
+// boundary is unit-testable without a hook harness.
+//
+// Why client-side: NodeBB's /api/recent takes ?term=daily|weekly|monthly and
+// nothing else, so an exact 14-day window can't be pushed down. The single
+// ~20-topic page it returns is trimmed here instead.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** The oldest activity a post may have and still show. Takes `nowMs` rather
+ *  than reading the clock so callers own when the boundary is fixed — see
+ *  useFeedSocial, which snapshots it once per session. */
+export function feedWindowCutoffIso(days: number, nowMs: number): string {
+  return new Date(nowMs - days * MS_PER_DAY).toISOString();
+}
+
+/** Posts whose latest activity — creation or last reply, whichever is later —
+ *  is at or after the cutoff. Compares ISO strings directly: toISOString() is
+ *  fixed-width UTC, so lexicographic order is chronological order, the same
+ *  property mergeFeedEntries already relies on.
+ *
+ *  Undefined in, undefined out: `undefined` means "news-only feed" (not loaded,
+ *  no access, or error) and must not collapse into an empty-but-loaded list. */
+export function withinFeedWindow(
+  posts: IFeedForumPost[] | undefined,
+  cutoffIso: string,
+): IFeedForumPost[] | undefined {
+  return posts?.filter((post) => post.lastActivityAt >= cutoffIso);
+}

--- a/components/page/home/TeamNews/utils/feedForumPostWindow.ts
+++ b/components/page/home/TeamNews/utils/feedForumPostWindow.ts
@@ -23,9 +23,6 @@ export function feedWindowCutoffIso(days: number, nowMs: number): string {
  *
  *  Undefined in, undefined out: `undefined` means "news-only feed" (not loaded,
  *  no access, or error) and must not collapse into an empty-but-loaded list. */
-export function withinFeedWindow(
-  posts: IFeedForumPost[] | undefined,
-  cutoffIso: string,
-): IFeedForumPost[] | undefined {
+export function withinFeedWindow(posts: IFeedForumPost[] | undefined, cutoffIso: string): IFeedForumPost[] | undefined {
   return posts?.filter((post) => post.lastActivityAt >= cutoffIso);
 }

--- a/services/feed/constants.ts
+++ b/services/feed/constants.ts
@@ -23,3 +23,14 @@ export const FEED_COMMENT_MAX_LENGTH = 2000;
 // A thread that goes 60s stale is not worth a focus-refetch burst; re-expands
 // within a minute are cache hits.
 export const FEED_COMMENTS_STALE_TIME = 60_000;
+
+// Forum posts are trimmed to the same window the news side already uses
+// (TEAM_NEWS_DEFAULT_WINDOW_DAYS, sent to the backend as ?windowDays=) and that
+// the feed's empty state already promises — "No network news in the last 14
+// days yet". Deliberately a separate constant rather than an import: the two
+// govern different domains (a NodeBB client-side trim vs. a directory query
+// param) and happening to share a value today shouldn't couple them.
+//
+// Client-side because it cannot be pushed down: NodeBB's /api/recent only
+// accepts ?term=daily|weekly|monthly — there is no 14-day term.
+export const FEED_FORUM_POST_WINDOW_DAYS = 14;

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -99,6 +99,12 @@ function tidFromForumPostUid(uid: ForumPostUid): number {
 function toFeedForumPost(topic: Topic): IFeedForumPost {
   const user = topic.user;
 
+  const createdMs = Number(topic.timestamp) || Date.now();
+  // NodeBB seeds lastposttime from the opening post, so it is normally >=
+  // timestamp. Maxed defensively anyway: a zero/malformed value must not make a
+  // topic look older than its own creation and window itself out of the feed.
+  const lastActivityMs = Math.max(createdMs, Number(topic.lastposttime) || 0);
+
   return {
     uid: `fp_${topic.tid}`,
     tid: topic.tid,
@@ -115,7 +121,8 @@ function toFeedForumPost(topic: Topic): IFeedForumPost {
     // no focusAreas field to map from — posts show in every tab.
     focusAreas: [],
     category: topic.category?.name ?? '',
-    createdAt: new Date(Number(topic.timestamp) || Date.now()).toISOString(),
+    createdAt: new Date(createdMs).toISOString(),
+    lastActivityAt: new Date(lastActivityMs).toISOString(),
     forumTopicUrl: `/forum/topics/${topic.cid}/${topic.tid}`,
     // postcount includes the topic's own opening post, which is the post itself
     // rather than a comment on it.

--- a/types/feed.types.ts
+++ b/types/feed.types.ts
@@ -70,7 +70,14 @@ export interface IFeedForumPost {
   focusAreas: string[];
   /** Forum category label, shown where news shows its event type. */
   category: string;
+  /** Topic creation. What the card displays and what the feed merge ranks on. */
   createdAt: string;
+  /** Latest activity on the topic — its creation or its last reply, whichever
+   *  is later, so `>= createdAt` by construction. The 14-day feed window is
+   *  measured on THIS, not on createdAt: /api/recent is ordered by activity, so
+   *  windowing on creation alone would drop actively-discussed older threads the
+   *  endpoint deliberately surfaced. Never displayed. */
+  lastActivityAt: string;
   /** In-app path to the origin topic (`/forum/topics/:cid/:tid`), for "view the
    *  full discussion" — same form CreatePost builds. Not an absolute URL, so
    *  it's never what gets shared; the share menu links to `/home?post=`. */


### PR DESCRIPTION
## Summary

Forum posts merged into the `/home` feed were unwindowed — whatever NodeBB's `/api/recent` returned, the feed showed. News is already windowed to 14 days server-side, so a months-old thread could outrank fresh network news for the six visible slots.

The feed already promised this in its own copy — *"No network news in the last 14 days yet"* — so forum posts were the one kind of feed content not honouring it.

**The window measures `max(createdAt, lastposttime)`, not `createdAt`.** `/api/recent` is ordered by *last activity* while the mapped `createdAt` is *topic creation*, so windowing on creation alone would drop actively-discussed threads the endpoint deliberately surfaced. `toFeedForumPost` now carries `lastActivityAt` (it already had `lastposttime` available and was discarding it).

**Applied at the hook boundary, not the display layer.** `useFeedSocial` returns two arrays:

- `forumPosts` — windowed; the default for all rendering, counting, merging and analytics.
- `unwindowedForumPosts` — the same **access-gated** list with only the *date* window lifted, consumed solely by `?post=` deep-link resolution.

That split is what makes it correct by default. `TeamNews.tsx` reads the post array at seven sites and three aren't the visible list — the "new" badge, the empty-state check, and the search-analytics ref. A filter inside `filterFeedForumPosts` would have left those on unwindowed data, inflating the badge and suppressing the empty state for a post that never renders.

Both deep-link sites read the unwindowed array: the resolver **and** `activeForumPost`, which is what the modal actually renders — swapping only the former would let a link validate and open an empty modal.

## Key decisions

- **Client-side, single page, trim only.** NodeBB's `/api/recent` accepts `?term=daily|weekly|monthly` — there is no 14-day term, so the window can't be pushed down. No pagination added; this trims the one ~20-topic page.
- **Cutoff snapshotted at mount.** The posts query is session-frozen (`staleTime: Infinity`), so a per-render `Date.now()` would creep forward and could drop a post out from under someone mid-read.
- **Windowed array memoized.** `TeamNews` depends on its identity to keep the feed merge from re-running on unrelated renders (upvote-overlay writes); a bare `.filter()` would have silently defeated that.
- **Separate `FEED_FORUM_POST_WINDOW_DAYS`** rather than importing `TEAM_NEWS_DEFAULT_WINDOW_DAYS` — different domains (a NodeBB client-side trim vs. a directory query param) that happen to share a value today.

## Known limitation

`mergeFeedEntries` still ranks posts by `createdAt`. An old topic admitted by a fresh reply is *kept* but ranks by its old creation date, so it will usually sort below the visible six. The rule therefore guards against **disappearance**, not **promotion**. Ranking on activity instead would reorder the news/post interleave and sort by a timestamp the card never displays — a separate change with its own display decision.

## Testing

- New `feed-forum-post-window.test.ts` — 8 cases: exact boundary, one-ms-outside, revived-old-topic, order preservation, `undefined` passthrough.
- New `team-news.test.tsx` block — an out-of-window post stays out of the feed and out of the Discussions pill, but still opens from `?post=`. **Verified as a real guard:** temporarily rewiring both call sites back to the windowed array makes it fail.
- `feed.service.test.ts` — `lastActivityAt` mapping plus the zero/missing `lastposttime` fallback (a bogus 1970 timestamp would silently hide a fresh topic).
- Full suite: 1226 passed, 0 failed. Lint and prettier clean for every changed file.

No screenshots: this changes which items appear, not how anything looks, and a meaningful before/after needs seeded forum topics older than 14 days against a live backend.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)