### PR TITLE
feat(feed): render forum post modal with full body HTML

### DIFF
--- a/__tests__/services/feed/feed.service.test.ts
+++ b/__tests__/services/feed/feed.service.test.ts
@@ -563,6 +563,26 @@ describe('feed.service', () => {
       expect(forumTopic?.totalReplyCount).toBe(50);
     });
 
+    it('carries the opening post’s full raw HTML for the modal body', async () => {
+      customFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          mainPid: 263,
+          cid: 5,
+          postcount: 2,
+          posts: [
+            { pid: 263, content: '<p>First para.</p><p>See <a href="https://x.test">this</a></p>' },
+            { pid: 264, content: 'hi', timestamp: 1, user: {} },
+          ],
+        }),
+      });
+
+      const { forumTopic } = await getFeedComments('fp_96');
+
+      // Raw on purpose — the modal sanitizes at render, same as comment text.
+      expect(forumTopic?.bodyHtml).toBe('<p>First para.</p><p>See <a href="https://x.test">this</a></p>');
+    });
+
     it('treats a missing vote state as not-liked rather than undefined', async () => {
       customFetchMock.mockResolvedValue({
         ok: true,

--- a/__tests__/utils/sanitizeForumPostHtml.test.ts
+++ b/__tests__/utils/sanitizeForumPostHtml.test.ts
@@ -1,0 +1,33 @@
+import { sanitizeForumPostHtml } from '@/utils/html/sanitizeForumPostHtml';
+
+describe('sanitizeForumPostHtml', () => {
+  it('keeps the formatting a real forum post carries', () => {
+    const html = '<h2>Title</h2><p><strong>bold</strong> and <em>italic</em></p><ul><li>one</li></ul>';
+    expect(sanitizeForumPostHtml(html)).toBe(html);
+  });
+
+  it('keeps images and their src/alt, dropping the inline style', () => {
+    expect(sanitizeForumPostHtml('<img src="https://cdn.test/x.png" alt="shot" style="max-width:100%" />')).toBe(
+      '<img alt="shot" src="https://cdn.test/x.png">',
+    );
+  });
+
+  it('forces target/rel on anchors and keeps mention identity attributes', () => {
+    const out = sanitizeForumPostHtml('<a class="ql-mention" data-uid="m_1" href="/members/m_1">@Jane</a>');
+    expect(out).toContain('class="ql-mention"');
+    expect(out).toContain('data-uid="m_1"');
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+
+  it('drops script, event handlers, and javascript: URLs', () => {
+    expect(sanitizeForumPostHtml('<p>hi<script>alert(1)</script></p>')).toBe('<p>hi</p>');
+    expect(sanitizeForumPostHtml('<p onclick="alert(1)">hi</p>')).toBe('<p>hi</p>');
+    expect(sanitizeForumPostHtml('<a href="javascript:alert(1)">x</a>')).toBe('<a>x</a>');
+  });
+
+  it('allows root-relative URLs but not protocol-relative ones', () => {
+    expect(sanitizeForumPostHtml('<img src="/assets/uploads/x.png" />')).toBe('<img src="/assets/uploads/x.png">');
+    expect(sanitizeForumPostHtml('<img src="//evil.test/x.png" />')).toBe('<img>');
+  });
+});

--- a/__tests__/utils/stripHtml.test.ts
+++ b/__tests__/utils/stripHtml.test.ts
@@ -1,4 +1,4 @@
-import { stripHtml } from '@/utils/forum/stripHtml';
+import { stripHtml, stripHtmlPreservingBreaks } from '@/utils/forum/stripHtml';
 
 describe('stripHtml', () => {
   it('removes tags and collapses whitespace', () => {
@@ -32,5 +32,39 @@ describe('stripHtml', () => {
   it('returns an empty string for empty or tag-only content', () => {
     expect(stripHtml('')).toBe('');
     expect(stripHtml('<p></p>')).toBe('');
+  });
+});
+
+describe('stripHtmlPreservingBreaks', () => {
+  it('keeps a blank line between paragraphs', () => {
+    expect(stripHtmlPreservingBreaks('<p>First para.</p><p>Second para.</p>')).toBe('First para.\n\nSecond para.');
+  });
+
+  it('turns <br> into a single line break', () => {
+    expect(stripHtmlPreservingBreaks('<p>line one<br>line two<br/>line three</p>')).toBe(
+      'line one\nline two\nline three',
+    );
+  });
+
+  it('puts list items on their own lines', () => {
+    expect(stripHtmlPreservingBreaks('<ul><li>one</li><li>two</li></ul><p>after</p>')).toBe('one\ntwo\n\nafter');
+  });
+
+  it('caps consecutive breaks at one blank line', () => {
+    expect(stripHtmlPreservingBreaks('<p>a</p><p></p><p></p><p>b</p>')).toBe('a\n\nb');
+  });
+
+  it('collapses spaces within a line without eating the breaks', () => {
+    expect(stripHtmlPreservingBreaks('<p>Hi   Protocol&nbsp;Labs </p><p> next</p>')).toBe('Hi Protocol Labs\n\nnext');
+  });
+
+  it('still decodes entities after stripping, so escaped tags stay text', () => {
+    expect(stripHtmlPreservingBreaks('<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>')).toBe(
+      '<script>alert(1)</script>',
+    );
+  });
+
+  it('drops markdown images', () => {
+    expect(stripHtmlPreservingBreaks('<p>Ship it ![shot](https://cdn/img.png) today</p>')).toBe('Ship it today');
   });
 });

--- a/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.module.scss
+++ b/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.module.scss
@@ -36,3 +36,57 @@
   text-transform: uppercase;
   color: var(--foreground-neutral-secondary, #455468);
 }
+
+/* The post's full body, on the forum page's rendering pipeline. Layered over
+   the news modal's .content (paragraph/list margins, link color, wrapping);
+   these are the elements a real post has that AI news summaries never do —
+   mirroring /forum's .postContent, scaled to the modal's type. The <img>
+   rules replace the inline style the sanitizer strips off
+   processPostContent's markdown images. */
+.postBody {
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    margin: 8px 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 16px 0 8px;
+    font-size: 15px;
+    line-height: 1.4;
+    color: var(--foreground-neutral-primary, #0a0c11);
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  blockquote {
+    margin: 0 0 12px;
+    padding-left: 12px;
+    border-left: 3px solid #e2e8f0;
+  }
+
+  pre {
+    margin: 0 0 12px;
+    padding: 12px;
+    overflow-x: auto;
+    background: #f8fafc;
+    border-radius: 8px;
+  }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+}

--- a/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.tsx
+++ b/components/page/home/TeamNews/components/ForumPostModal/ForumPostModal.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import parse from 'html-react-parser';
 
 import { Modal } from '@/components/common/Modal';
 import { CloseIcon } from '@/components/icons';
+import { processPostContent } from '@/components/page/forum/Post';
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { linkifyHtml, sanitizeForumPostHtml } from '@/utils/html';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import { useFeedForumTopicBodyHtml } from '@/services/feed/hooks/useFeedComments';
 import type { IFeedForumPost } from '@/types/feed.types';
 
 import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
@@ -43,16 +47,36 @@ interface ForumPostModalProps {
 /**
  * Detail modal for a feed forum post (ported from the newsfeed-v0 prototype's
  * ForumPostModal, on the production news-modal chrome): author on top,
- * "Discussion" kicker, plain-text body, the shared inline comment thread, and
- * Like + Share in the footer. `post.body` is contract-guaranteed plain text
- * and renders via JSX interpolation only — it never goes anywhere near the
- * news modal's sanitizer/dangerouslySetInnerHTML path.
+ * "Discussion" kicker, the post's FULL body, the shared inline comment thread,
+ * and Like + Share in the footer.
+ *
+ * The body renders the same content /forum does, through the forum page's own
+ * pipeline (processPostContent → linkify → parse) plus the feed's
+ * sanitize-on-read layer — /forum trusts NodeBB's HTML directly, the feed
+ * never does. It comes off the comments query (the thread below fetches the
+ * whole topic anyway); until that lands, the card's plain-text teaser
+ * (`post.body`) stands in via JSX interpolation.
  */
 export function ForumPostModal({ post, onClose, onLikeToggle }: ForumPostModalProps) {
   // Same share-popover layering rule as the news modal: while the popover is
   // open, the modal's Escape/backdrop closers stand down so one gesture never
   // dismisses both layers.
   const [shareOpen, setShareOpen] = useState(false);
+
+  // Same order as FeedCommentContent, for the same reason: linkify FIRST so
+  // the sanitizer checks the anchors it emits, then sanitize, then parse.
+  // processPostContent runs before both — it's the forum page's own
+  // markdown-image/nbsp step, so an image post renders here exactly as there
+  // (its inline <img> style is dropped by the sanitizer; .postBody's CSS is
+  // the replacement).
+  const bodyHtml = useFeedForumTopicBodyHtml(post.uid);
+  const richBody = useMemo(() => {
+    // The typeof check is load-bearing: jest.setup.js's global useQuery mock
+    // ignores `select` and hands back its stub object, and NodeBB wire data
+    // carries no runtime guarantees either.
+    if (typeof bodyHtml !== 'string' || !bodyHtml) return null;
+    return parse(sanitizeForumPostHtml(linkifyHtml(processPostContent(bodyHtml).processedContent)));
+  }, [bodyHtml]);
 
   const focusOnAttach = useCallback((node: HTMLButtonElement | null) => {
     node?.focus();
@@ -115,7 +139,11 @@ export function ForumPostModal({ post, onClose, onLikeToggle }: ForumPostModalPr
           {post.title}
         </h3>
 
-        <p className={clsx(modalStyles.content, modalStyles.contentPlain)}>{post.body}</p>
+        {richBody ? (
+          <div className={clsx(modalStyles.content, s.postBody)}>{richBody}</div>
+        ) : (
+          <p className={clsx(modalStyles.content, modalStyles.contentPlain)}>{post.body}</p>
+        )}
 
         {/* The post's real NodeBB thread. `forumMainPid` is the topic's opening
             post — the reply target for a top-level comment — passed down so the

--- a/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.module.scss
+++ b/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.module.scss
@@ -117,6 +117,9 @@
   font-size: 14px;
   line-height: 1.6;
   color: var(--foreground-neutral-secondary, #455468);
+  // Pasted URLs and other unbroken tokens wrap instead of stretching the
+  // scrolling body past the modal's width.
+  overflow-wrap: anywhere;
 
   // Sanitized contentHtml: paragraphs/lists with inline emphasis.
   p,

--- a/services/feed/feed.service.ts
+++ b/services/feed/feed.service.ts
@@ -1,6 +1,6 @@
 import { customFetch } from '@/utils/fetch-wrapper';
 import { getHeader } from '@/utils/common.utils';
-import { stripHtml } from '@/utils/forum';
+import { stripHtml, stripHtmlPreservingBreaks } from '@/utils/forum';
 import { buildCommentTree } from '@/utils/comments';
 import { sanitizeCommentHtml } from '@/utils/html';
 import { forumFetch, postForumReply } from '@/services/forum/forum.service';
@@ -110,7 +110,9 @@ function toFeedForumPost(topic: Topic): IFeedForumPost {
     tid: topic.tid,
     mainPid: topic.mainPid,
     title: stripHtml(topic.titleRaw || topic.title || ''),
-    body: stripHtml(topic.teaser?.content || ''),
+    // Breaks preserved so the modal's `white-space: pre-line` can render the
+    // post's paragraphs; the card's line-clamp collapses them back to spaces.
+    body: stripHtmlPreservingBreaks(topic.teaser?.content || ''),
     author: {
       memberUid: user?.memberUid ?? '',
       name: user?.displayname || user?.username || 'Unknown',
@@ -382,6 +384,10 @@ async function getForumPostComments(itemUid: ForumPostUid): Promise<IFeedComment
         likeCount: Number(mainPost?.upvotes) || 0,
         viewerHasLiked: Boolean(mainPost?.upvoted),
       },
+      // Raw on purpose, like a comment's `text` — ForumPostModal sanitizes at
+      // render. This is how the modal shows the post's real formatting and
+      // links: the card's `body` teaser is stripped and truncated.
+      bodyHtml: mainPost?.content ?? '',
     },
   };
 }

--- a/services/feed/hooks/useFeedComments.ts
+++ b/services/feed/hooks/useFeedComments.ts
@@ -42,3 +42,17 @@ export function useFeedForumTopicLike(itemUid: string | null): IFeedForumPostLik
   });
   return data;
 }
+
+// The opening post's full content HTML, off the same cache entry the modal's
+// own FeedCommentsThread fetches (skipToken = observe only, never a second
+// request). Undefined until that fetch lands — the modal shows the card's
+// plain teaser meanwhile. RAW NodeBB HTML: the consumer sanitizes at render.
+export function useFeedForumTopicBodyHtml(itemUid: string | null): string | undefined {
+  const { data } = useQuery<IFeedCommentsResponse, Error, string | undefined>({
+    queryKey: feedQueryKeys.comments(itemUid ?? ''),
+    queryFn: skipToken,
+    select: (response) => response.forumTopic?.bodyHtml,
+    enabled: Boolean(itemUid),
+  });
+  return data;
+}

--- a/types/feed.types.ts
+++ b/types/feed.types.ts
@@ -61,7 +61,8 @@ export interface IFeedForumPost {
   mainPid: number;
   /** PLAIN TEXT (NodeBB HTML stripped + entities decoded by the service).
    *  Never raw or rendered HTML — rich content would be a new field with its
-   *  own sanitization contract. Same rule for `body`. */
+   *  own sanitization contract. Same rule for `body`, which additionally keeps
+   *  paragraph/line breaks as newlines (render with `white-space: pre-line`). */
   title: string;
   body: string;
   author: IFeedAuthor;
@@ -130,6 +131,10 @@ export interface IFeedForumTopicMeta {
   /** The topic's own vote state, which the /api/recent listing doesn't carry —
    *  the only way a forum card can learn whether the viewer already liked it. */
   like: IFeedForumPostLikeStatus;
+  /** The opening post's FULL content — what /forum itself renders — where the
+   *  card's `body` is a stripped, truncated teaser. RAW NodeBB HTML, same
+   *  contract as IFeedComment.text: sanitize at render, never trust it. */
+  bodyHtml: string;
 }
 
 /** Top-level comments, oldest first, each with its own `replies`. No `total`

--- a/utils/forum/index.ts
+++ b/utils/forum/index.ts
@@ -1,3 +1,3 @@
-export { stripHtml } from './stripHtml';
+export { stripHtml, stripHtmlPreservingBreaks } from './stripHtml';
 export { truncateText } from './truncateText';
 export { extractImagesAndClean } from './extractImagesAndClean';

--- a/utils/forum/stripHtml.ts
+++ b/utils/forum/stripHtml.ts
@@ -7,16 +7,42 @@
  * can never become a live tag) and `&amp;` is decoded LAST (so a doubly-escaped
  * `&amp;lt;` ends up as the literal text `&lt;`, not as `<`).
  */
-export function stripHtml(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, '')
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+function decodeEntities(text: string): string {
+  return text
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;|&apos;/g, "'")
-    .replace(/&nbsp;| /g, ' ')
-    .replace(/&amp;/g, '&')
+    .replace(/&nbsp;| /g, ' ')
+    .replace(/&amp;/g, '&');
+}
+
+export function stripHtml(html: string): string {
+  return decodeEntities(
+    html.replace(/<[^>]*>/g, '').replace(/!\[[^\]]*\]\([^)]*\)/g, ' '),
+  )
     .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Like stripHtml, but block boundaries survive as newlines instead of the text
+ * fusing into one run-on line: paragraph-level closers (`</p>`, headings,
+ * `</blockquote>`, …) become a blank line, `<br>`/`</li>` a single break.
+ * For text rendered with `white-space: pre-line`. Same decode-after-strip
+ * ordering as stripHtml, so an escaped tag still can never come back to life.
+ */
+export function stripHtmlPreservingBreaks(html: string): string {
+  return decodeEntities(
+    html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(?:li|tr)\s*>/gi, '\n')
+      .replace(/<\/(?:p|div|h[1-6]|blockquote|pre|ul|ol|table)\s*>/gi, '\n\n')
+      .replace(/<[^>]*>/g, '')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, ' '),
+  )
+    .replace(/[^\S\n]+/g, ' ') // collapse spaces/tabs, keep the breaks
+    .replace(/ ?\n ?/g, '\n')
+    .replace(/\n{3,}/g, '\n\n') // at most one blank line between paragraphs
     .trim();
 }

--- a/utils/html/index.ts
+++ b/utils/html/index.ts
@@ -1,5 +1,6 @@
 export { linkifyHtml } from './linkifyHtml';
 export { isBlankHtml } from './isBlankHtml';
 export { sanitizeCommentHtml, COMMENT_SANITIZE_CONFIG } from './sanitizeCommentHtml';
+export { sanitizeForumPostHtml, FORUM_POST_SANITIZE_CONFIG } from './sanitizeForumPostHtml';
 export { countMentions } from './countMentions';
 export { classifyAnchor, type AnchorTarget } from './classifyAnchor';

--- a/utils/html/sanitizeForumPostHtml.ts
+++ b/utils/html/sanitizeForumPostHtml.ts
@@ -1,0 +1,60 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+/**
+ * Allowlist for a forum post's FULL body (ForumPostModal). Wider than
+ * COMMENT_SANITIZE_CONFIG because a post really does carry headings, images,
+ * lists, code and quotes — the formatting /forum renders — but the same
+ * principle: NodeBB's HTML is unauthored-by-us markup and the app ships no
+ * CSP, so this sanitizer is the only defense layer.
+ *
+ * No `style`: processPostContent inlines one on its <img>, but the equivalent
+ * rules live in ForumPostModal's stylesheet, so dropping the attribute costs
+ * nothing and keeps CSS out of the untrusted channel.
+ */
+export const FORUM_POST_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p',
+    'br',
+    'a',
+    'strong',
+    'em',
+    'b',
+    'i',
+    'u',
+    's',
+    'ul',
+    'ol',
+    'li',
+    'blockquote',
+    'code',
+    'pre',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'img',
+    'span',
+    'hr',
+  ],
+  // Mention anchors keep their identity in class/data-* (same as comments).
+  ALLOWED_ATTR: ['href', 'src', 'alt', 'class', 'target', 'rel', 'data-uid', 'data-name', 'data-external-id'],
+  // Root-relative allowed (mention hrefs, forum-hosted uploads) but not
+  // protocol-relative `//evil.example`, and never `javascript:`.
+  ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|\/(?!\/))/i,
+};
+
+// Registered at module scope: DOMPurify hooks are global and stack if added
+// per call. Identical and idempotent alongside the same hook registered by
+// sanitizeCommentHtml, NewsDetailModal and PrdContent.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.hasAttribute('href')) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+export function sanitizeForumPostHtml(html: string): string {
+  return DOMPurify.sanitize(html ?? '', FORUM_POST_SANITIZE_CONFIG);
+}


### PR DESCRIPTION
- Add `useFeedForumTopicBodyHtml` hook to fetch and sanitize full post content.
- Render sanitized, linkified rich content in `ForumPostModal` for modal post bodies.
- Rework `stripHtml` and add `stripHtmlPreservingBreaks` utility to preserve line breaks.
- Update forum topic service to include raw HTML content for modal rendering.
- Enhance styles to align modal content with forum rendering pipeline.
- Add test cases for stripping HTML while preserving breaks.