### PR TITLE
fix(plaa): KPI chart zero-data axis + Points Pending overlay

### DIFF
--- a/components/page/aligement-assets/rounds/sections/chart-section.tsx
+++ b/components/page/aligement-assets/rounds/sections/chart-section.tsx
@@ -24,6 +24,8 @@ function buildYAxisTicks(maxValue: number): number[] {
  * @param data - Chart section data from master JSON
  */
 export default function ChartSection({ data }: ChartSectionProps) {
+  const axisMaxValue = data.maxValue || 100;
+
   return (
     <>
       <section className="chart-section">
@@ -59,9 +61,9 @@ export default function ChartSection({ data }: ChartSectionProps) {
                     }}
                     dy={10}
                   />
-                  <YAxis 
-                    domain={[0, data.maxValue]}
-                    ticks={buildYAxisTicks(data.maxValue)}
+                  <YAxis
+                    domain={[0, axisMaxValue]}
+                    ticks={buildYAxisTicks(axisMaxValue)}
                     axisLine={false}
                     tickLine={false}
                     tick={{ 


### PR DESCRIPTION
## Summary
- KPI points chart Y-axis domain collapsed to [0, 0] when every category is still at 0 points (early in a round), which put the axis line/ticks in the wrong place instead of the bottom baseline. Falls back to a 100-point axis ceiling when maxValue is 0.
- Added a "Points Pending" overlay on top of the chart for that same zero-data case, instead of showing a flat, unexplained empty chart.

## Test plan
- [ ] Load /alignment-asset for a round with all-zero KPI values, confirm axis renders at the bottom with a 0-100 scale and the Points Pending overlay shows
- [ ] Load /alignment-asset for a round with real values, confirm chart and overlay are unchanged / overlay does not show
- [ ] Check mobile width, overlay stays centered on the visible viewport rather than the full scrollable chart width