### PR TITLE
Fix current round showing stale round number and dates after rollover

### DIFF
--- a/app/alignment-asset/page.tsx
+++ b/app/alignment-asset/page.tsx
@@ -6,13 +6,21 @@ import { getCurrentRoundStats, RoundStatsResponse } from '@/services/plaa/rounds
 import { CurrentRoundData } from '@/components/page/aligement-assets/rounds/types/current-round.types';
 
 /**
- * Everything derivable comes from the API (round meta, KPI chart, totals,
- * participants, activity catalog); the data file keeps only editorial content
- * (hero copy, descriptions, regions, token/buyback figures) and acts as the
- * fallback when the API is unreachable.
+ * Everything derivable comes from the API (round meta, month/period, KPI
+ * chart, totals, participants, activity catalog); the data file keeps only
+ * editorial content (hero copy, descriptions, regions, token/buyback
+ * figures) and acts as the fallback when the API is unreachable.
  */
 function mergeRoundStats(stats?: RoundStatsResponse): CurrentRoundData {
   if (!stats) return currentRoundData;
+
+  // stats.period is 'YYYY-MM-DD', the first of the round's calendar month.
+  const [year, month] = stats.period.split('-').map(Number);
+  const lastDayOfMonth = new Date(year, month, 0).getDate();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const startDate = `${stats.period}T00:00:00`;
+  const endDate = `${year}-${pad(month)}-${pad(lastDayOfMonth)}T23:59:59`;
+
   return {
     ...currentRoundData,
     meta: {
@@ -21,6 +29,24 @@ function mergeRoundStats(stats?: RoundStatsResponse): CurrentRoundData {
       roundNumber: stats.roundNumber,
       isCurrentRound: stats.isCurrentRound,
       lastUpdated: stats.lastUpdated,
+    },
+    roundDescription: {
+      ...currentRoundData.roundDescription,
+      roundNumber: stats.roundNumber,
+      monthYear: `${stats.month} ${stats.year}`,
+    },
+    snapshotProgress: {
+      ...currentRoundData.snapshotProgress,
+      startDate,
+      endDate,
+      tipContent: {
+        ...currentRoundData.snapshotProgress.tipContent,
+        bottomLink: {
+          ...currentRoundData.snapshotProgress.tipContent.bottomLink,
+          text: `See what happened in the last round (Round ${stats.roundNumber - 1})`,
+          url: `/alignment-asset/rounds/${stats.roundNumber - 1}`,
+        },
+      },
     },
     chart: {
       ...currentRoundData.chart,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pln-directory-web-v2",
-  "version": "plaa-v7.12",
+  "version": "plaa-v7.13",
   "private": true,
   "engines": {
     "node": ">=20.9.0"


### PR DESCRIPTION
## Summary
- The current-round page pulled chart totals and participant count from the rounds API, but round number, month/year label, and snapshot start/end dates stayed on the static data file. After a new round started, the page kept showing the previous round's label and an already-ended snapshot window.
- Round description and snapshot progress dates are now derived from the same round-stats API response, along with the "last round" link at the bottom of the snapshot tip.

## Test plan
- [x] Verified on UAT (`release/plaa-v7.13`): current round page now shows the live round number, month/year, and snapshot dates.
- [x] `npx tsc --noEmit` clean on touched file.