### PR TITLE
feat(notifications): Mark all as read on the Updates panel and /recent-updates

### DIFF
--- a/__tests__/core/updates-panel-mark-all.test.tsx
+++ b/__tests__/core/updates-panel-mark-all.test.tsx
@@ -41,9 +41,13 @@ describe('UpdatesPanel mark all as read', () => {
     expect(screen.getByRole('button', { name: 'Mark all as read' })).toBeInTheDocument();
   });
 
-  it('hides the control at zero unread rather than disabling it', () => {
-    renderPanel({ unreadCount: 0 });
-    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+  it('shows the control grayed out at zero unread, and a click does nothing', () => {
+    const { onMarkAllAsRead } = renderPanel({ unreadCount: 0 });
+    const button = screen.getByRole('button', { name: 'Mark all as read' });
+
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onMarkAllAsRead).not.toHaveBeenCalled();
   });
 
   it('never shows the control to logged-out viewers', () => {

--- a/__tests__/core/updates-panel-mark-all.test.tsx
+++ b/__tests__/core/updates-panel-mark-all.test.tsx
@@ -75,4 +75,37 @@ describe('UpdatesPanel mark all as read', () => {
     await waitFor(() => expect(mockOnMarkAllFailed).toHaveBeenCalledWith('updates_panel', 3));
     expect(screen.getByRole('status')).toHaveTextContent('Could not mark notifications as read');
   });
+
+  it('scopes the list with the All/Unread/Read tabs, with a caught-up escape hatch', () => {
+    const now = new Date().toISOString();
+    const notification = (id: string, title: string, isRead: boolean) =>
+      ({ id, uid: id, title, description: '', isRead, category: 'FORUM_POST', createdAt: now }) as never;
+    renderPanel({
+      notifications: [notification('n1', 'Unread thing', false), notification('n2', 'Read thing', true)],
+      unreadCount: 1,
+    });
+
+    expect(screen.getByRole('tablist', { name: 'Filter updates' })).toBeInTheDocument();
+    expect(screen.getByText('Unread thing')).toBeInTheDocument();
+    expect(screen.getByText('Read thing')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Unread/ }));
+    expect(screen.getByText('Unread thing')).toBeInTheDocument();
+    expect(screen.queryByText('Read thing')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Read' }));
+    expect(screen.queryByText('Unread thing')).not.toBeInTheDocument();
+    expect(screen.getByText('Read thing')).toBeInTheDocument();
+  });
+
+  it('offers "Show all updates" when the Unread segment is empty but the list is not', () => {
+    const notification = { id: 'n2', title: 'Read thing', isRead: true, category: 'FORUM_POST' } as never;
+    renderPanel({ notifications: [notification], unreadCount: 0 });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Unread' }));
+    expect(screen.getByText("You're all caught up")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all updates' }));
+    expect(screen.getByText('Read thing')).toBeInTheDocument();
+  });
 });

--- a/__tests__/core/updates-panel-mark-all.test.tsx
+++ b/__tests__/core/updates-panel-mark-all.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockOnMarkAllClicked = jest.fn();
+const mockOnMarkAllFailed = jest.fn();
+
+jest.mock('@/analytics/notification.analytics', () => ({
+  useNotificationAnalytics: () => ({
+    onUpdatesPanelNotificationClicked: jest.fn(),
+    onNotificationActionLinkClicked: jest.fn(),
+    onViewAllUpdatesClicked: jest.fn(),
+    onMarkAllUpdatesReadClicked: (...a: unknown[]) => mockOnMarkAllClicked(...a),
+    onMarkAllUpdatesReadFailed: (...a: unknown[]) => mockOnMarkAllFailed(...a),
+  }),
+}));
+
+import { UpdatesPanel } from '@/components/core/UpdatesPanel';
+
+function renderPanel(props: Partial<React.ComponentProps<typeof UpdatesPanel>> = {}) {
+  const onMarkAllAsRead = jest.fn().mockResolvedValue(undefined);
+  render(
+    <UpdatesPanel
+      open
+      notifications={[]}
+      unreadCount={3}
+      onClose={jest.fn()}
+      onMarkAsRead={jest.fn()}
+      onMarkAllAsRead={onMarkAllAsRead}
+      isLoggedIn
+      {...props}
+    />,
+  );
+  return { onMarkAllAsRead };
+}
+
+describe('UpdatesPanel mark all as read', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('shows the control with unread notifications — even when the loaded list is empty', () => {
+    renderPanel();
+    expect(screen.getByRole('button', { name: 'Mark all as read' })).toBeInTheDocument();
+  });
+
+  it('hides the control at zero unread rather than disabling it', () => {
+    renderPanel({ unreadCount: 0 });
+    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+  });
+
+  it('never shows the control to logged-out viewers', () => {
+    renderPanel({ isLoggedIn: false });
+    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+  });
+
+  it('invokes the action, reports the click with the count, parks focus, and announces', () => {
+    const { onMarkAllAsRead } = renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all as read' }));
+
+    expect(onMarkAllAsRead).toHaveBeenCalledTimes(1);
+    expect(mockOnMarkAllClicked).toHaveBeenCalledWith('updates_panel', 3);
+    // Focus parked on Close before the mark-all button can unmount.
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('All notifications marked as read');
+  });
+
+  it('reports the failure and updates the announcement when the action rejects', async () => {
+    renderPanel({ onMarkAllAsRead: jest.fn().mockRejectedValue(new Error('boom')) });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all as read' }));
+
+    await waitFor(() => expect(mockOnMarkAllFailed).toHaveBeenCalledWith('updates_panel', 3));
+    expect(screen.getByRole('status')).toHaveTextContent('Could not mark notifications as read');
+  });
+});

--- a/__tests__/page/home/recent-updates-mark-all.test.tsx
+++ b/__tests__/page/home/recent-updates-mark-all.test.tsx
@@ -54,11 +54,14 @@ describe('RecentUpdatesSection mark all as read', () => {
     expect(screen.getByText('Unread 2')).toBeInTheDocument();
   });
 
