### PR TITLE
fix(editor): stop silent Quill regeneration from killing mention detection

### DIFF
--- a/__tests__/ui/rich-text-editor.test.tsx
+++ b/__tests__/ui/rich-text-editor.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Pins the stability of the `modules` prop RichTextEditor hands to ReactQuill.
+ *
+ * react-quill-new deep-compares `modules` (lodash isEqual) on every update
+ * and, on any mismatch, destroys and recreates the whole Quill instance —
+ * invisibly, since contents and selection are restored. Distinct function
+ * references never compare equal, so a `modules` object rebuilt per render
+ * regenerates the editor per render and orphans every listener attached via
+ * getEditor(). That is how mention detection died in the feed composer, which
+ * passes an inline `toolbarConfig={[]}`: the dropdown never opened while the
+ * same editor kept working on /forum, whose toolbar config is referentially
+ * stable. These tests re-render with fresh config identities and assert the
+ * regeneration predicate stays quiet.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import isEqual from 'lodash/isEqual';
+
+import RichTextEditor from '@/components/ui/RichTextEditor/RichTextEditor';
+
+// Overrides the null-rendering stub from jest.setup.js: this suite asserts on
+// the props ReactQuill receives, so the stub must record them.
+jest.mock('react-quill-new', () => {
+  const ReactLib = require('react');
+  const capturedProps: unknown[] = [];
+  const MockReactQuill = ReactLib.forwardRef((props: Record<string, unknown>, _ref: unknown) => {
+    capturedProps.push(props);
+    return null;
+  });
+  (MockReactQuill as unknown as { capturedProps: unknown[] }).capturedProps = capturedProps;
+  class MockBlot {}
+  return {
+    __esModule: true,
+    default: MockReactQuill,
+    Quill: {
+      register: jest.fn(),
+      import: jest.fn(() => MockBlot),
+    },
+  };
+});
+
+const capturedProps: { modules: unknown }[] = (require('react-quill-new') as any).default.capturedProps;
+
+function lastTwoModules() {
+  expect(capturedProps.length).toBeGreaterThanOrEqual(2);
+  const [prev, next] = capturedProps.slice(-2);
+  return { prev: prev.modules, next: next.modules };
+}
+
+describe('RichTextEditor modules stability', () => {
+  beforeEach(() => {
+    capturedProps.length = 0;
+  });
+
+  it('keeps modules deep-equal across re-renders with an inline empty toolbarConfig (feed composer)', () => {
+    const { rerender } = render(
+      <RichTextEditor value="<p></p>" onChange={() => undefined} toolbarConfig={[]} enableMentions />,
+    );
+    // A fresh [] every render, plus a value change — the feed composer does
+    // exactly this on every keystroke.
+    rerender(<RichTextEditor value="<p>@a</p>" onChange={() => undefined} toolbarConfig={[]} enableMentions />);
+
+    const { prev, next } = lastTwoModules();
+    expect(isEqual(prev, next)).toBe(true);
+  });
+
+  it('keeps modules deep-equal across re-renders with the default toolbar (forum editor)', () => {
+    const { rerender } = render(<RichTextEditor value="<p></p>" onChange={() => undefined} />);
+    rerender(<RichTextEditor value="<p>hello</p>" onChange={() => undefined} />);
+
+    const { prev, next } = lastTwoModules();
+    expect(isEqual(prev, next)).toBe(true);
+  });
+
+  it('keeps modules deep-equal when an equal-content toolbarConfig arrives with a new identity', () => {
+    const { rerender } = render(
+      <RichTextEditor value="<p></p>" onChange={() => undefined} toolbarConfig={[['bold', 'italic']]} />,
+    );
+    rerender(<RichTextEditor value="<p>hello</p>" onChange={() => undefined} toolbarConfig={[['bold', 'italic']]} />);
+
+    const { prev, next } = lastTwoModules();
+    expect(isEqual(prev, next)).toBe(true);
+  });
+
+  it('rebuilds modules when the toolbar content actually changes', () => {
+    const { rerender } = render(<RichTextEditor value="<p></p>" onChange={() => undefined} toolbarConfig={[]} />);
+    rerender(<RichTextEditor value="<p></p>" onChange={() => undefined} toolbarConfig={[['bold']]} />);
+
+    const { prev, next } = lastTwoModules();
+    expect(isEqual(prev, next)).toBe(false);
+  });
+});