-  it('hides the control at zero unread', () => {
+  it('shows the control grayed out at zero unread, and a click does nothing', () => {
     providerUnreadCount = 0;
     render(<RecentUpdatesSection isLoggedIn />);
+    const button = screen.getByRole('button', { name: 'Mark all as read' });
 
-    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(mockMarkAllAsRead).not.toHaveBeenCalled();
   });
 
   it('never shows the control to logged-out viewers', () => {

--- a/__tests__/page/home/recent-updates-mark-all.test.tsx
+++ b/__tests__/page/home/recent-updates-mark-all.test.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockMarkAllAsRead = jest.fn();
+const mockOnMarkAllClicked = jest.fn();
+const mockOnMarkAllFailed = jest.fn();
+let providerUnreadCount = 0;
+
+jest.mock('@/providers/PushNotificationsProvider', () => ({
+  usePushNotificationsContext: () => ({
+    markAsRead: jest.fn(),
+    markAllAsRead: mockMarkAllAsRead,
+    unreadCount: providerUnreadCount,
+  }),
+  stripHtml: (value: string) => value,
+}));
+
+jest.mock('@/services/push-notifications/hooks', () => ({
+  useInfiniteNotifications: () => ({
+    notifications: [],
+    total: 0,
+    // Deliberately 0 while the provider says otherwise: the control and the
+    // pill must run off the provider's LIVE count, not this first-page snapshot.
+    unreadCount: 0,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    isFetchingNextPage: false,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/analytics/notification.analytics', () => ({
+  useNotificationAnalytics: () => ({
+    onRecentUpdatesNotificationClicked: jest.fn(),
+    onNotificationActionLinkClicked: jest.fn(),
+    onMarkAllUpdatesReadClicked: (...a: unknown[]) => mockOnMarkAllClicked(...a),
+    onMarkAllUpdatesReadFailed: (...a: unknown[]) => mockOnMarkAllFailed(...a),
+  }),
+}));
+
+import { RecentUpdatesSection } from '@/components/page/home/recent-updates/RecentUpdatesSection';
+
+describe('RecentUpdatesSection mark all as read', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    providerUnreadCount = 2;
+    mockMarkAllAsRead.mockResolvedValue(undefined);
+  });
+
+  it('drives visibility and the pill off the provider count, not the page snapshot', () => {
+    render(<RecentUpdatesSection isLoggedIn />);
+
+    expect(screen.getByRole('button', { name: 'Mark all as read' })).toBeInTheDocument();
+    expect(screen.getByText('Unread 2')).toBeInTheDocument();
+  });
+
+  it('hides the control at zero unread', () => {
+    providerUnreadCount = 0;
+    render(<RecentUpdatesSection isLoggedIn />);
+
+    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+  });
+
+  it('never shows the control to logged-out viewers', () => {
+    render(<RecentUpdatesSection isLoggedIn={false} />);
+
+    expect(screen.queryByRole('button', { name: 'Mark all as read' })).not.toBeInTheDocument();
+  });
+
+  it('invokes the provider action, reports the click, parks focus on the heading, and announces', () => {
+    render(<RecentUpdatesSection isLoggedIn />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all as read' }));
+
+    expect(mockMarkAllAsRead).toHaveBeenCalledTimes(1);
+    expect(mockOnMarkAllClicked).toHaveBeenCalledWith('recent_updates', 2);
+    expect(screen.getByRole('heading', { name: 'Recent Updates' })).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('All notifications marked as read');
+  });
+
+  it('reports the failure and updates the announcement when the action rejects', async () => {
+    mockMarkAllAsRead.mockRejectedValue(new Error('boom'));
+    render(<RecentUpdatesSection isLoggedIn />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all as read' }));
+
+    await waitFor(() => expect(mockOnMarkAllFailed).toHaveBeenCalledWith('recent_updates', 2));
+    expect(screen.getByRole('status')).toHaveTextContent('Could not mark notifications as read');
+  });
+});

--- a/__tests__/providers/push-notifications-mark-all.test.tsx
+++ b/__tests__/providers/push-notifications-mark-all.test.tsx
@@ -1,0 +1,195 @@
+import '@testing-library/jest-dom';
+import { useState } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// Stable react-query mocks (the global jest.setup mock builds new fns per
+// call, which can't be asserted against). The provider only uses useQueryClient.
+jest.mock('@tanstack/react-query', () => {
+  const getQueryData = jest.fn();
+  const setQueryData = jest.fn();
+  return {
+    useQueryClient: () => ({ getQueryData, setQueryData }),
+    __rq: { getQueryData, setQueryData },
+  };
+});
+
+// Stable websocket mocks + capture of the provider's onCountUpdate callback,
+// so the cross-tab path can be driven directly.
+jest.mock('@/hooks/usePushNotifications', () => {
+  const wsMarkAsRead = jest.fn();
+  const wsMarkAllAsRead = jest.fn();
+  const captured: { onCountUpdate?: (p: { unreadCount: number }) => void } = {};
+  return {
+    usePushNotifications: (opts: { onCountUpdate: (p: { unreadCount: number }) => void }) => {
+      captured.onCountUpdate = opts.onCountUpdate;
+      return {
+        isConnected: true,
+        connectionEstablished: true,
+        error: null,
+        markAsRead: wsMarkAsRead,
+        markAllAsRead: wsMarkAllAsRead,
+      };
+    },
+    __ws: { wsMarkAsRead, wsMarkAllAsRead, captured },
+  };
+});
+
+jest.mock('@/services/push-notifications.service', () => ({
+  getUnreadLinks: jest.fn().mockResolvedValue([]),
+  getNotifications: jest.fn(),
+  markNotificationAsRead: jest.fn().mockResolvedValue({}),
+  markAllNotificationsAsRead: jest.fn(),
+}));
+
+import { PushNotificationsProvider, usePushNotificationsContext } from '@/providers/PushNotificationsProvider';
+import { getNotifications, markAllNotificationsAsRead } from '@/services/push-notifications.service';
+
+const { __rq } = jest.requireMock('@tanstack/react-query');
+const { __ws } = jest.requireMock('@/hooks/usePushNotifications');
+const getNotificationsMock = getNotifications as jest.Mock;
+const markAllMock = markAllNotificationsAsRead as jest.Mock;
+
+function notif(id: string, isRead: boolean) {
+  return { id, uid: id, title: `t-${id}`, description: '', isRead, category: 'NEW_FEATURE', createdAt: '' };
+}
+
+function Consumer() {
+  const { notifications, unreadCount, markAllAsRead } = usePushNotificationsContext();
+  const [failed, setFailed] = useState(false);
+  return (
+    <div>
+      <span data-testid="count">{unreadCount}</span>
+      <span data-testid="unread-ids">
+        {notifications
+          .filter((n) => !n.isRead)
+          .map((n) => n.id)
+          .join(',')}
+      </span>
+      {failed && <span data-testid="failed" />}
+      <button
+        onClick={() => {
+          markAllAsRead().catch(() => setFailed(true));
+        }}
+      >
+        mark all
+      </button>
+    </div>
+  );
+}
+
+async function renderProvider() {
+  render(
+    <PushNotificationsProvider authToken="tok" enabled>
+      <Consumer />
+    </PushNotificationsProvider>,
+  );
+  await waitFor(() => expect(getNotificationsMock).toHaveBeenCalled());
+}
+
+describe('PushNotificationsProvider.markAllAsRead', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __rq.getQueryData.mockReturnValue(undefined);
+    getNotificationsMock.mockResolvedValue({
+      notifications: [notif('n1', false), notif('n2', true)],
+      unreadCount: 1,
+      total: 2,
+    });
+    markAllMock.mockResolvedValue({ success: true });
+  });
+
+  it('optimistically clears everything, calls the API once, then broadcasts', async () => {
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('mark all'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+    expect(screen.getByTestId('unread-ids')).toHaveTextContent('');
+    await waitFor(() => expect(markAllMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(__ws.wsMarkAllAsRead).toHaveBeenCalledTimes(1));
+  });
+
+  it('skips the API entirely with zero unread', async () => {
+    getNotificationsMock.mockResolvedValue({ notifications: [notif('n2', true)], unreadCount: 0, total: 1 });
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('0'));
+
+    fireEvent.click(screen.getByText('mark all'));
+
+    expect(markAllMock).not.toHaveBeenCalled();
+  });
+
+  it('still calls the API when the loaded 50 are all read but the count says otherwise', async () => {
+    // The old guard (`some(!isRead)` over loaded items) silently skipped this.
+    getNotificationsMock.mockResolvedValue({ notifications: [notif('n2', true)], unreadCount: 3, total: 1 });
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('3'));
+
+    fireEvent.click(screen.getByText('mark all'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+    await waitFor(() => expect(markAllMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('absorbs a double-click into one API call', async () => {
+    let resolveCall!: (v: unknown) => void;
+    markAllMock.mockImplementation(() => new Promise((res) => (resolveCall = res)));
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('mark all'));
+    fireEvent.click(screen.getByText('mark all'));
+
+    expect(markAllMock).toHaveBeenCalledTimes(1);
+    await act(async () => resolveCall({ success: true }));
+  });
+
+  it('patches and rolls back the infinite cache alongside its own state', async () => {
+    const cached = {
+      pages: [{ notifications: [notif('n1', false)], total: 1, unreadCount: 1, offset: 0 }],
+      pageParams: [0],
+    };
+    __rq.getQueryData.mockReturnValue(cached);
+    markAllMock.mockRejectedValue(new Error('boom'));
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('mark all'));
+
+    // Optimistic patch first…
+    expect(__rq.setQueryData).toHaveBeenCalledTimes(1);
+    // …then the failure restores the exact snapshot.
+    await waitFor(() => expect(screen.getByTestId('failed')).toBeInTheDocument());
+    expect(__rq.setQueryData).toHaveBeenCalledTimes(2);
+    expect(__rq.setQueryData).toHaveBeenLastCalledWith(['infinite-notifications'], cached);
+  });
+
+  it('rolls back read state on failure without broadcasting to other tabs', async () => {
+    markAllMock.mockRejectedValue(new Error('boom'));
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('mark all'));
+
+    await waitFor(() => expect(screen.getByTestId('failed')).toBeInTheDocument());
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+    expect(screen.getByTestId('unread-ids')).toHaveTextContent('n1');
+    expect(__ws.wsMarkAllAsRead).not.toHaveBeenCalled();
+  });
+
+  it('patches the infinite cache when another tab broadcasts count 0', async () => {
+    __rq.getQueryData.mockReturnValue({
+      pages: [{ notifications: [notif('n1', false)], total: 1, unreadCount: 1, offset: 0 }],
+      pageParams: [0],
+    });
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+
+    act(() => __ws.captured.onCountUpdate!({ unreadCount: 0 }));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+    expect(screen.getByTestId('unread-ids')).toHaveTextContent('');
+    expect(__rq.setQueryData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/services/push-notifications/infinite-notifications-cache.test.ts
+++ b/__tests__/services/push-notifications/infinite-notifications-cache.test.ts
@@ -1,0 +1,73 @@
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  INFINITE_NOTIFICATIONS_KEY,
+  patchInfiniteNotificationsAllRead,
+  restoreInfiniteNotifications,
+  type InfiniteNotificationsData,
+} from '@/services/push-notifications/hooks/useInfiniteNotifications';
+
+function makeQueryClient(initial?: InfiniteNotificationsData) {
+  let store: InfiniteNotificationsData | undefined = initial;
+  return {
+    getQueryData: jest.fn(() => store),
+    setQueryData: jest.fn((_key: unknown, value: InfiniteNotificationsData) => {
+      store = value;
+    }),
+    read: () => store,
+  } as unknown as QueryClient & { read: () => InfiniteNotificationsData | undefined };
+}
+
+const cache = (): InfiniteNotificationsData => ({
+  pages: [
+    {
+      notifications: [
+        { id: 'a', isRead: false },
+        { id: 'b', isRead: true },
+      ] as InfiniteNotificationsData['pages'][number]['notifications'],
+      total: 3,
+      unreadCount: 2,
+      offset: 0,
+    },
+    {
+      notifications: [{ id: 'c', isRead: false }] as InfiniteNotificationsData['pages'][number]['notifications'],
+      total: 3,
+      unreadCount: 2,
+      offset: 2,
+    },
+  ],
+  pageParams: [0, 2],
+});
+
+describe('patchInfiniteNotificationsAllRead', () => {
+  it('flips every cached page to read and zeroes each unreadCount', () => {
+    const client = makeQueryClient(cache());
+
+    patchInfiniteNotificationsAllRead(client);
+
+    const patched = client.read()!;
+    expect(patched.pages.every((p) => p.unreadCount === 0)).toBe(true);
+    expect(patched.pages.flatMap((p) => p.notifications).every((n) => n.isRead)).toBe(true);
+    // Untouched fields survive the patch.
+    expect(patched.pages[1].offset).toBe(2);
+    expect(patched.pageParams).toEqual([0, 2]);
+  });
+
+  it('returns the pre-patch snapshot, which restore puts back verbatim', () => {
+    const original = cache();
+    const client = makeQueryClient(original);
+
+    const snapshot = patchInfiniteNotificationsAllRead(client);
+    expect(snapshot).toBe(original);
+
+    restoreInfiniteNotifications(client, snapshot!);
+    expect(client.read()).toBe(original);
+    expect(client.setQueryData).toHaveBeenLastCalledWith(INFINITE_NOTIFICATIONS_KEY, original);
+  });
+
+  it('is a no-op with nothing cached (the page was never visited)', () => {
+    const client = makeQueryClient(undefined);
+
+    expect(patchInfiniteNotificationsAllRead(client)).toBeUndefined();
+    expect(client.setQueryData).not.toHaveBeenCalled();
+  });
+});

--- a/analytics/notification.analytics.ts
+++ b/analytics/notification.analytics.ts
@@ -90,6 +90,16 @@ export const useNotificationAnalytics = () => {
     captureEvent(NOTIFICATION_ANALYTICS_EVENTS.VIEW_ALL_UPDATES_CLICKED);
   }
 
+  function onMarkAllUpdatesReadClicked(source: 'updates_panel' | 'recent_updates', unreadCount: number) {
+    captureEvent(NOTIFICATION_ANALYTICS_EVENTS.MARK_ALL_UPDATES_READ_CLICKED, { source, unreadCount });
+  }
+
+  // The rollback path's only signal: this flow has no toast or undo, so a
+  // failed mark-all is invisible outside analytics.
+  function onMarkAllUpdatesReadFailed(source: 'updates_panel' | 'recent_updates', unreadCount: number) {
+    captureEvent(NOTIFICATION_ANALYTICS_EVENTS.MARK_ALL_UPDATES_READ_FAILED, { source, unreadCount });
+  }
+
   function onRecentUpdatesNotificationClicked(notification: PushNotification) {
     captureEvent(NOTIFICATION_ANALYTICS_EVENTS.RECENT_UPDATES_NOTIFICATION_CLICKED, {
       notificationId: notification.id,
@@ -109,6 +119,8 @@ export const useNotificationAnalytics = () => {
     onUpdatesPanelNotificationClicked,
     onNotificationActionLinkClicked,
     onViewAllUpdatesClicked,
+    onMarkAllUpdatesReadClicked,
+    onMarkAllUpdatesReadFailed,
     onRecentUpdatesNotificationClicked,
   };
 };

--- a/components/core/NotificationBell/NotificationBell.tsx
+++ b/components/core/NotificationBell/NotificationBell.tsx
@@ -9,7 +9,7 @@ import s from './NotificationBell.module.scss';
 
 export function NotificationBell({ isLoggedIn }: { isLoggedIn: boolean }) {
   const [isOpen, setIsOpen] = useState(false);
-  const { notifications, unreadCount, markAsRead } = usePushNotificationsContext();
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = usePushNotificationsContext();
   const analytics = useNotificationAnalytics();
   const controls = useAnimation();
   const prevUnreadCountRef = useRef(unreadCount);
@@ -68,6 +68,7 @@ export function NotificationBell({ isLoggedIn }: { isLoggedIn: boolean }) {
         unreadCount={unreadCount}
         onClose={handleClose}
         onMarkAsRead={markAsRead}
+        onMarkAllAsRead={markAllAsRead}
         isLoggedIn={isLoggedIn}
       />
     </>

--- a/components/core/UpdatesPanel/UpdatesPanel.module.scss
+++ b/components/core/UpdatesPanel/UpdatesPanel.module.scss
@@ -82,22 +82,46 @@
   padding: 0 2px;
 }
 
-/* Quiet text action beside the unread pill; hidden entirely at zero unread. */
+/* Mark-all + close, right of the header. */
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Quiet neutral action, transcribed from the notifications-hub prototype's
+   .markAllLink — reads as chrome, not as a link into content. Hidden entirely
+   at zero unread (production decision), so the prototype's :disabled state
+   never renders here. */
 .markAllButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
   border: none;
   background: none;
-  padding: 0;
-  cursor: pointer;
+  border-radius: 6px;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
   line-height: 20px;
   letter-spacing: -0.2px;
-  color: #156ff7;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
   white-space: nowrap;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
 
   &:hover {
-    text-decoration: underline;
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 1px;
   }
 }
 

--- a/components/core/UpdatesPanel/UpdatesPanel.module.scss
+++ b/components/core/UpdatesPanel/UpdatesPanel.module.scss
@@ -82,17 +82,62 @@
   padding: 0 2px;
 }
 
-/* The bulk action's own row, between the header and the list — the
-   prototype's .searchRow chrome without the view tabs (out of scope here),
-   so the single control right-aligns the way it does there. */
+/* The prototype's filter row between the header and the list: All/Unread/Read
+   tabs on the left, the bulk action on the right (.searchRow chrome). */
 .actionRow {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 8px;
   padding: 10px 16px;
   border-bottom: 1px solid rgba(27, 56, 96, 0.12);
   flex-shrink: 0;
+}
+
+/* Segment-empty copy (list has items, this view doesn't) — the proto's
+   .emptyState/.emptyTitle/.emptyBody/.emptyAction, minus the icon. */
+.viewEmptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.viewEmptyTitle {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 26px;
+  letter-spacing: -0.3px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.viewEmptyBody {
+  margin: 0;
+  max-width: 38ch;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.viewEmptyAction {
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--foreground-brand-primary, #1b4dff);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 /* Quiet neutral action, transcribed from the notifications-hub prototype's

--- a/components/core/UpdatesPanel/UpdatesPanel.module.scss
+++ b/components/core/UpdatesPanel/UpdatesPanel.module.scss
@@ -82,6 +82,38 @@
   padding: 0 2px;
 }
 
+/* Quiet text action beside the unread pill; hidden entirely at zero unread. */
+.markAllButton {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #156ff7;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* Visually hidden, still announced — the aria-live status region. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .closeButton {
   display: flex;
   align-items: center;

--- a/components/core/UpdatesPanel/UpdatesPanel.module.scss
+++ b/components/core/UpdatesPanel/UpdatesPanel.module.scss
@@ -82,18 +82,22 @@
   padding: 0 2px;
 }
 
-/* Mark-all + close, right of the header. */
-.headerActions {
+/* The bulk action's own row, between the header and the list — the
+   prototype's .searchRow chrome without the view tabs (out of scope here),
+   so the single control right-aligns the way it does there. */
+.actionRow {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(27, 56, 96, 0.12);
   flex-shrink: 0;
 }
 
 /* Quiet neutral action, transcribed from the notifications-hub prototype's
-   .markAllLink — reads as chrome, not as a link into content. Hidden entirely
-   at zero unread (production decision), so the prototype's :disabled state
-   never renders here. */
+   .markAllLink — reads as chrome, not as a link into content. Grayed out
+   (not hidden) at zero unread, exactly like the prototype. */
 .markAllButton {
   display: inline-flex;
   align-items: center;
@@ -114,7 +118,7 @@
     background-color 0.12s ease,
     color 0.12s ease;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
     color: var(--foreground-neutral-primary, #0a0c11);
   }
@@ -122,6 +126,11 @@
   &:focus-visible {
     outline: 2px solid var(--foreground-brand-primary, #1b4dff);
     outline-offset: 1px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 }
 

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -9,6 +9,7 @@ import { CloseIcon, ArrowRightIcon } from './icons';
 import { EmptyState } from './EmptyState';
 import { NotLoggedInState } from './NotLoggedInState';
 import { NotificationItem } from './NotificationItem';
+import { ViewSwitch, applyView, type UpdatesView } from './ViewSwitch/ViewSwitch';
 import s from './UpdatesPanel.module.scss';
 
 interface UpdatesPanelProps {
@@ -37,6 +38,12 @@ export function UpdatesPanel({
   // by design), and on failure the only signal a person gets at all.
   const [statusMessage, setStatusMessage] = useState('');
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // All / Unread / Read scoping (prototype behavior). Deliberately NOT reset
+  // on close: reopening where you left off matches the proto's session-scoped
+  // view state.
+  const [view, setView] = useState<UpdatesView>('all');
+  const visibleNotifications = applyView(notifications, view);
 
   const handleNotificationClick = (notification: PushNotification) => {
     analytics.onUpdatesPanelNotificationClicked(notification);
@@ -102,20 +109,24 @@ export function UpdatesPanel({
               </button>
             </div>
 
-            {/* The prototype's arrangement: the bulk action gets its own row
-                between the header and the list it operates on, right-aligned,
-                and stays visible-but-disabled at zero unread (a bulk
-                mark-as-read hides nothing). Logged-out viewers never see it. */}
-            {isLoggedIn && onMarkAllAsRead && (
+            {/* The prototype's filter row: All/Unread/Read scoping against the
+                list it scopes, beside the bulk action that operates on the same
+                set. Mark-all stays visible-but-disabled at zero unread (with a
+                Read segment present, a bulk mark-as-read hides nothing).
+                Logged-out viewers never see this row. */}
+            {isLoggedIn && (
               <div className={s.actionRow}>
-                <button
-                  type="button"
-                  className={s.markAllButton}
-                  onClick={handleMarkAllClick}
-                  disabled={unreadCount === 0}
-                >
-                  Mark all as read
-                </button>
+                <ViewSwitch view={view} unreadCount={unreadCount} onChange={setView} />
+                {onMarkAllAsRead && (
+                  <button
+                    type="button"
+                    className={s.markAllButton}
+                    onClick={handleMarkAllClick}
+                    disabled={unreadCount === 0}
+                  >
+                    Mark all as read
+                  </button>
+                )}
               </div>
             )}
             <span role="status" className={s.srOnly}>
@@ -127,9 +138,28 @@ export function UpdatesPanel({
                 <NotLoggedInState onClose={onClose} />
               ) : notifications.length === 0 ? (
                 <EmptyState />
+              ) : visibleNotifications.length === 0 ? (
+                // The list has items — just none in this segment. The proto's
+                // per-view copy, with an escape back to All where one helps.
+                <div className={s.viewEmptyState}>
+                  {view === 'unread' ? (
+                    <>
+                      <p className={s.viewEmptyTitle}>You&apos;re all caught up</p>
+                      <p className={s.viewEmptyBody}>Nothing unread right now.</p>
+                      <button type="button" className={s.viewEmptyAction} onClick={() => setView('all')}>
+                        Show all updates
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <p className={s.viewEmptyTitle}>Nothing read yet</p>
+                      <p className={s.viewEmptyBody}>Updates you&apos;ve read will collect here.</p>
+                    </>
+                  )}
+                </div>
               ) : (
                 <div className={s.notificationsList}>
-                  {notifications.map((notification) => (
+                  {visibleNotifications.map((notification) => (
                     <NotificationItem
                       key={notification.id}
                       notification={notification}

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -49,8 +49,9 @@ export function UpdatesPanel({
 
   const handleMarkAllClick = async () => {
     const count = unreadCount;
-    // The clicked button unmounts the moment the count hits zero — park focus
-    // on the close button first so it never drops to <body>. Panel stays open.
+    // The clicked button disables the moment the count hits zero, which drops
+    // its focus — park it on the close button first so it never lands on
+    // <body>. Panel stays open.
     closeButtonRef.current?.focus();
     analytics.onMarkAllUpdatesReadClicked('updates_panel', count);
     setStatusMessage('All notifications marked as read');
@@ -96,21 +97,27 @@ export function UpdatesPanel({
                   </div>
                 )}
               </div>
-              <div className={s.headerActions}>
-                {/* The prototype's placement: right-aligned against the window
-                    controls, away from the identity cluster. Hidden (not
-                    disabled) with nothing unread — the rule the unread pill
-                    already follows — and never shown to logged-out viewers. */}
-                {isLoggedIn && unreadCount > 0 && onMarkAllAsRead && (
-                  <button type="button" className={s.markAllButton} onClick={handleMarkAllClick}>
-                    Mark all as read
-                  </button>
-                )}
-                <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
-                  <CloseIcon />
+              <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
+                <CloseIcon />
+              </button>
+            </div>
+
+            {/* The prototype's arrangement: the bulk action gets its own row
+                between the header and the list it operates on, right-aligned,
+                and stays visible-but-disabled at zero unread (a bulk
+                mark-as-read hides nothing). Logged-out viewers never see it. */}
+            {isLoggedIn && onMarkAllAsRead && (
+              <div className={s.actionRow}>
+                <button
+                  type="button"
+                  className={s.markAllButton}
+                  onClick={handleMarkAllClick}
+                  disabled={unreadCount === 0}
+                >
+                  Mark all as read
                 </button>
               </div>
-            </div>
+            )}
             <span role="status" className={s.srOnly}>
               {statusMessage}
             </span>

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -95,17 +95,21 @@ export function UpdatesPanel({
                     <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
                   </div>
                 )}
-                {/* Hidden (not disabled) with nothing unread — same rule as
-                    the pill above, and never shown to logged-out viewers. */}
+              </div>
+              <div className={s.headerActions}>
+                {/* The prototype's placement: right-aligned against the window
+                    controls, away from the identity cluster. Hidden (not
+                    disabled) with nothing unread — the rule the unread pill
+                    already follows — and never shown to logged-out viewers. */}
                 {isLoggedIn && unreadCount > 0 && onMarkAllAsRead && (
                   <button type="button" className={s.markAllButton} onClick={handleMarkAllClick}>
                     Mark all as read
                   </button>
                 )}
+                <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
+                  <CloseIcon />
+                </button>
               </div>
-              <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
-                <CloseIcon />
-              </button>
             </div>
             <span role="status" className={s.srOnly}>
               {statusMessage}

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import { PushNotification } from '@/types/push-notifications.types';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -17,6 +17,8 @@ interface UpdatesPanelProps {
   unreadCount?: number;
   onClose: () => void;
   onMarkAsRead: (id: string) => void;
+  /** Rejects on failure (provider rolls back first); the panel reports it. */
+  onMarkAllAsRead?: () => Promise<void>;
   isLoggedIn?: boolean;
 }
 
@@ -26,9 +28,15 @@ export function UpdatesPanel({
   unreadCount = 0,
   onClose,
   onMarkAsRead,
+  onMarkAllAsRead,
   isLoggedIn = true,
 }: UpdatesPanelProps) {
   const analytics = useNotificationAnalytics();
+
+  // aria-live announcement — the only feedback this flow has (no toast/undo
+  // by design), and on failure the only signal a person gets at all.
+  const [statusMessage, setStatusMessage] = useState('');
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleNotificationClick = (notification: PushNotification) => {
     analytics.onUpdatesPanelNotificationClicked(notification);
@@ -37,6 +45,21 @@ export function UpdatesPanel({
       onMarkAsRead(notification.id);
     }
     onClose();
+  };
+
+  const handleMarkAllClick = async () => {
+    const count = unreadCount;
+    // The clicked button unmounts the moment the count hits zero — park focus
+    // on the close button first so it never drops to <body>. Panel stays open.
+    closeButtonRef.current?.focus();
+    analytics.onMarkAllUpdatesReadClicked('updates_panel', count);
+    setStatusMessage('All notifications marked as read');
+    try {
+      await onMarkAllAsRead?.();
+    } catch {
+      analytics.onMarkAllUpdatesReadFailed('updates_panel', count);
+      setStatusMessage('Could not mark notifications as read');
+    }
   };
 
   const handleViewAllClick = () => {
@@ -72,11 +95,21 @@ export function UpdatesPanel({
                     <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
                   </div>
                 )}
+                {/* Hidden (not disabled) with nothing unread — same rule as
+                    the pill above, and never shown to logged-out viewers. */}
+                {isLoggedIn && unreadCount > 0 && onMarkAllAsRead && (
+                  <button type="button" className={s.markAllButton} onClick={handleMarkAllClick}>
+                    Mark all as read
+                  </button>
+                )}
               </div>
-              <button className={s.closeButton} onClick={onClose} aria-label="Close">
+              <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
                 <CloseIcon />
               </button>
             </div>
+            <span role="status" className={s.srOnly}>
+              {statusMessage}
+            </span>
 
             <div className={s.content}>
               {!isLoggedIn ? (

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -144,6 +144,22 @@ export function UpdatesPanel({
                 <div className={s.viewEmptyState}>
                   {view === 'unread' ? (
                     <>
+                      <svg
+                        width="56"
+                        height="56"
+                        viewBox="0 0 56 56"
+                        fill="none"
+                        aria-hidden="true"
+                        className="NotificationsHub-module-scss-module__GrkIOW__emptyIcon"
+                      >
+                        <path
+                          d="M8 30.5 13.2 14a3 3 0 0 1 2.85-2.05h23.9A3 3 0 0 1 42.8 14L48 30.5m-40 0V40a4 4 0 0 0 4 4h32a4 4 0 0 0 4-4v-9.5m-40 0h10.8a2 2 0 0 1 1.86 1.27l.62 1.56A2 2 0 0 0 23.14 35h9.72a2 2 0 0 0 1.86-1.27l.62-1.56A2 2 0 0 1 37.2 30.5H48"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        ></path>
+                      </svg>
                       <p className={s.viewEmptyTitle}>You&apos;re all caught up</p>
                       <p className={s.viewEmptyBody}>Nothing unread right now.</p>
                       <button type="button" className={s.viewEmptyAction} onClick={() => setView('all')}>

--- a/components/core/UpdatesPanel/ViewSwitch/ViewSwitch.module.scss
+++ b/components/core/UpdatesPanel/ViewSwitch/ViewSwitch.module.scss
@@ -1,0 +1,56 @@
+/* Transcribed from the notifications-hub prototype's segmented control. */
+
+.segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  border-radius: 8px;
+}
+
+.segmentedBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &:hover {
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 1px;
+  }
+
+  /* Selected reads as a raised white pill — shape and elevation, not colour
+     alone. */
+  &[aria-selected='true'] {
+    background: var(--background-neutral-primary, #ffffff);
+    color: var(--foreground-neutral-primary, #0a0c11);
+    box-shadow: 0 1px 2px rgba(14, 15, 17, 0.08);
+  }
+}
+
+.segmentCount {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  /* #1b4dff = 5.91:1 on white; the pill's #4174ff would fail AA at this size. */
+  color: var(--foreground-brand-primary, #1b4dff);
+}

--- a/components/core/UpdatesPanel/ViewSwitch/ViewSwitch.tsx
+++ b/components/core/UpdatesPanel/ViewSwitch/ViewSwitch.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+
+import s from './ViewSwitch.module.scss';
+
+export type UpdatesView = 'all' | 'unread' | 'read';
+
+type Props = {
+  view: UpdatesView;
+  unreadCount: number;
+  onChange: (next: UpdatesView) => void;
+};
+
+const OPTIONS: Array<{ value: UpdatesView; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'unread', label: 'Unread' },
+  { value: 'read', label: 'Read' },
+];
+
+/**
+ * All / Unread / Read, transcribed from the notifications-hub prototype's
+ * ViewSwitch. Read notifications become reachable without scrolling the
+ * merged list, and a bulk mark-as-read stops feeling destructive — everything
+ * it touched is one segment away.
+ */
+export function ViewSwitch({ view, unreadCount, onChange }: Props) {
+  return (
+    <div className={s.segmented} role="tablist" aria-label="Filter updates">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          role="tab"
+          aria-selected={view === opt.value}
+          className={s.segmentedBtn}
+          onClick={() => onChange(opt.value)}
+        >
+          {opt.label}
+          {opt.value === 'unread' && unreadCount > 0 && <span className={s.segmentCount}>{unreadCount}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Shared filter, so the panel and the full page never diverge. An absent
+ *  isRead counts as unread — the same reading the unread dot gives it. */
+export function applyView<T extends { isRead?: boolean }>(items: T[], view: UpdatesView): T[] {
+  if (view === 'unread') return items.filter((n) => !n.isRead);
+  if (view === 'read') return items.filter((n) => n.isRead);
+  return items;
+}

--- a/components/page/home/recent-updates/RecentUpdatesSection.module.scss
+++ b/components/page/home/recent-updates/RecentUpdatesSection.module.scss
@@ -63,3 +63,41 @@
   flex-direction: column;
   gap: 16px;
 }
+
+/* Quiet text action beside the unread pill; hidden entirely at zero unread. */
+.markAllButton {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #156ff7;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* The heading doubles as the post-click focus target (tabindex="-1") —
+   programmatic focus shouldn't paint a ring on a non-interactive element. */
+.title:focus {
+  outline: none;
+}
+
+/* Visually hidden, still announced — the aria-live status region. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/components/page/home/recent-updates/RecentUpdatesSection.module.scss
+++ b/components/page/home/recent-updates/RecentUpdatesSection.module.scss
@@ -64,22 +64,40 @@
   gap: 16px;
 }
 
-/* Quiet text action beside the unread pill; hidden entirely at zero unread. */
+/* Quiet neutral action, transcribed from the notifications prototypes'
+   .markAllLink, at the header's right edge (the inbox prototype's placement:
+   the bulk action sits against the list it operates on, opposite the identity
+   cluster). Hidden entirely at zero unread, so the prototype's :disabled
+   state never renders here. */
 .markAllButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding: 4px 6px;
   border: none;
   background: none;
-  padding: 0;
-  cursor: pointer;
+  border-radius: 6px;
   font-family: 'Inter', sans-serif;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
   line-height: 20px;
   letter-spacing: -0.2px;
-  color: #156ff7;
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
   white-space: nowrap;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
 
   &:hover {
-    text-decoration: underline;
+    background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 1px;
   }
 }
 

--- a/components/page/home/recent-updates/RecentUpdatesSection.module.scss
+++ b/components/page/home/recent-updates/RecentUpdatesSection.module.scss
@@ -67,8 +67,7 @@
 /* Quiet neutral action, transcribed from the notifications prototypes'
    .markAllLink, at the header's right edge (the inbox prototype's placement:
    the bulk action sits against the list it operates on, opposite the identity
-   cluster). Hidden entirely at zero unread, so the prototype's :disabled
-   state never renders here. */
+   cluster). Grayed out (not hidden) at zero unread, like the prototypes. */
 .markAllButton {
   display: inline-flex;
   align-items: center;
@@ -90,7 +89,7 @@
     background-color 0.12s ease,
     color 0.12s ease;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
     color: var(--foreground-neutral-primary, #0a0c11);
   }
@@ -98,6 +97,11 @@
   &:focus-visible {
     outline: 2px solid var(--foreground-brand-primary, #1b4dff);
     outline-offset: 1px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 }
 

--- a/components/page/home/recent-updates/RecentUpdatesSection.module.scss
+++ b/components/page/home/recent-updates/RecentUpdatesSection.module.scss
@@ -64,15 +64,23 @@
   gap: 16px;
 }
 
+/* The inbox prototype's filter row, between the header and the card: view
+   tabs left, bulk action right. */
+.filtersRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 /* Quiet neutral action, transcribed from the notifications prototypes'
-   .markAllLink, at the header's right edge (the inbox prototype's placement:
-   the bulk action sits against the list it operates on, opposite the identity
-   cluster). Grayed out (not hidden) at zero unread, like the prototypes. */
+   .markAllLink — the bulk action sits against the list it operates on,
+   opposite the view tabs. Grayed out (not hidden) at zero unread. */
 .markAllButton {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-left: auto;
   padding: 4px 6px;
   border: none;
   background: none;
@@ -122,4 +130,50 @@
   clip: rect(0 0 0 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* Segment-empty copy (list has items, this view doesn't) — the proto's
+   .emptyState/.emptyTitle/.emptyBody/.emptyAction, minus the icon. */
+.viewEmptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.viewEmptyTitle {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 26px;
+  letter-spacing: -0.3px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.viewEmptyBody {
+  margin: 0;
+  max-width: 38ch;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+.viewEmptyAction {
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--foreground-brand-primary, #1b4dff);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/components/page/home/recent-updates/RecentUpdatesSection.tsx
+++ b/components/page/home/recent-updates/RecentUpdatesSection.tsx
@@ -57,8 +57,8 @@ export function RecentUpdatesSection(props: Props) {
 
   const handleMarkAllClick = async () => {
     const count = unreadCount;
-    // The clicked button unmounts when the count hits zero — park focus on the
-    // heading first so it never drops to <body>.
+    // The clicked button disables when the count hits zero, which drops its
+    // focus — park it on the heading first so it never lands on <body>.
     titleRef.current?.focus();
     analytics.onMarkAllUpdatesReadClicked('recent_updates', count);
     setStatusMessage('All notifications marked as read');
@@ -76,15 +76,16 @@ export function RecentUpdatesSection(props: Props) {
         Recent Updates
       </h2>
       {isLoggedIn && unreadCount > 0 && (
-        <>
-          <div className={s.unreadBadge}>
-            <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
-          </div>
-          {/* Hidden (not disabled) with nothing unread — same rule as the pill. */}
-          <button type="button" className={s.markAllButton} onClick={handleMarkAllClick}>
-            Mark all as read
-          </button>
-        </>
+        <div className={s.unreadBadge}>
+          <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
+        </div>
+      )}
+      {/* Grayed out (not hidden) at zero unread — the prototypes' behavior.
+          Logged-out viewers never see it. */}
+      {isLoggedIn && (
+        <button type="button" className={s.markAllButton} onClick={handleMarkAllClick} disabled={unreadCount === 0}>
+          Mark all as read
+        </button>
       )}
       <span role="status" className={s.srOnly}>
         {statusMessage}

--- a/components/page/home/recent-updates/RecentUpdatesSection.tsx
+++ b/components/page/home/recent-updates/RecentUpdatesSection.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from './components/EmptyState/EmptyState';
 import { NotificationItem } from '@/components/core/UpdatesPanel/NotificationItem';
 import { LoadingIndicator } from './components/LoadingIndicator/LoadingIndicator';
 import { NotLoggedInState } from '@/components/core/UpdatesPanel/NotLoggedInState';
+import { ViewSwitch, applyView, type UpdatesView } from '@/components/core/UpdatesPanel/ViewSwitch/ViewSwitch';
 import s from './RecentUpdatesSection.module.scss';
 
 /**
@@ -43,9 +44,14 @@ export function RecentUpdatesSection(props: Props) {
   const [statusMessage, setStatusMessage] = useState('');
   const titleRef = useRef<HTMLHeadingElement>(null);
 
+  // All / Unread / Read scoping (the inbox prototype's arrangement). Filters
+  // the pages loaded so far; scrolling keeps feeding the filter.
+  const [view, setView] = useState<UpdatesView>('all');
+
   // Sanitize notifications to remove HTML markup from title and description
   // TODO: REMOVE MOCK_IRL_GATHERING_NOTIFICATION from the array below when done testing
   const sanitizedNotifications = useMemo(() => notifications.map(sanitizeNotification), [notifications]);
+  const visibleNotifications = applyView(sanitizedNotifications, view);
 
   const handleNotificationClick = (notification: PushNotification) => {
     analytics.onRecentUpdatesNotificationClicked(notification);
@@ -80,18 +86,25 @@ export function RecentUpdatesSection(props: Props) {
           <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
         </div>
       )}
-      {/* Grayed out (not hidden) at zero unread — the prototypes' behavior.
-          Logged-out viewers never see it. */}
-      {isLoggedIn && (
-        <button type="button" className={s.markAllButton} onClick={handleMarkAllClick} disabled={unreadCount === 0}>
-          Mark all as read
-        </button>
-      )}
       <span role="status" className={s.srOnly}>
         {statusMessage}
       </span>
     </div>
   );
+
+  // The inbox prototype's filter row, between the header and the card: view
+  // scoping sits against the list it scopes, beside the bulk action that
+  // operates on the same set. Mark-all is grayed out (not hidden) at zero
+  // unread. Logged-out viewers never see this row.
+  const renderFilters = () =>
+    isLoggedIn && (
+      <div className={s.filtersRow}>
+        <ViewSwitch view={view} unreadCount={unreadCount} onChange={setView} />
+        <button type="button" className={s.markAllButton} onClick={handleMarkAllClick} disabled={unreadCount === 0}>
+          Mark all as read
+        </button>
+      </div>
+    );
 
   if (!isLoggedIn) {
     return (
@@ -118,20 +131,39 @@ export function RecentUpdatesSection(props: Props) {
   return (
     <section id="recent-updates" className={s.section}>
       {renderHeader()}
+      {renderFilters()}
       <div className={s.card}>
         {sanitizedNotifications.length === 0 ? (
           <EmptyState />
+        ) : visibleNotifications.length === 0 ? (
+          // The list has items — just none in this segment (proto copy).
+          <div className={s.viewEmptyState}>
+            {view === 'unread' ? (
+              <>
+                <p className={s.viewEmptyTitle}>You&apos;re all caught up</p>
+                <p className={s.viewEmptyBody}>Nothing unread right now.</p>
+                <button type="button" className={s.viewEmptyAction} onClick={() => setView('all')}>
+                  Show all updates
+                </button>
+              </>
+            ) : (
+              <>
+                <p className={s.viewEmptyTitle}>Nothing read yet</p>
+                <p className={s.viewEmptyBody}>Updates you&apos;ve read will collect here.</p>
+              </>
+            )}
+          </div>
         ) : (
           <InfiniteScroll
             scrollableTarget="body"
             loader={null}
             hasMore={hasNextPage}
-            dataLength={sanitizedNotifications.length}
+            dataLength={visibleNotifications.length}
             next={fetchNextPage}
             style={{ overflow: 'unset' }}
           >
             <div className={s.notificationsList}>
-              {sanitizedNotifications.map((notification) => (
+              {visibleNotifications.map((notification) => (
                 <NotificationItem
                   key={notification.id}
                   notification={notification}

--- a/components/page/home/recent-updates/RecentUpdatesSection.tsx
+++ b/components/page/home/recent-updates/RecentUpdatesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { stripHtml, usePushNotificationsContext } from '@/providers/PushNotificationsProvider';
 import { useInfiniteNotifications } from '@/services/push-notifications/hooks';
@@ -30,12 +30,18 @@ interface Props {
 export function RecentUpdatesSection(props: Props) {
   const { isLoggedIn } = props;
 
-  const { markAsRead } = usePushNotificationsContext();
+  // unreadCount from the provider, NOT from the infinite query: pages[0]'s
+  // count is a snapshot from the first fetch, while the provider's is live —
+  // it zeroes the moment mark-all runs (from either surface, or another tab).
+  const { markAsRead, markAllAsRead, unreadCount } = usePushNotificationsContext();
   const analytics = useNotificationAnalytics();
-  const { notifications, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, unreadCount } =
-    useInfiniteNotifications({
-      enabled: isLoggedIn,
-    });
+  const { notifications, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteNotifications({
+    enabled: isLoggedIn,
+  });
+
+  // aria-live announcement — this flow's only feedback (no toast/undo by design).
+  const [statusMessage, setStatusMessage] = useState('');
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   // Sanitize notifications to remove HTML markup from title and description
   // TODO: REMOVE MOCK_IRL_GATHERING_NOTIFICATION from the array below when done testing
@@ -49,14 +55,40 @@ export function RecentUpdatesSection(props: Props) {
     }
   };
 
+  const handleMarkAllClick = async () => {
+    const count = unreadCount;
+    // The clicked button unmounts when the count hits zero — park focus on the
+    // heading first so it never drops to <body>.
+    titleRef.current?.focus();
+    analytics.onMarkAllUpdatesReadClicked('recent_updates', count);
+    setStatusMessage('All notifications marked as read');
+    try {
+      await markAllAsRead();
+    } catch {
+      analytics.onMarkAllUpdatesReadFailed('recent_updates', count);
+      setStatusMessage('Could not mark notifications as read');
+    }
+  };
+
   const renderHeader = () => (
     <div className={s.header}>
-      <h2 className={s.title}>Recent Updates</h2>
+      <h2 className={s.title} tabIndex={-1} ref={titleRef}>
+        Recent Updates
+      </h2>
       {isLoggedIn && unreadCount > 0 && (
-        <div className={s.unreadBadge}>
-          <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
-        </div>
+        <>
+          <div className={s.unreadBadge}>
+            <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
+          </div>
+          {/* Hidden (not disabled) with nothing unread — same rule as the pill. */}
+          <button type="button" className={s.markAllButton} onClick={handleMarkAllClick}>
+            Mark all as read
+          </button>
+        </>
       )}
+      <span role="status" className={s.srOnly}>
+        {statusMessage}
+      </span>
     </div>
   );
 

--- a/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
+++ b/providers/PushNotificationsProvider/PushNotificationsProvider.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { usePushNotifications } from '@/hooks/usePushNotifications';
+import {
+  patchInfiniteNotificationsAllRead,
+  restoreInfiniteNotifications,
+} from '@/services/push-notifications/hooks/useInfiniteNotifications';
 import {
   PushNotification,
   NotificationUpdatePayload,
@@ -34,6 +39,15 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
   const [notifications, setNotifications] = useState<PushNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+
+  // The /recent-updates list renders from the infinite-notifications react-query
+  // cache, not from this provider's state — bulk read-state changes have to
+  // reach both, and only the provider sees both (the navbar bell is global, so
+  // mark-all can be clicked from the bell while that page is on screen).
+  const queryClient = useQueryClient();
+
+  // One mark-all API call at a time, across every surface that can trigger it.
+  const markAllInFlightRef = useRef(false);
 
   // Ref mirror of notifications for synchronous access in callbacks
   // (avoids calling setUnreadCount inside setNotifications updater, which React strict mode double-invokes)
@@ -127,8 +141,9 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
         const normalized = normalizeLink(link);
 
         if (normalized === pathToCompareNotyLink) {
-          markNotificationAsRead(authToken, uid)
-            .catch((err) => console.error('Failed to auto-mark notification:', err));
+          markNotificationAsRead(authToken, uid).catch((err) =>
+            console.error('Failed to auto-mark notification:', err),
+          );
           wsMarkAsReadRef.current(uid);
 
           return;
@@ -177,12 +192,18 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
   }, []);
 
   // Handle count update from WebSocket
-  const handleCountUpdate = useCallback((payload: NotificationCountPayload) => {
-    setUnreadCount(payload.unreadCount);
-    if (payload.unreadCount === 0) {
-      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-    }
-  }, []);
+  const handleCountUpdate = useCallback(
+    (payload: NotificationCountPayload) => {
+      setUnreadCount(payload.unreadCount);
+      if (payload.unreadCount === 0) {
+        setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+        // A mark-all in another tab reaches this tab as count:0 — its
+        // /recent-updates rows live in the query cache, not in this state.
+        patchInfiniteNotificationsAllRead(queryClient);
+      }
+    },
+    [queryClient],
+  );
 
   const {
     isConnected,
@@ -307,33 +328,55 @@ export function PushNotificationsProvider({ children, authToken, enabled = true 
 
   // Mark all notifications as read
   const markAllAsRead = useCallback(async () => {
-    const hadUnread = notifications.some((n) => !n.isRead);
-    if (!hadUnread) return;
+    // Count-based guard, not `some(!isRead)` over the loaded list: this state
+    // holds only the newest 50, so unread items older than that would
+    // otherwise silently skip the API call.
+    if (markAllInFlightRef.current || unreadCount === 0) return;
+    markAllInFlightRef.current = true;
+
+    // Snapshots for rollback. id → isRead (not a copy of the array), so a
+    // notification that arrives over the WebSocket mid-flight survives the
+    // rollback with its own read state instead of being clobbered.
+    const previousReadById = new Map(notificationsRef.current.map((n) => [n.id, n.isRead]));
+    const previousCount = unreadCount;
+    const previousPages = patchInfiniteNotificationsAllRead(queryClient);
 
     // Optimistic update
-    const previousNotifications = [...notifications];
-    const previousCount = unreadCount;
     setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
     setUnreadCount(0);
 
-    // Call REST API
-    if (authToken) {
-      try {
+    try {
+      if (authToken) {
         await markAllNotificationsAsRead(authToken);
-      } catch (err) {
-        console.error('Failed to mark all notifications as read:', err);
-        // Revert optimistic update on error
-        setNotifications(previousNotifications);
-        setUnreadCount(previousCount);
       }
+
+      // Success-only side effects: a failed request must not tell other tabs
+      // "all read", and auto-mark-on-navigation must keep its map so it can
+      // still PATCH the notifications that are in fact unread.
+      wsMarkAllAsRead();
+      unreadLinksMapRef.current.clear();
+    } catch (err) {
+      console.error('Failed to mark all notifications as read:', err);
+
+      // Revert optimistic updates on error (merge, never replace)
+      setNotifications((prev) =>
+        prev.map((n) => {
+          const wasRead = previousReadById.get(n.id);
+          return wasRead === undefined ? n : { ...n, isRead: wasRead };
+        }),
+      );
+      setUnreadCount(previousCount);
+      if (previousPages) {
+        restoreInfiniteNotifications(queryClient, previousPages);
+      }
+
+      // Surfaces report the failure (analytics is the only failure signal —
+      // this flow has no toast or undo by design).
+      throw err;
+    } finally {
+      markAllInFlightRef.current = false;
     }
-
-    // Notify other devices via WebSocket
-    wsMarkAllAsRead();
-
-    // Clear the unread links map — everything is read now
-    unreadLinksMapRef.current.clear();
-  }, [notifications, unreadCount, authToken, wsMarkAllAsRead]);
+  }, [unreadCount, authToken, wsMarkAllAsRead, queryClient]);
 
   const value = useMemo(
     () => ({

--- a/providers/PushNotificationsProvider/types.ts
+++ b/providers/PushNotificationsProvider/types.ts
@@ -7,7 +7,9 @@ export interface PushNotificationsContextValue {
   isLoading: boolean;
   error: string | null;
   markAsRead: (id: string) => void;
-  markAllAsRead: () => void;
+  /** Rejects on API failure (after rolling back) so surfaces can report it —
+   *  there is no toast/undo in this flow, analytics is the only failure signal. */
+  markAllAsRead: () => Promise<void>;
   refreshNotifications: () => Promise<void>;
 }
 

--- a/services/push-notifications/hooks/useInfiniteNotifications.ts
+++ b/services/push-notifications/hooks/useInfiniteNotifications.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, type QueryClient } from '@tanstack/react-query';
 import { PushNotification } from '@/types/push-notifications.types';
 import { getNotifications } from '@/services/push-notifications.service';
 import Cookies from 'js-cookie';
@@ -12,6 +12,50 @@ export const NotificationsQueryKeys = {
   INFINITE_NOTIFICATIONS: 'infinite-notifications',
 } as const;
 
+export const INFINITE_NOTIFICATIONS_KEY = [NotificationsQueryKeys.INFINITE_NOTIFICATIONS];
+
+interface NotificationsPage {
+  notifications: PushNotification[];
+  total: number;
+  unreadCount: number;
+  offset?: number;
+}
+
+export interface InfiniteNotificationsData {
+  pages: NotificationsPage[];
+  pageParams: unknown[];
+}
+
+/**
+ * Flip every cached notification to read and zero each page's unreadCount, in
+ * place — used by the provider's markAllAsRead. setQueryData rather than
+ * invalidateQueries on purpose: the server sorts unread-first and paginates in
+ * memory, so a refetch after mark-all reshuffles rows already on screen (and
+ * recomputing unreadCount server-side is expensive).
+ *
+ * Returns the pre-patch snapshot for rollback, or undefined when nothing is
+ * cached (the /recent-updates page was never visited).
+ */
+export function patchInfiniteNotificationsAllRead(queryClient: QueryClient): InfiniteNotificationsData | undefined {
+  const previous = queryClient.getQueryData<InfiniteNotificationsData>(INFINITE_NOTIFICATIONS_KEY);
+  if (!previous) return undefined;
+
+  queryClient.setQueryData<InfiniteNotificationsData>(INFINITE_NOTIFICATIONS_KEY, {
+    ...previous,
+    pages: previous.pages.map((page) => ({
+      ...page,
+      unreadCount: 0,
+      notifications: page.notifications.map((n) => (n.isRead ? n : { ...n, isRead: true })),
+    })),
+  });
+
+  return previous;
+}
+
+export function restoreInfiniteNotifications(queryClient: QueryClient, snapshot: InfiniteNotificationsData): void {
+  queryClient.setQueryData(INFINITE_NOTIFICATIONS_KEY, snapshot);
+}
+
 interface UseInfiniteNotificationsOptions {
   enabled?: boolean;
 }
@@ -19,51 +63,50 @@ interface UseInfiniteNotificationsOptions {
 export function useInfiniteNotifications(options: UseInfiniteNotificationsOptions = {}) {
   const { enabled = true } = options;
 
-  const {
-    data,
-    error,
-    fetchNextPage,
-    hasNextPage,
-    isLoading,
-    isFetchingNextPage,
-    status,
-    refetch,
-    isRefetching,
-  } = useInfiniteQuery({
-    queryKey: [NotificationsQueryKeys.INFINITE_NOTIFICATIONS],
-    initialPageParam: 0,
-    enabled,
-    queryFn: async ({ pageParam = 0 }) => {
-      const authToken = getParsedValue(Cookies.get('authToken'));
-      if (!authToken) {
-        return { notifications: [], total: 0, unreadCount: 0 };
-      }
+  const { data, error, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage, status, refetch, isRefetching } =
+    useInfiniteQuery({
+      queryKey: [NotificationsQueryKeys.INFINITE_NOTIFICATIONS],
+      initialPageParam: 0,
+      enabled,
+      queryFn: async ({ pageParam = 0 }) => {
+        const authToken = getParsedValue(Cookies.get('authToken'));
+        if (!authToken) {
+          return { notifications: [], total: 0, unreadCount: 0 };
+        }
 
-      const response = await getNotifications(authToken, {
-        limit: NOTIFICATIONS_PER_PAGE,
-        offset: pageParam,
-      });
+        const response = await getNotifications(authToken, {
+          limit: NOTIFICATIONS_PER_PAGE,
+          offset: pageParam,
+        });
 
-      return {
-        notifications: response.notifications.map((n) => ({
-          ...n,
-          id: n.uid ?? n.id, // Normalize id field
-        })),
-        total: response.total,
-        unreadCount: response.unreadCount,
-        offset: pageParam,
-      };
-    },
-    getNextPageParam: (lastPage, allPages) => {
-      const totalFetched = allPages.reduce((acc, page) => acc + page.notifications.length, 0);
-      if (totalFetched >= lastPage.total) {
-        return undefined; // No more pages
-      }
-      return totalFetched; // Next offset
-    },
+        return {
+          notifications: response.notifications.map((n) => ({
+            ...n,
+            id: n.uid ?? n.id, // Normalize id field
+          })),
+          total: response.total,
+          unreadCount: response.unreadCount,
+          offset: pageParam,
+        };
+      },
+      getNextPageParam: (lastPage, allPages) => {
+        const totalFetched = allPages.reduce((acc, page) => acc + page.notifications.length, 0);
+        if (totalFetched >= lastPage.total) {
+          return undefined; // No more pages
+        }
+        return totalFetched; // Next offset
+      },
+    });
+
+  // Dedupe by id: cumulative offsets are computed against the ordering at
+  // fetch time, and a mark-all changes the server's unread-first sort — a page
+  // fetched afterwards can re-serve rows that are already on screen.
+  const seenIds = new Set<string>();
+  const notifications: PushNotification[] = (data?.pages?.flatMap((page) => page.notifications) ?? []).filter((n) => {
+    if (seenIds.has(n.id)) return false;
+    seenIds.add(n.id);
+    return true;
   });
-
-  const notifications: PushNotification[] = data?.pages?.flatMap((page) => page.notifications) ?? [];
   const total = data?.pages?.[0]?.total ?? 0;
   const unreadCount = data?.pages?.[0]?.unreadCount ?? 0;
 
@@ -81,4 +124,3 @@ export function useInfiniteNotifications(options: UseInfiniteNotificationsOption
     isRefetching,
   };
 }
-

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -183,6 +183,8 @@ export const NOTIFICATION_ANALYTICS_EVENTS = {
   VIEW_ALL_UPDATES_CLICKED: 'view-all-updates-clicked',
   UPDATES_PANEL_NOTIFICATION_CLICKED: 'updates-panel-notification-clicked',
   RECENT_UPDATES_NOTIFICATION_CLICKED: 'recent-updates-notification-clicked',
+  MARK_ALL_UPDATES_READ_CLICKED: 'mark-all-updates-read-clicked',
+  MARK_ALL_UPDATES_READ_FAILED: 'mark-all-updates-read-failed',
 };
 
 export const SETTINGS_ANALYTICS_EVENTS = {


### PR DESCRIPTION
## Summary

Adds a visible **"Mark all as read"** action to both notification surfaces — the bell dropdown (Updates panel) and `/recent-updates`. Clicking it immediately marks every unread notification read: no confirmation dialog, no undo toast (by design). The bell badge, both unread pills, and every unread dot clear at once.

Companion to backend PR memser-spaceport/pln-directory-portal#3307 (mark-all-read hardening). **Release after that deploys** — on a 404 the optimistic update would visibly roll itself back.

### How it works

- **The provider owns the whole action.** `PushNotificationsProvider.markAllAsRead()` (exported since the beginning, never called by any component) is now wired from both surfaces — and it also patches the `['infinite-notifications']` react-query cache, because the navbar bell is global: mark-all clicked from the bell while standing on `/recent-updates` must clear that page's rows too. Cross-tab `notification:count 0` broadcasts patch the cache the same way.
- **Four provider defects fixed while wiring:**
  - the unread guard is count-based — previously `some(!isRead)` over the loaded 50 silently skipped the API call when all unread items were older;
  - an in-flight ref absorbs double-clicks and simultaneous clicks from both surfaces into one API call;
  - the websocket broadcast and unread-links-map clear now run **only on success** — a failed request no longer tells other tabs "all read" or disables auto-mark-on-navigation;
  - rollback merges by id instead of replacing the array, so a notification that arrived over the websocket mid-flight survives with its own read state.
- **`setQueryData`, not `invalidateQueries`**: the server sorts unread-first and paginates in memory, so a refetch after mark-all reshuffles rows already on screen (and recomputing the count server-side is expensive). An id-dedupe in the hook's `flatMap` absorbs duplicate rows from pages fetched after the sort changes.
- **Visibility**: hidden (not disabled) at zero unread, and never shown to logged-out viewers — same rule as the existing "Unread N" pill. The page's pill now reads the provider's **live** count instead of the first-page snapshot, so it zeroes immediately.
- **No toast/undo** means focus and announcements carry the UX: focus parks on a stable element (panel close button / page heading) before the button unmounts, and an `aria-live` status region announces success or failure. New analytics events `mark-all-updates-read-clicked` / `-failed` carry the surface and the count at click time — the failure path's only signal.

## View tabs (added after prototype review)

Oleg reviewed against the notifications-hub prototype and asked for its All/Unread/Read scoping too: a shared `ViewSwitch` component (transcribed from the prototype) now sits in the panel's filter row and the page's filters row, left of the mark-all action. Client-side filter over the loaded list; Unread segment carries the live count; empty segments get the prototype's copy with a "Show all updates" escape. The mark-all control itself also now matches the prototype: quiet neutral styling, its own row, and visible-but-disabled at zero unread (revised from the earlier hidden-at-zero decision).

## Testing

- 4 new test files, 20 tests: cache patch/restore helper; provider behavior (count-based guard, optimistic + broadcast ordering, double-click absorption, merge-rollback with cache restore, no broadcast on failure, cross-tab count:0 patch); both surfaces' gating, focus, announcements, and analytics.
- Full suite: 153 suites / 1263 tests pass. `eslint` clean on touched files (one pre-existing warning in untouched provider code), `prettier` clean, no new `tsc` errors.

## Screenshots

Not included — requires a signed-in session with unread notifications against a live backend; happy to add after a dev-environment pass.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