--- a/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
+++ b/components/page/home/TeamNews/components/FeedCommentsThread/FeedCommentsThread.tsx
@@ -392,7 +392,7 @@ export function FeedCommentsThread({
               value={draft}
               onChange={handleDraftChange}
               onSubmit={() => submit(draft)}
-              placeholder="Write your comment here…"
+              placeholder="Write your comment here, use @ to mention someone"
               submitLabel="Comment"
               disabled={addComment.isPending}
               onMentionSelected={reportMentionSelected}

--- a/components/ui/RichTextEditor/RichTextEditor.tsx
+++ b/components/ui/RichTextEditor/RichTextEditor.tsx
@@ -65,6 +65,16 @@ registerMentionBlot();
 (Quill.import('ui/icons') as Record<string, unknown>)['officeHours'] = officeHours;
 (Quill.import('ui/icons') as Record<string, unknown>)['mention'] = mentionIcon;
 
+const DEFAULT_TOOLBAR_CONTAINER = [
+  [{ header: [1, 2, 3, false] }],
+  ['bold', 'italic', 'strike', 'underline'],
+  [{ color: [] }, { background: [] }],
+  [{ list: ['ordered'] }, { list: 'bullet' }],
+  [{ align: [] }],
+  ['code-block', 'link', 'mention', 'image'],
+  // ['code-block', 'image', 'officeHours'],
+];
+
 const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
   const {
     value,
@@ -133,19 +143,20 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
     }
   }, [mentionState.query, mentionState.isOpen, mentionResults?.length, enableMentions, onMentionSearch]);
 
-  // 3. Define toolbar modules (with proper nesting)
-  const defaultToolbarContainer = [
-    [{ header: [1, 2, 3, false] }],
-    ['bold', 'italic', 'strike', 'underline'],
-    [{ color: [] }, { background: [] }],
-    [{ list: ['ordered'] }, { list: 'bullet' }],
-    [{ align: [] }],
-    ['code-block', 'link', 'mention', 'image'],
-    // ['code-block', 'image', 'officeHours'],
-  ];
+  // react-quill-new deep-compares `modules` (lodash isEqual) and on any
+  // mismatch destroys and recreates the whole Quill instance — invisibly,
+  // since it restores contents and selection. Distinct function references
+  // never compare equal, and this memo creates closures (clipboard matcher,
+  // toolbar handlers), so recomputing it on a mere identity change of
+  // `toolbarConfig` regenerates the editor every render — orphaning every
+  // listener attached via getEditor() (mention detection died this way under
+  // a caller passing an inline `toolbarConfig={[]}`). Key the memo on the
+  // config's content, not its identity.
+  const toolbarKey = JSON.stringify(toolbarConfig ?? null);
 
   const modules = useMemo(() => {
-    const container = toolbarConfig || defaultToolbarContainer;
+    const container: NonNullable<Props['toolbarConfig']> =
+      toolbarKey === 'null' ? DEFAULT_TOOLBAR_CONTAINER : JSON.parse(toolbarKey);
     const hasMention = container.some((group) => group.includes('mention'));
     const hasImage = container.some((group) => group.includes('image'));
 
@@ -226,7 +237,7 @@ const RichTextEditor = forwardRef<ReactQuill, Props>((props, ref) => {
         ],
       },
     };
-  }, [toolbarConfig]);
+  }, [toolbarKey]);
 
   // Prevent quill-image-uploader from treating emoji pastes as image uploads.
   // When clipboard contains both text and image data (common for emojis copied from


### PR DESCRIPTION
Key the `modules` memo on the config's JSON **content** instead of its identity, so the object — closures included — is rebuilt only when the toolbar actually changes. Fixes the feed composer and immunizes every current and future caller against the same trap.
