### PR TITLE
Warm intros improvements

### DIFF
--- a/prototypes/entries/warm-intros-v2/COMPONENTS.md
+++ b/prototypes/entries/warm-intros-v2/COMPONENTS.md
@@ -9,53 +9,55 @@ production drifts.
 
 ## Imported straight from production (do not copy into this folder)
 
-| What | Path |
-| --- | --- |
-| Results table **styles** | `@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss` |
-| Glossary drawer | `…/WarmIntrosV2GlossaryDrawer` |
-| Score % pill | `…/ScorePercentPill` |
-| Person chip | `…/PathProfileChip` |
-| CSV export | `…/exportWarmIntrosV2Csv` |
-| hopChain parsing + proximity derivation | `…/parseWarmPathHopChain` |
-| MasterProfile display helpers | `…/masterProfileDisplay.util` |
-| Workspace / drawer / modal styles | `…/WarmIntrosV2Workspace.module.scss`, `…/WarmIntrosV2InvestorDrawer.module.scss`, `…/MasterProfileModal.module.scss` |
-| Proximity badge | `@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge` |
-| Sector chips | `@/components/page/investors/SectorTagsList/SectorTagsList` |
-| Filter dropdowns | `@/components/common/filters/FilterSelect/FilterSelect` |
-| Drawer / Modal / CopyButton | `@/components/common/Drawer/Drawer`, `@/components/common/Modal`, `@/components/ui/CopyButton` |
-| Avatar fallback | `@/hooks/useDefaultAvatar` → `getDefaultAvatar` |
-| Types + target-set constants | `@/services/investors/warm-intros-v2.types` |
+| What                                                         | Path                                                                                                                  |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Results table **styles**                                     | `@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss`                                     |
+| Glossary drawer                                              | `…/WarmIntrosV2GlossaryDrawer`                                                                                        |
+| Score % pill                                                 | `…/ScorePercentPill`                                                                                                  |
+| Person chip (+ Directory-member dot)                         | `…/PathProfileChip`                                                                                                   |
+| Hop role pill (PL Member / Founder / Co-investor / Investor) | `…/HopRoleBadge`                                                                                                      |
+| Co-investment parsing                                        | `…/masterProfileDisplay.util` → `parseCoInvestments`                                                                  |
+| CSV export                                                   | `…/exportWarmIntrosV2Csv`                                                                                             |
+| hopChain parsing + proximity derivation                      | `…/parseWarmPathHopChain`                                                                                             |
+| MasterProfile display helpers                                | `…/masterProfileDisplay.util`                                                                                         |
+| Workspace / drawer / modal styles                            | `…/WarmIntrosV2Workspace.module.scss`, `…/WarmIntrosV2InvestorDrawer.module.scss`, `…/MasterProfileModal.module.scss` |
+| Proximity badge                                              | `@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge`                                                   |
+| Sector chips                                                 | `@/components/page/investors/SectorTagsList/SectorTagsList`                                                           |
+| Filter dropdowns                                             | `@/components/common/filters/FilterSelect/FilterSelect`                                                               |
+| Drawer / Modal / CopyButton                                  | `@/components/common/Drawer/Drawer`, `@/components/common/Modal`, `@/components/ui/CopyButton`                        |
+| Avatar fallback                                              | `@/hooks/useDefaultAvatar` → `getDefaultAvatar`                                                                       |
+| Types + target-set constants                                 | `@/services/investors/warm-intros-v2.types`                                                                           |
 
 ## Transcribed here (only because production calls the API)
 
-| File | Production source | What changed |
-| --- | --- | --- |
-| `WarmIntrosV2Prototype.tsx` | `WarmIntrosV2Workspace.tsx` | `useQueryStates` (nuqs) → `useState`; `useWarmIntrosV2Paths` / `useWarmIntrosV2Facets` / `useGetInvestorLists` → mock selectors; infinite scroll dropped (14 rows fit one page); PostHog analytics dropped |
-| `InvestorDrawerMock.tsx` | `WarmIntrosV2InvestorDrawer.tsx` | `useWarmIntrosV2PathsForInvestor` + `useMasterProfile` → mock lookups |
-| `MasterProfileModalMock.tsx` | `MasterProfileModal.tsx` | `useMasterProfile` → `MOCK_MASTER_PROFILES[uid]`; loading / error branches are inert |
-| `WarmIntrosV2TableMock.tsx` | `WarmIntrosV2Table.tsx` | **Team** and **Industry / Sector** columns removed (a design change, not a data one); firm · role folded under the investor name; column widths re-balanced in `TableColumns.module.scss` |
+| File                         | Production source                | What changed                                                                                                                                                                                               |
+| ---------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WarmIntrosV2Prototype.tsx`  | `WarmIntrosV2Workspace.tsx`      | `useQueryStates` (nuqs) → `useState`; `useWarmIntrosV2Paths` / `useWarmIntrosV2Facets` / `useGetInvestorLists` → mock selectors; infinite scroll dropped (14 rows fit one page); PostHog analytics dropped |
+| `InvestorDrawerMock.tsx`     | `WarmIntrosV2InvestorDrawer.tsx` | `useWarmIntrosV2PathsForInvestor` + `useMasterProfile` → mock lookups                                                                                                                                      |
+| `MasterProfileModalMock.tsx` | `MasterProfileModal.tsx`         | `useMasterProfile` → `MOCK_MASTER_PROFILES[uid]`; loading / error branches are inert                                                                                                                       |
+| `WarmIntrosV2TableMock.tsx`  | `WarmIntrosV2Table.tsx`          | **Team** and **Industry / Sector** columns removed (a design change, not a data one); firm · role folded under the investor name; column widths re-balanced in `TableColumns.module.scss`                  |
 
 ## New UI (prototype still; production twin shipped)
 
 Production counterparts live under
 `components/page/investors/WarmIntrosV2Workspace/`:
 
-| Prototype | Production |
-| --- | --- |
-| `PathFeedback.tsx` | `PathActions.tsx` (+ `PathFeedbackAdminSummary.tsx` for editors) |
-| `PathFeedbackModal.tsx` | `PathFeedbackModal.tsx` |
-| `PathFeedback.module.scss` | `PathFeedback.module.scss` |
-| — | `PathFeedbackQueuePanel.tsx` (admin queue; `investor_db.edit`) |
+| Prototype                  | Production                                                       |
+| -------------------------- | ---------------------------------------------------------------- |
+| `PathFeedback.tsx`         | `PathActions.tsx` (+ `PathFeedbackAdminSummary.tsx` for editors) |
+| `PathFeedbackModal.tsx`    | `PathFeedbackModal.tsx`                                          |
+| `PathFeedback.module.scss` | `PathFeedback.module.scss`                                       |
+| —                          | `PathFeedbackQueuePanel.tsx` (admin queue; `investor_db.edit`)   |
 
 Prototype keeps an in-memory `FEEDBACK_STORE`. Production wires
 `PUT/DELETE …/warm-intros-v2/paths/:uid/feedback` and enriches investor detail with
 `myFeedbackByConnector` / `feedbackSummaryByConnector`.
 
-| File | What it is |
-| --- | --- |
-| `PathFeedback.tsx` | The action strip at the foot of every grey path card (`.pathItem`): `Can you refer?` → inline Yes / No, an answered state with Undo, and the `Give feedback` link |
-| `PathFeedbackModal.tsx` | The feedback modal — the path restated as avatar chips, and one free-text box with a 600-char counter |
-| `PathFeedback.module.scss` | Styling for both. New UI, so every color is a `var(--token, #fallback)` pair per `prototypes/CLAUDE.md` §3–4 |
+| File                       | What it is                                                                                                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PathFeedback.tsx`         | The action strip at the foot of every grey path card (`.pathItem`): `Can you refer?` → inline Yes / No, an answered state with Undo, and the `Give feedback` link |
+| `PathFeedbackModal.tsx`    | The feedback modal — the path restated as avatar chips, and one free-text box with a 600-char counter                                                             |
+| `PathFeedback.module.scss` | Styling for both. New UI, so every color is a `var(--token, #fallback)` pair per `prototypes/CLAUDE.md` §3–4                                                      |
 
 Design intent, so it doesn't get re-litigated:
 
@@ -67,9 +69,9 @@ Design intent, so it doesn't get re-litigated:
   promotes the question to the left of the row, where Yes / No do get real button
   affordance; `Give feedback` stays pinned right so it never changes position.
 - **The modal restates the path with the drawer's own avatar chips** (`PathProfileChip.module.scss`
-  + the drawer's `.chain` / `.node` / `.arrow`), rendered as spans. `pointer-events: none`
-  drops the affordance without touching production's chip colors — mid-report is no
-  place to navigate off to a profile.
+  - the drawer's `.chain` / `.node` / `.arrow`), rendered as spans. `pointer-events: none`
+    drops the affordance without touching production's chip colors — mid-report is no
+    place to navigate off to a profile.
 - **Free text only.** The modal is one box. Nothing is pre-categorised, so whatever
   is wrong gets said in the reporter's own words rather than squeezed into a chip.
 - **`No` asks no follow-up.** The verdict is the signal. A "Why not?" chip row was
@@ -85,20 +87,269 @@ Design intent, so it doesn't get re-litigated:
 Markup inside those three is a verbatim transcription — if you change the shape of a
 row or a section, change it here on purpose, not by accident.
 
+## Synced from dev — co-investment filters (`268306185`, Aug 2026)
+
+Production grew a path-shape axis. The prototype tracks it:
+
+| Dev change                                                                               | Where it landed here                                                                                     |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Quick-filter chips: Founder bridge · Co-investor bridge · PL/FIL investors · Direct only | `WarmIntrosV2Prototype.tsx` (`s.quickFilters` / `s.quickChip`, mutually exclusive exactly as production) |
+| `relationKind` / `directOnly` / `plBacker` list params                                   | `filterPaths()` in `mocks.ts`                                                                            |
+| Two-hop bridge paths + `F+2` / `VC+2` proximity families                                 | `buildRow()` uses production's `hopCountFromRelationKind` + `proximityFamilyFromRelationKind`            |
+| `HopRoleBadge` beside each hop chip                                                      | table + drawer, wrapped in `s.pathHop`                                                                   |
+| Directory-member dot (`memberUid` on `PathProfileChip`) + `PL Network` row badge         | `WarmIntrosV2TableMock.tsx`                                                                              |
+| `MasterProfile.coInvestments`                                                            | drawer `s.coInvestBlock`, modal "Co-investments with PL" section                                         |
+| Alternates carry their own `relationKind`                                                | drawer derives the alt's code + role badge from it                                                       |
+
+No new local CSS: every class above already exists in the production modules this
+prototype imports.
+
+The table now renders the **hopChain** rather than connector → investor, so a
+founder or co-investor bridge shows all three chips. The two-chip branch is kept
+as production keeps it — a fallback for rows with no parsed chain.
+
+## Design change on top of dev — the filter bar
+
+Dev's bar asks "how does this intro get made?" **twice**: the `PL member` select
+answers it by person, three chips answer it by shape. They are one axis, so here
+they are one control — `PathViaSelect.tsx`, a grouped selector:
+
+| Group                 | Options                                    |
+| --------------------- | ------------------------------------------ |
+| Path type             | Direct · Via a founder · Via a co-investor |
+| PL member             | the six connectors                         |
+| Founder / co-investor | the five bridge people                     |
+
+This is the mediation axis as originally specced in `warm-intros-filter-update`
+(one grouped selector, teammates and founders together), with dev's third kind
+folded in. Single-select, so there is nothing beside it to silently clear — dev's
+chips null two sibling filters per click with no feedback.
+
+`Backed PL/FIL` stays a separate toggle: it describes the _investor_, not the
+route to them, so it is not a fourth pretend-shape on the axis.
+
+**Counts are honest.** `pathViaFacets` / `sectorFacets` / `plBackerCount` each
+count against the _other_ live filters via `filterPaths(filters, omit)`, so an
+option reading `(3)` returns three rows. Dev's `facetsForTargetSet` keyed off the
+target set alone and kept showing stale counts under an active chip.
+
+Also: active-filter pills + `Clear all` (imported from Warm Intros **v1**, which
+already has `.filterPills` / `.pill` / `.pillRemove` / `.clearAll`), the empty
+state carries a recovery action, `Export CSV` moved onto the results line where
+it acts on the result set rather than changing it, and the search placeholder now
+admits it matches the firm too.
+
+Dropped from dev: the `directOnly` param (it is `relationKind: 'pl_direct'` by
+another name) and `.quickChipToggle`'s dashed border (a third visual state with
+no meaning once position carries it).
+
+Local CSS is `FilterBar.module.scss` — layout only, plus a 40px height and a
+disabled state for the one toggle, because production's 32px `.quickChip` sits
+beside 40px selects here and never defined `:disabled`.
+
+## Design change on top of dev — two columns, not five
+
+| Production column       | Where it went                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Team, Industry / Sector | dropped; sectors remain in the drawer                                                                        |
+| firm · role             | under the investor name                                                                                      |
+| email                   | drawer + CSV only — nobody reads an address at a glance, and it mostly re-encoded the firm on the line above |
+| Proximity               | the joined badge now **leads** the path cell                                                                 |
+
+Proximity moved because the code _is_ a description of the chain: family = which
+bridge, `+N` = hops, `A`/`B` = caliber. Leading position is what makes it work —
+the badge's left edge lands at the same x on every row, so the top-to-bottom scan
+a dedicated column was buying survives without spending a column on it. Only the
+code's own width varies (`F+2A` is a character shorter than `PL+1A`), ~8px of
+jitter. Trailing the chain instead would scatter it across a variable-width row.
+
+Freeing the column pays for itself: Path goes 48% → 68%, so even after the badge
+takes ~95px the chain has more room than it had before.
+
+## Design change on top of dev — proximity + score joined, not merged
+
+`ProximityCodeBadge` has a `confidence` prop that renders the % **inside** the
+badge. Not used, deliberately: inside, the % inherits the **caliber** colour,
+which collapses the score band from three levels to two — yellow and red become
+one, so a 33% path reads identically to a 12% one. The filtering already cuts at
+20%, so that is a line someone drew on purpose.
+
+Instead the two stay separate elements butted together (`joinGroup` / `joinLeft` /
+`joinRight` in `TableColumns.module.scss`): no gap, inner corners squared, heights
+matched. One shape, two signals — caliber on the left, band on the right. Where
+they agree (caliber A is always >60, so A pairs with green) the fills match and
+the seam simply disappears.
+
+Joined only when both halves exist; a lone score pill with one squared edge would
+look broken.
+
+## Design change on top of dev — path evidence (`PathEvidence.tsx`)
+
+Two gaps in what dev shows about _why_ a path is claimed:
+
+**Reason provenance.** The payload puts `sourceType` on every reason and
+`parseWarmPathHopChain` reads it — `pickPrimaryReasonDescription` even prefers
+`webVerify` — but nothing ever rendered it. The drawer flattens reasons to strings
+via `allReasonDescriptions`, so a web-verified fact and a model's guess arrive
+looking identical. `ReasonList` keeps the pairing and prints the source after each
+line: `Web-verified` · `Shared event` · `Model-inferred`. Only the model-inferred
+one is italicised — a guess shouldn't read with the authority of a record.
+
+**Shared events.** `MasterProfile.events` exists per person and the modal lists it,
+but nothing computed the _overlap_ — you'd open both profiles and compare by eye.
+`SharedEventsNote` derives the intersection for each adjacent pair and reports it
+under the chain, because a shared event is a property of the **edge**, not of
+either person.
+
+> Copy rule: **"Both attended", never "met at".** Two people at a conference with
+> a few thousand attendees did not necessarily meet, and a UI that says they did is
+> asserting something the data cannot support. That is how someone sends a warm
+> intro request that lands cold.
+
+`EVENTS_BY_PROFILE` in `mocks.ts` is the single source for both the modal's event
+list and the derived overlap, so the two can never disagree. Overlaps are sparse
+on purpose — if everyone shared LabWeek the note would fire on every row and mean
+nothing. Seed `reasons` now accept `{ text, source }` alongside a bare string, so a
+seed can state its own provenance instead of inheriting the positional default.
+
+## Design change on top of dev — role labels cut to what carries information
+
+Dev renders `HopRoleBadge` after every hop chip — ~34 bordered pills across 14
+rows.
+
+**Only one of them is redundant: the last.** The final hop is the row's own
+investor by definition, so labelling it restates the subject of the row.
+
+Every other position is information. **A path does not have to start at a PL
+member** — `Founder → Investor` is a shape the backend emits, and production's own
+drawer builds its alternates exactly that way. `role` is a free-form string on the
+payload (`parseWarmPathHopChain.ts`) with nothing constraining hop 0, so
+`PathRole.tsx` reads it and never infers it from index.
+
+> An earlier revision of this prototype dropped the first hop's label on the
+> reasoning that "hop 0 is always the PL member". That was generalised from this
+> file's own mock data, which only emitted the 3-node chain. It is wrong, and
+> `bridgeLeads` now exists so the 2-node shape is represented here too.
+
+What does change is weight, not presence: the label loses its pill chrome and
+becomes a caption under the name — the shape Workable / Aboard / Peerlist use for
+a role that appears on every row.
+
+No colour system for roles. Proximity already colour-codes by caliber, and a
+second palette competing with the load-bearing one is what made the column noisy.
+Icon-only was rejected too: a dot works for binary status, not a four-way role,
+and it would carry meaning in colour alone.
+
+`.chainTop` overrides production's `align-items: center` on the chain — once one
+hop is two lines tall, centring lifts its chip off the line the others sit on.
+
+**Knock-on:** with the `Investor` role badge gone from the Path column, the violet
+the `Backed PL/FIL` pill borrows no longer echoes anywhere else in the row.
+
+## Design change on top of dev — PL backing made visible
+
+Dev added `plBacking` as a **filter with no display**: nothing in the table,
+drawer or profile ever renders it, so the only way to learn an investor backed
+Filecoin is to toggle the chip and see who survives. `PlHistory.tsx` shows the
+fact, which demotes the toggle to an ordinary filter over something visible.
+
+| Surface             | What it shows                                                               |
+| ------------------- | --------------------------------------------------------------------------- |
+| Table row           | Third fact-line under firm · title and email: the pill + `N co-investments` |
+| Investor drawer     | Pill beside the `Co-investments with PL` heading                            |
+| MasterProfile modal | Same, on the section title                                                  |
+
+The heading falls back to `Relationship with PL` when an investor is a backer but
+has no recorded co-investments, so the block never announces a count of zero.
+
+Label is `Backed PL` / `Backed Filecoin` / `Backed PL + FIL` — "backer" alone
+loses the useful half. `matchKind` (firm vs person) rides in the tooltip rather
+than lengthening the pill.
+
+**Colour.** Amber was the obvious pick and is wrong: `.listGold` already carries
+`Gold PLC` two lines above it in the same cell. Every other tone is load-bearing
+too — green is "directory member", indigo is the Neuro list, and the Proximity
+column owns green/yellow/red. So the pill borrows `HopRoleBadge`'s `.badge` +
+`.investor` violet: unspoken-for inside the investor cell, and the same 10px
+shape as `.directoryBadge`. It does share that violet with the `Investor` hop
+badge over in the Path column — different column, explicit label, and the least
+bad of the options.
+
+### Deliberate deviation from production's visual layer
+
+This is the **one** place the prototype overrides a production style rather than
+importing it, so it is called out rather than left to be discovered.
+
+Production's `.coInvestBlock` is a filled amber box — `#fff7ed` on `#fed7aa`,
+label `#c2410c`. Dev's logic is sound in production: that exact triplet is
+`HopRoleBadge`'s `.coInvestor`, so orange consistently means co-investor.
+
+Three things break it here:
+
+1. **A filled amber box with an amber border is the shape of a warning.** This is
+   good news — an existing relationship with PL — and it's the only tinted box in
+   the drawer, so it alerts on the section that should reassure.
+2. **The link it depends on is gone.** Orange-means-co-investor only reads if the
+   orange co-investor badge is nearby; role badges became plain grey captions, so
+   `.coInvestor` orange renders nowhere in this drawer.
+3. **Amber is already spoken for** by the `Gold PLC` list chip.
+
+`h.coInvestPlain` swaps the fill for the hairline the drawer already uses
+elsewhere. **Take this back to dev as a proposal** — do not let it become silent
+drift.
+
+**Count as a chip on the name line.** The co-investment count moved up beside the
+list chip, reusing the drawer's own `.count` so the number is the same object on
+both surfaces. It carries the violet marker rather than a bare digit — next to a
+list chip, a lone "3" would read as "3 lists" — and it retires the repeated
+"co-investments" noun that used to run down the column. The backing mark keeps
+the third line to itself.
+
+**Colour budget.** The cell had four hues in ~60px — blue name, green
+`PL Network`, amber list badge, violet backing — so nothing receded. Two cuts
+fixed it: the `PL Network` badge went (the investor's own chip in the Path column
+already carries the green Directory dot, so the row said it twice), and the
+backing text dropped to neutral grey with only the 6px marker keeping the violet.
+What's left is one blue name, one amber badge, one small dot.
+
+> Tradeoff taken knowingly: a dot is less discoverable than the words
+> "PL Network". It has a tooltip. If Directory membership turns out to be
+> something people act on rather than notice, the badge comes back and something
+> else gives.
+
+**Marker, not a pill.** Attio renders connection strength as a small coloured
+glyph plus plain words — no border, no fill. Once the email line came out, a
+filled pill here was the loudest thing in the cell after the name, over-weighting
+a secondary fact. One treatment on all three surfaces, so the same fact never has
+two looks.
+
+**The repeated noun is handled by weight, not by deletion.** `co-investments`
+repeats down the column while only the number changes. Cutting the word leaves an
+ambiguous bare digit, and a shorter synonym would contradict the drawer's
+"Co-investments with PL" — so the numeral takes the primary ink and the noun sits
+in tertiary grey. You scan the digits; the word becomes texture.
+
 ## Mock data (`mocks.ts`)
 
 - 14 investors across the two real target sets (`neuro-fund-i`, `gold-co-investors`)
 - 6 PL connectors, mirroring the "six connectors" the glossary describes
+- 5 bridge people (3 founders, 2 co-investors) — the middle hop, each with its own
+  MasterProfile so the middle chip opens something
+- 5 rows are bridges (3 founder, 2 co-investor); 4 investors carry `plBacking`,
+  4 carry `coInvestments`, so every quick filter returns a non-empty set
 - `derivePathProximity()` (production) generates every `proximityCode`, `caliber`,
   `scorePercent` and `scoreBand`, so band colors match production rules exactly
-- `hopChain` uses the real `pl_direct` shape: `hops` / `reasons` / `alternates`
+- `hopChain` uses the real shapes: `pl_direct` (1 hop), `founder_bridge` and
+  `coinvestor_bridge` (2 hops) — `hops` / `reasons` / `alternates`
 - A `MasterProfileDetail` exists for every investor **and** connector, so every chip
   in the table and drawer opens a populated modal
 - All names, firms, emails and Affinity ids are invented
 
 ## Local CSS
 
-`TableColumns.module.scss` only — three column widths and the table's `min-width`,
+`TableColumns.module.scss` and `FilterBar.module.scss`.
+
+`TableColumns.module.scss` — three column widths and the table's `min-width`,
 needed because production's 22/18/18/14/28 split assumed five columns. Layout values
-only, no colors, so there is nothing to token-swap. Any *new* styling beyond this
+only, no colors, so there is nothing to token-swap. Any _new_ styling beyond this
 must use `var(--token, #fallback)` pairs per `prototypes/CLAUDE.md` §3.

--- a/prototypes/entries/warm-intros-v2/CheckSelect.tsx
+++ b/prototypes/entries/warm-intros-v2/CheckSelect.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+/**
+ * Multi-select with a checkbox on every option, shared by "Path via" (grouped,
+ * see PathViaSelect) and "Industry / Sector" (flat, below).
+ *
+ * Four settings between them are what stop the menu moving under the pointer when
+ * you tick something. They are the whole point of this file:
+ *
+ *   closeMenuOnSelect={false}     a tick is not "I'm finished"
+ *   hideSelectedOptions={false}   the row you just ticked stays where it was —
+ *                                 the default removes it, so the list collapses
+ *                                 upward and the next row lands under your cursor
+ *   controlShouldRenderValue={false}  no chips growing the control, which would
+ *                                 push the menu down as you select
+ *   blurInputOnSelect={false}     keeps focus and scroll position in the menu
+ *
+ * The count goes in the placeholder instead of chips, so the control is exactly
+ * as tall with five selections as with none.
+ */
+
+import Select, {
+  components,
+  type CSSObjectWithLabel,
+  type GroupBase,
+  type OptionProps,
+  type StylesConfig,
+} from 'react-select';
+import { Checkbox } from '@/components/common/Checkbox/Checkbox';
+import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
+import type { Option } from '@/components/form/FormSelect/types';
+import { dsIndicators } from './FilterSelectThin';
+import s from './PathViaSelect.module.scss';
+
+/**
+ * The DS `Checkbox` plus the label, inside react-select's own option wrapper — so
+ * highlight, keyboard handling and group structure stay react-select's and only
+ * the indicator is ours.
+ *
+ * The checkbox is `aria-hidden` and non-interactive: the option already carries
+ * `role="option"` and `aria-selected`, so a second focusable control inside it
+ * would be announced twice and would swallow the click meant for the option.
+ */
+export function CheckboxOption<Group extends GroupBase<Option>>(props: OptionProps<Option, true, Group>) {
+  return (
+    <components.Option {...props}>
+      <span className={s.optionRow}>
+        <span className={s.optionBox} aria-hidden>
+          <Checkbox checked={props.isSelected} />
+        </span>
+        {props.label}
+      </span>
+    </components.Option>
+  );
+}
+
+/** The settings above, in one place, for any multi-select in this filter bar. */
+export const steadyMenuProps = {
+  isMulti: true,
+  closeMenuOnSelect: false,
+  hideSelectedOptions: false,
+  controlShouldRenderValue: false,
+  blurInputOnSelect: false,
+} as const;
+
+/**
+ * Production's filter styles, plus one fix these multi-selects create.
+ *
+ * `controlShouldRenderValue: false` means the chosen values are never drawn, so
+ * react-select falls back to the placeholder — and `filterSelectStyles.placeholder`
+ * is `#cbd5e1` at weight 300, i.e. the "nothing here" treatment. Meanwhile
+ * `control` keys off `hasValue` and turns the box blue. The result reads as a
+ * control that is simultaneously filled and empty.
+ *
+ * With a selection the summary is a value, so it takes `singleValue`'s own colour
+ * and weight. Without one it stays the placeholder it actually is.
+ */
+const basePlaceholder = filterSelectStyles.placeholder as
+  | ((base: CSSObjectWithLabel, state: unknown) => CSSObjectWithLabel)
+  | undefined;
+
+export const checkSelectStyles: StylesConfig<Option, true, GroupBase<Option>> = {
+  ...(filterSelectStyles as unknown as StylesConfig<Option, true, GroupBase<Option>>),
+  placeholder: (base, state) => ({
+    ...(basePlaceholder ? basePlaceholder(base, state) : base),
+    ...(state.hasValue
+      ? { color: 'var(--foreground-brand-primary, #1b4dff)', fontWeight: 400 }
+      : {}),
+  }),
+};
+
+interface Props {
+  options: Option[];
+  value: string[];
+  onChange: (values: string[]) => void;
+  /** Shown alone when nothing is picked, and with a count when something is. */
+  placeholder: string;
+  'aria-label': string;
+  isSearchable?: boolean;
+}
+
+export function CheckSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+  'aria-label': ariaLabel,
+  isSearchable = true,
+}: Props) {
+  const selected = options.filter((opt) => value.includes(opt.value));
+
+  return (
+    <Select<Option, true, GroupBase<Option>>
+      {...steadyMenuProps}
+      aria-label={ariaLabel}
+      options={options}
+      value={selected}
+      onChange={(opts) => onChange([...(opts ?? [])].map((opt) => opt.value))}
+      placeholder={value.length > 0 ? `${placeholder} · ${value.length}` : placeholder}
+      isClearable
+      isSearchable={isSearchable}
+      styles={checkSelectStyles}
+      components={{ ...dsIndicators, Option: CheckboxOption }}
+      menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+      menuPosition="fixed"
+      noOptionsMessage={() => 'Nothing matches the other filters'}
+    />
+  );
+}

--- a/prototypes/entries/warm-intros-v2/ChipPress.module.scss
+++ b/prototypes/entries/warm-intros-v2/ChipPress.module.scss
@@ -1,0 +1,37 @@
+/**
+ * Press and focus states for the person chips in a hop chain.
+ *
+ * `PathProfileChip` styles `:hover` and nothing else. On a pointer that is enough
+ * — the chip lights up before you commit. On touch no hover event fires at all, so
+ * the chip's entire affordance is the pill shape: you tap it and a modal appears,
+ * with nothing in between confirming the tap landed on something interactive.
+ *
+ * `:active` closes that gap using the values the chip already defines for hover
+ * (`PathProfileChip.module.scss`: `#eef2ff` fill, `#1b4dff` border and text), so
+ * this adds a state, not a colour. On a pointer it doubles as the press feedback
+ * hover was already implying.
+ *
+ * `:focus-visible` comes along for the same reason it did on the investor name:
+ * production defines no focus style anywhere on these chips, so a keyboard user
+ * tabbing through a three-hop chain gets no indication of where they are.
+ *
+ * Targeted by element rather than by class because `PathProfileChip` takes no
+ * `className`, and by `button` specifically because the non-interactive org stubs
+ * render as `<span>` — they should not light up, and this way they can't.
+ * `.chipPress button` (0,1,1) also clears production's single-class `.chip`
+ * without depending on stylesheet order.
+ */
+
+.chipPress button:active,
+.chipPress button:focus-visible {
+  background: var(--background-brand-subtle, #eef2ff);
+  border-color: var(--foreground-brand-primary, #1b4dff);
+  color: var(--foreground-brand-primary, #1b4dff);
+}
+
+/* Focus also gets a ring — press is momentary and self-evident, focus persists and
+   has to be findable at a glance. Matches the offset the DS `Checkbox` uses. */
+.chipPress button:focus-visible {
+  outline: 2px solid var(--action-background-brand-normal, #1b4dff);
+  outline-offset: 2px;
+}

--- a/prototypes/entries/warm-intros-v2/FilterBar.module.scss
+++ b/prototypes/entries/warm-intros-v2/FilterBar.module.scss
@@ -1,0 +1,159 @@
+/**
+ * Layout-only additions for the reworked filter bar. No colors, no type sizes —
+ * those all come from the production modules the prototype imports
+ * (`WarmIntrosV2Workspace.module.scss` for the bar, `WarmIntrosWorkspace.module.scss`
+ * for the active-filter pills), so there is nothing here to token-swap.
+ *
+ * Two things production's own classes can't do:
+ *   - `.meta` is a bare text line; Export now sits on it, so it needs to be a row
+ *   - the pill row and the empty state need their own spacing under the bar
+ */
+
+/**
+ * Production's `.quickChip` is 32px because it lived in a row of other chips.
+ * Here it sits beside 40px selects, so it takes their height — and it needs a
+ * disabled state, which production never defined: at 0 matches the toggle was
+ * inert but looked identical to a live one.
+ */
+/**
+ * Squared off to match the selects.
+ *
+ * Production's `.quickChip` is `border-radius: 999px` at `height: 32px` — a small
+ * pill among other small chips, which is where it was designed to sit. Raising it
+ * to 40px to line up with the selects is what made the roundness conspicuous: a
+ * 999px radius at 40px tall stops being a chip and becomes a stadium beside three
+ * 8px fields.
+ *
+ * It stays a toggle rather than becoming a checkbox. Across the B2B data-table
+ * products on Mobbin (Deel, Twenty, Databricks, Amplitude, Base44, Clay, Attio,
+ * LangChain, Braintrust, Basedash, Confluence) checkboxes appear only *inside*
+ * dropdown panels, never loose in the toolbar; toolbar filters are small-radius
+ * chips, and Databricks' one binary switch lives inside the filter popover. Deel's
+ * bar is the closest analogue — uniform-height, uniform-radius chips, one carrying
+ * a count badge, which is exactly this control.
+ *
+ * The rule is not "8px" as such, it is that the toggle and the selects share one
+ * radius. Theirs is 8px. It also keeps the semantics: this is a momentary lens
+ * deliberately kept out of the facet set, which is what a toggle reads as.
+ */
+.axisToggle {
+  height: 40px;
+  border-radius: 8px;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+
+    &:hover {
+      border-color: #e5e7eb;
+      color: #455468;
+    }
+  }
+}
+
+/**
+ * Present for screen readers, gone visually — the same technique the table's
+ * `mobile-only` block uses to keep column names in the a11y tree. `display: none`
+ * would remove the label from that tree along with the pixels, which is the whole
+ * thing being fixed.
+ */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* Results count on the left, view tabs beside it, Export at the right edge. */
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/**
+ * The variant switcher, on the results line rather than above the table: it
+ * changes how the same result set is drawn, so it belongs with the sentence that
+ * says how many results there are — not in the row of controls that change *which*
+ * results there are.
+ *
+ * DS `Tabs` at `variant="pill"` is already a segmented control (grey track, white
+ * raised indicator, 8px radius). Only the type scale comes down: it ships at 16px
+ * for page-level tabs, which would outweigh the 13px count it sits next to.
+ */
+.viewTabs {
+  flex: 0 0 auto;
+}
+
+.viewTab {
+  padding: 4px 10px;
+}
+
+.viewTabLabel {
+  font-size: 13px;
+  line-height: 18px;
+  letter-spacing: normal;
+}
+
+.metaRowSpacer {
+  margin-left: auto;
+}
+
+/**
+ * Export CSV becomes the blue primary its siblings already are.
+ *
+ * Production's `.exportBtn` is white because in `WarmIntrosV2Workspace.tsx` that
+ * class dresses *two* buttons — the feedback queue and Export — sitting in the row
+ * of 40px filter selects. It is generic secondary chrome sized to match the
+ * selects, not an export treatment. The two sibling table pages both render the
+ * same action as a blue primary:
+ * `InvestorsTableSection.module.scss` `.exportBtn` and
+ * `FoundersTableSection.module.scss` `.exportBtn` are byte-for-byte the same rule
+ * — `#1b4dff` on `#fff`, 36px, radius 6, weight 600, hover `#1a3fd9`.
+ *
+ * Export has moved onto the results line here, so it is no longer one of a row of
+ * filter controls and no longer needs to match their height. Its geometry is
+ * copied from `InvestorsTableSection` — the closest sibling, same feature area —
+ * rather than kept at production's select-matching 40px/8px.
+ *
+ * Note on tokens: `--action-background-brand-normal` is verified in
+ * `Tabs.module.scss` and `UnsavedChangesPrompt.module.scss`. No token name exists
+ * anywhere for the `#1a3fd9` hover — every file writes it raw — so the name below
+ * is extrapolated from the sibling `--action-foreground-brand-hover` that forum's
+ * `CommentItem.module.scss` uses. The fallback renders identically today.
+ */
+.exportPrimary.exportPrimary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  background: var(--action-background-brand-normal, #1b4dff);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  transition: background 0.12s;
+
+  &:hover:not(:disabled) {
+    background: var(--action-background-brand-hover, #1a3fd9);
+    box-shadow: none;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+  }
+}
+
+/* The empty state has to hold a recovery action, so it stops being a bare line. */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}

--- a/prototypes/entries/warm-intros-v2/FilterBar.module.scss
+++ b/prototypes/entries/warm-intros-v2/FilterBar.module.scss
@@ -36,8 +36,10 @@
  * radius. Theirs is 8px. It also keeps the semantics: this is a momentary lens
  * deliberately kept out of the facet set, which is what a toggle reads as.
  */
-.axisToggle {
+.axisToggle.axisToggle {
   height: 40px;
+  /* Doubled: production's `.quickChip` carries `border-radius: 999px` and a single
+     class ties it, so which one won came down to bundle order. It lost. */
   border-radius: 8px;
 
   &:disabled {

--- a/prototypes/entries/warm-intros-v2/FilterSelectThin.tsx
+++ b/prototypes/entries/warm-intros-v2/FilterSelectThin.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+/**
+ * The filter selects, with the design system's chevron instead of react-select's.
+ *
+ * `filterSelectStyles` styles the *container* around the dropdown indicator — its
+ * colour (`#1b4dff` with a value, `#455468` without) and its `0 8px` padding — but
+ * the glyph inside it is react-select's own built-in caret: a chunky filled wedge
+ * on a 20×20 viewBox. Nothing in this codebase drew it; it arrived with the
+ * library. Next to 14px text at weight 300–400 it is the heaviest mark in the
+ * filter bar.
+ *
+ * `@/components/icons/ChevronDownIcon` is the house glyph — a hairline chevron on
+ * a 16×16 box, `currentColor`, already used elsewhere in the app. Swapping it in
+ * is a substitution, not a restyle: you cannot thin a filled path with CSS.
+ *
+ * Only the glyph changes. Wrapping in `components.DropdownIndicator` keeps
+ * react-select's own indicator container, so `filterSelectStyles`' colour and
+ * padding rules still apply untouched — including the blue-when-selected state.
+ *
+ * `FilterSelectThin` is otherwise a verbatim transcription of production's
+ * `FilterSelect` (same props, same react-select config, same `filterSelectStyles`,
+ * same portal + fixed position). It exists only because `FilterSelect` takes no
+ * `components` prop, so the indicator cannot be passed in from outside.
+ */
+
+import Select, { components, type DropdownIndicatorProps, type GroupBase } from 'react-select';
+import { ChevronDownIcon } from '@/components/icons';
+import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
+import type { Option } from '@/components/form/FormSelect/types';
+
+function DropdownIndicator<IsMulti extends boolean, Group extends GroupBase<Option>>(
+  props: DropdownIndicatorProps<Option, IsMulti, Group>,
+) {
+  return (
+    <components.DropdownIndicator {...props}>
+      <ChevronDownIcon />
+    </components.DropdownIndicator>
+  );
+}
+
+/** Spread into any local react-select instance to pick up the same chevron. */
+export const thinChevron = { DropdownIndicator };
+
+interface Props {
+  readonly options: Option[];
+  readonly value: Option | null;
+  readonly onChange: (value: Option | null) => void;
+  readonly placeholder?: string;
+  readonly isClearable?: boolean;
+  readonly isSearchable?: boolean;
+  readonly isDisabled?: boolean;
+  readonly 'aria-label'?: string;
+  readonly title?: string;
+}
+
+export function FilterSelectThin({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select…',
+  isClearable = false,
+  isSearchable = false,
+  isDisabled = false,
+  'aria-label': ariaLabel,
+  title,
+}: Props) {
+  return (
+    <div title={title}>
+      <Select
+        inputId={ariaLabel ? undefined : 'filter-select'}
+        aria-label={ariaLabel}
+        options={options}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        isClearable={isClearable}
+        isSearchable={isSearchable}
+        isDisabled={isDisabled}
+        styles={filterSelectStyles}
+        components={thinChevron}
+        menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+        menuPosition="fixed"
+      />
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/FilterSelectThin.tsx
+++ b/prototypes/entries/warm-intros-v2/FilterSelectThin.tsx
@@ -24,8 +24,13 @@
  * `components` prop, so the indicator cannot be passed in from outside.
  */
 
-import Select, { components, type DropdownIndicatorProps, type GroupBase } from 'react-select';
-import { ChevronDownIcon } from '@/components/icons';
+import Select, {
+  components,
+  type ClearIndicatorProps,
+  type DropdownIndicatorProps,
+  type GroupBase,
+} from 'react-select';
+import { ChevronDownIcon, CloseIcon } from '@/components/icons';
 import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
 import type { Option } from '@/components/form/FormSelect/types';
 
@@ -39,8 +44,34 @@ function DropdownIndicator<IsMulti extends boolean, Group extends GroupBase<Opti
   );
 }
 
-/** Spread into any local react-select instance to pick up the same chevron. */
-export const thinChevron = { DropdownIndicator };
+/**
+ * The clear button, same substitution as the chevron.
+ *
+ * react-select's built-in clear glyph is a heavy filled X on a 20×20 viewBox — it
+ * arrived with the library, nothing here drew it, and beside a hairline chevron it
+ * is the heaviest mark in the control. `CloseIcon` is the house glyph (16×16,
+ * `currentColor`, 1.5px round-capped strokes) and is what the DS `SearchInput`
+ * already uses to clear itself, so the two clear affordances in this bar finally
+ * match.
+ *
+ * `filterSelectStyles.clearIndicator` still supplies the container's colour and
+ * padding — only the glyph inside changes.
+ */
+function ClearIndicator<IsMulti extends boolean, Group extends GroupBase<Option>>(
+  props: ClearIndicatorProps<Option, IsMulti, Group>,
+) {
+  return (
+    <components.ClearIndicator {...props}>
+      <CloseIcon />
+    </components.ClearIndicator>
+  );
+}
+
+/**
+ * Spread into any local react-select instance to pick up the house chevron and
+ * clear icon in place of react-select's built-ins.
+ */
+export const dsIndicators = { DropdownIndicator, ClearIndicator };
 
 interface Props {
   readonly options: Option[];
@@ -78,7 +109,7 @@ export function FilterSelectThin({
         isSearchable={isSearchable}
         isDisabled={isDisabled}
         styles={filterSelectStyles}
-        components={thinChevron}
+        components={dsIndicators}
         menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
         menuPosition="fixed"
       />

--- a/prototypes/entries/warm-intros-v2/InvestorDrawerMock.tsx
+++ b/prototypes/entries/warm-intros-v2/InvestorDrawerMock.tsx
@@ -20,16 +20,27 @@ import type { SectorTag } from '@/services/investors/types';
 import type { WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
 import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
 import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
+import { hopRoleFromRelationKind } from '@/components/page/investors/WarmIntrosV2Workspace/HopRoleBadge';
+import { parseCoInvestments } from '@/components/page/investors/WarmIntrosV2Workspace/masterProfileDisplay.util';
 import {
   affinityPersonUrl,
   allReasonDescriptions,
   derivePathProximity,
   explanationFromHopChain,
+  hopCountFromRelationKind,
   parseWarmPathHopChain,
+  proximityFamilyFromRelationKind,
   reasonDescription,
   type WarmPathV2HopNode,
 } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
 import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2InvestorDrawer.module.scss';
+import c from './TableColumns.module.scss';
+import { PathHop } from './PathRole';
+import role from './PathRole.module.scss';
+import { ReasonList, SharedEventsNote } from './PathEvidence';
+import { PlBackingMark, plBackingLabel } from './PlHistory';
+import h from './PlHistory.module.scss';
+import press from './ChipPress.module.scss';
 import { PathActions } from './PathFeedback';
 import { MOCK_MASTER_PROFILES, pathsForInvestor } from './mocks';
 
@@ -51,18 +62,28 @@ function PathHopRow({
 }) {
   if (hops.length === 0) return null;
   return (
-    <div className={s.chain}>
-      {hops.map((hop, i) => (
-        <span key={`${hop.profileUid}-${i}`} className={s.node}>
-          {i > 0 && <span className={s.arrow}>→</span>}
-          <PathProfileChip
-            name={hop.name}
-            profileUid={hop.profileUid}
-            imageUrl={imageByUid.get(hop.profileUid)}
-            onOpen={onOpen}
-          />
-        </span>
-      ))}
+    // Same chips as the table, so the same press/focus states — the drawer is a
+    // touch surface too, and hover reaches neither.
+    <div className={`${s.chain} ${press.chipPress}`}>
+      {hops.map((hop, i) => {
+        const isOrg = hop.role === 'pl_org' || !hop.profileUid;
+        return (
+          <span key={`${hop.profileUid}-${i}`} className={s.node}>
+            {i > 0 && <span className={s.arrow}>→</span>}
+            {/* Same rule as the table: label every hop but the last. */}
+            <PathHop role={hop.role} isLast={i === hops.length - 1}>
+              <PathProfileChip
+                name={hop.name}
+                profileUid={hop.profileUid}
+                imageUrl={isOrg ? null : imageByUid.get(hop.profileUid)}
+                onOpen={onOpen}
+                nonInteractive={isOrg}
+                memberUid={isOrg ? null : hop.memberUid}
+              />
+            </PathHop>
+          </span>
+        );
+      })}
     </div>
   );
 }
@@ -81,6 +102,7 @@ export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: 
   const masterProfile = open && profileUid ? MOCK_MASTER_PROFILES[profileUid] : undefined;
 
   const [showAlternates, setShowAlternates] = useState(true);
+  const coInvestments = useMemo(() => parseCoInvestments(masterProfile?.coInvestments), [masterProfile?.coInvestments]);
 
   const bestPath = useMemo(() => {
     const paths = detail?.paths ?? [];
@@ -248,6 +270,30 @@ export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: 
                   <SectorTagsList tags={sectors} max={20} />
                 </dd>
               </dl>
+              {/* Dev filters on plBacking but never renders it. The drawer was
+                  showing one half of the PL relationship and not the other.
+
+                  Untinted via `h.coInvestPlain` — production ships this as a
+                  filled amber box, which reads as a warning on what is good news.
+                  Deliberate deviation, flagged in COMPONENTS.md. */}
+              {coInvestments.length > 0 || plBackingLabel(masterProfile?.plBacking) ? (
+                <div className={`${s.coInvestBlock} ${h.coInvestPlain}`}>
+                  <div className={`${s.coInvestLabel} ${h.coInvestPlainLabel}`}>
+                    {coInvestments.length > 0 ? 'Co-investments with PL' : 'Relationship with PL'}
+                    {coInvestments.length > 0 ? <span className={s.count}>{coInvestments.length}</span> : null}
+                    <PlBackingMark backing={masterProfile?.plBacking} className={h.inline} />
+                  </div>
+                  {coInvestments.length > 0 ? (
+                    <div className={s.coInvestNames}>
+                      {coInvestments
+                        .slice(0, 5)
+                        .map((c) => c.name)
+                        .join(', ')}
+                      {coInvestments.length > 5 ? ` +${coInvestments.length - 5} more` : ''}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
               <button type="button" className={s.linkBtn} onClick={() => onOpenMasterProfile(investor.profileUid)}>
                 View full profile
               </button>
@@ -267,23 +313,37 @@ export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: 
                 <>
                   <div className={s.pathItem}>
                     <div className={s.pathMeta}>
-                      {bestPath.proximityCode ? <ProximityCodeBadge code={bestPath.proximityCode} /> : null}
-                      <ScorePercentPill scorePercent={bestPath.scorePercent} scoreBand={bestPath.scoreBand} />
+                      {/* Same joined object as the table — one fact should not
+                          have two shapes across two surfaces. Wrapped rather
+                          than collapsing `.pathMeta`'s gap, so "Best path" keeps
+                          its spacing. */}
+                      <span className={c.joinGroup}>
+                        {bestPath.proximityCode ? (
+                          <ProximityCodeBadge code={bestPath.proximityCode} className={c.joinLeft} />
+                        ) : null}
+                        <ScorePercentPill
+                          scorePercent={bestPath.scorePercent}
+                          scoreBand={bestPath.scoreBand}
+                          className={bestPath.proximityCode ? c.joinRight : undefined}
+                        />
+                      </span>
                       <span className={s.warmth}>Best path</span>
                     </div>
                     <p className={s.warmthSubtitle}>How strong this intro route is</p>
+                    {/* Reasons keep their `sourceType` here — production drops it
+                        on the floor, so a verified fact and a model's guess look
+                        the same. */}
                     {reasonLines.length > 0 ? (
-                      <ul className={s.reasonList}>
-                        {reasonLines.map((line) => (
-                          <li key={line}>{line}</li>
-                        ))}
-                      </ul>
+                      <ReasonList reasons={hopChain?.reasons ?? []} listClassName={s.reasonList} />
                     ) : explanation ? (
                       <div className={s.explanation}>{explanation}</div>
                     ) : null}
-                    <div className={s.chainRow}>
+                    <div className={`${s.chainRow} ${role.chainRowTight}`}>
                       <PathHopRow hops={hops} imageByUid={imageByUid} onOpen={onOpenMasterProfile} />
                     </div>
+                    {/* Overlap between adjacent hops — a property of the edge, so
+                        it sits under the chain rather than on either chip. */}
+                    <SharedEventsNote hops={hops} />
                     {/* Design change: the card ends in a referral answer + a
                         feedback escape hatch. Keyed by path so re-opening the
                         drawer shows what was already answered. */}
@@ -317,7 +377,15 @@ export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: 
                       {showAlternates ? (
                         <ul className={s.altList}>
                           {alternates.map((alt) => {
-                            const derived = derivePathProximity(alt.score, bestPath.hopCount ?? 1);
+                            // An alternate can reach the investor through a
+                            // different shape than the best path, so its code
+                            // and its role badge come from its own kind.
+                            const altKind = alt.relationKind ?? hopChain?.relationKind;
+                            const derived = derivePathProximity(
+                              alt.score,
+                              hopCountFromRelationKind(altKind),
+                              proximityFamilyFromRelationKind(altKind),
+                            );
                             const proximityCode = alt.proximityCode ?? derived?.proximityCode ?? null;
                             const pct = alt.scorePercent ?? derived?.scorePercent ?? null;
                             const scoreBand = alt.scoreBand ?? derived?.scoreBand;
@@ -327,22 +395,35 @@ export function InvestorDrawerMock({ row, open, onClose, onOpenMasterProfile }: 
                             return (
                               <li key={alt.profileUid} className={s.pathItem}>
                                 <div className={s.pathMeta}>
-                                  {proximityCode ? <ProximityCodeBadge code={proximityCode} /> : null}
-                                  {pct != null ? <ScorePercentPill scorePercent={pct} scoreBand={scoreBand} /> : null}
+                                  <span className={c.joinGroup}>
+                                    {proximityCode ? (
+                                      <ProximityCodeBadge code={proximityCode} className={c.joinLeft} />
+                                    ) : null}
+                                    {pct != null ? (
+                                      <ScorePercentPill
+                                        scorePercent={pct}
+                                        scoreBand={scoreBand}
+                                        className={proximityCode ? c.joinRight : undefined}
+                                      />
+                                    ) : null}
+                                  </span>
                                 </div>
                                 {altReason ? <div className={s.explanation}>{altReason}</div> : null}
-                                <div className={s.chainRow}>
+                                <div className={`${s.chainRow} ${role.chainRowTight}`}>
                                   <PathHopRow
                                     hops={[
                                       {
                                         profileUid: alt.profileUid,
                                         name: alt.name,
-                                        role: 'pl_connector',
+                                        role: hopRoleFromRelationKind(altKind),
+                                        memberUid: alt.memberUid,
+                                        imageUrl: alt.imageUrl,
                                       },
                                       {
                                         profileUid: investor.profileUid,
                                         name: investor.name,
                                         role: 'investor',
+                                        memberUid: investor.memberUid,
                                       },
                                     ]}
                                     imageByUid={imageByUid}

--- a/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
+++ b/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
@@ -314,7 +314,18 @@ export function MasterProfileModalMock({ profileUid, open, onClose }: Props) {
                   <h4 className={s.sectionTitle}>Locations</h4>
                   <div className={s.pillRow}>
                     {locations.map((loc) => (
-                      <span key={loc} className={s.tag}>
+                      // The house pin (`/icons/location.svg`, the same asset
+                      // `member-list-view` and `irl-card` use, at the 11×13 the
+                      // member list renders it). Its `#94A3B8` is lighter than the
+                      // tag's `#455468` text, which is right for a glyph that
+                      // labels rather than competes — and it means the pin does not
+                      // need a colour decision of its own.
+                      //
+                      // Decorative, so `alt=""`: the section heading already says
+                      // "Locations", and "location Remote" read out twice helps
+                      // nobody.
+                      <span key={loc} className={`${s.tag} ${chrome.locationTag}`}>
+                        <img src="/icons/location.svg" alt="" width={11} height={13} aria-hidden />
                         {loc}
                       </span>
                     ))}

--- a/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
+++ b/prototypes/entries/warm-intros-v2/MasterProfileModalMock.tsx
@@ -24,6 +24,7 @@ import { getContactLogoByProvider } from '@/utils/profile/getContactLogoByProvid
 import { affinityPersonUrl } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
 import {
   eventsFromProfile,
+  parseCoInvestments,
   parseEducation,
   parseExperience,
   parseInvestorMetaFields,
@@ -41,6 +42,8 @@ import s from '@/components/page/investors/WarmIntrosV2Workspace/MasterProfileMo
 import m from '@/components/page/deals/SubmitDealModal/SubmitDealModal.module.scss';
 import c from './ContactRow.module.scss';
 import chrome from './ModalChrome.module.scss';
+import { PlBackingMark, plBackingLabel } from './PlHistory';
+import h from './PlHistory.module.scss';
 import { MOCK_MASTER_PROFILES } from './mocks';
 
 interface Props {
@@ -63,6 +66,7 @@ export function MasterProfileModalMock({ profileUid, open, onClose }: Props) {
   const locations = useMemo(() => parseLocationLabels(data?.locations), [data?.locations]);
   const lists = useMemo(() => parseListMemberships(data?.listMemberships), [data?.listMemberships]);
   const investorFields = useMemo(() => parseInvestorMetaFields(data?.investorMeta), [data?.investorMeta]);
+  const coInvestments = useMemo(() => parseCoInvestments(data?.coInvestments), [data?.coInvestments]);
   const projects = useMemo(() => (data ? projectsFromProfile(data) : []), [data]);
   const events = useMemo(() => (data ? eventsFromProfile(data) : []), [data]);
   const snapshots = useMemo(() => summarizeSourceSnapshots(data?.sourceSnapshots), [data?.sourceSnapshots]);
@@ -217,6 +221,30 @@ export function MasterProfileModalMock({ profileUid, open, onClose }: Props) {
                       </div>
                     ))}
                   </dl>
+                </section>
+              ) : null}
+
+              {coInvestments.length > 0 || plBackingLabel(data.plBacking) ? (
+                <section className={s.section}>
+                  <h4 className={s.sectionTitle}>
+                    {coInvestments.length > 0 ? 'Co-investments with PL' : 'Relationship with PL'}
+                    {coInvestments.length > 0 ? <span className={s.count}>{coInvestments.length}</span> : null}
+                    {/* Same pill as the row and the drawer — one fact, one look. */}
+                    <PlBackingMark backing={data.plBacking} className={h.inline} />
+                  </h4>
+                  <ul className={s.itemList}>
+                    {coInvestments.map((item) => {
+                      const meta = [item.dealStage, item.dealDate, item.isLeadInvestor ? 'Lead' : null, item.dealAmount]
+                        .filter(Boolean)
+                        .join(' · ');
+                      return (
+                        <li key={item.teamUid || item.name} className={s.item}>
+                          <div className={s.itemPrimary}>{item.name}</div>
+                          {meta ? <div className={s.itemSecondary}>{meta}</div> : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
                 </section>
               ) : null}
 

--- a/prototypes/entries/warm-intros-v2/ModalChrome.module.scss
+++ b/prototypes/entries/warm-intros-v2/ModalChrome.module.scss
@@ -42,3 +42,18 @@
   line-height: 24px;
   letter-spacing: -0.2px;
 }
+
+/**
+ * A location tag carries the house pin.
+ *
+ * Production's `.tag` is already `inline-flex; align-items: center` — it just has
+ * no gap, because until now nothing sat inside it but text. 6px is the same
+ * distance the shared-events chips put between their calendar glyph and label, so
+ * the two icon-plus-label chips in this feature space themselves alike.
+ *
+ * The glyph is the shared `/icons/location.svg` asset, so there is no colour to
+ * declare here and nothing to keep in sync if the asset changes.
+ */
+.locationTag {
+  gap: 6px;
+}

--- a/prototypes/entries/warm-intros-v2/PathChain.tsx
+++ b/prototypes/entries/warm-intros-v2/PathChain.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * The hop chain itself, lifted out of `WarmIntrosV2TableMock` so the two table
+ * variants share one implementation rather than two that drift.
+ *
+ * Nothing here is new — it is the same rendering, moved: `parseWarmPathHopChain`
+ * for the real chain, the connector → investor pair as the fallback when a row
+ * has no `hopChain`, and `PathHop` labelling every hop but the last.
+ *
+ * The proximity badge is deliberately *not* included. The compact table leads the
+ * cell with it; the wide table gives score its own column and leaves only the code
+ * here. That difference is the whole point of having two variants, so it stays
+ * with the caller.
+ */
+
+import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
+import type { WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
+import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
+import {
+  parseWarmPathHopChain,
+  type WarmPathV2HopNode,
+} from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss';
+import { PathHop, roleLabel } from './PathRole';
+// Press + focus states the chips don't ship — see ChipPress.module.scss.
+import press from './ChipPress.module.scss';
+
+/** The parsed hops, or null when the row falls back to connector → investor. */
+export function chainHopsOf(row: WarmIntrosV2PathListItem): WarmPathV2HopNode[] | null {
+  const chain = parseWarmPathHopChain(row.hopChain);
+  return chain?.hops?.length ? chain.hops : null;
+}
+
+/**
+ * Whether the chain hangs a role caption below itself — the only thing
+ * `View all` has to clear. Rows on the two-chip fallback have no caption band.
+ */
+export function hasRoleCaption(hops: WarmPathV2HopNode[] | null): boolean {
+  return !!hops && hops.some((hop, i) => i !== hops.length - 1 && !!roleLabel(hop.role));
+}
+
+export function investorAvatarSrc(row: WarmIntrosV2PathListItem): string | null {
+  const investor = row.investor;
+  if (!investor?.memberUid) return null;
+  return investor.imageUrl?.trim() || getDefaultAvatar(investor.name);
+}
+
+interface Props {
+  row: WarmIntrosV2PathListItem;
+  onOpenProfileUid: (profileUid: string) => void;
+  /** Rendered before the first hop — the compact table puts proximity here. */
+  lead?: React.ReactNode;
+  className?: string;
+}
+
+export function PathChain({ row, onOpenProfileUid, lead, className }: Props) {
+  const investor = row.investor;
+  const name = investor?.name?.trim() || row.targetProfileUid;
+  const connector = row.bestConnector;
+  const avatarSrc = investorAvatarSrc(row);
+  const hops = chainHopsOf(row);
+
+  return (
+    <div className={`${s.pathChain} ${press.chipPress}${className ? ` ${className}` : ''}`}>
+      {lead}
+      {hops
+        ? hops.map((hop, i) => {
+            const isOrg = hop.role === 'pl_org' || !hop.profileUid;
+            const hopName =
+              hop.name && hop.name !== hop.profileUid
+                ? hop.name
+                : hop.profileUid === connector?.profileUid
+                  ? connector.name
+                  : hop.profileUid === investor?.profileUid
+                    ? name
+                    : hop.name;
+            const hopImage = isOrg
+              ? null
+              : hop.role === 'investor'
+                ? avatarSrc
+                : hop.memberUid
+                  ? hop.imageUrl?.trim() || getDefaultAvatar(hopName)
+                  : (hop.imageUrl ??
+                    (connector?.profileUid === hop.profileUid
+                      ? connector.memberUid
+                        ? connector.imageUrl?.trim() || getDefaultAvatar(connector.name)
+                        : connector.imageUrl
+                      : null));
+            return (
+              <span key={`${hop.role ?? 'hop'}-${hop.profileUid || hop.name}-${i}`} className={s.pathHop}>
+                {i > 0 ? <span className={s.pathArrow}>→</span> : null}
+                {/* Every hop is labelled except the last — that one is the row's
+                    own investor. A path can start at a founder, so hop 0's role
+                    is read, never assumed. */}
+                <PathHop role={hop.role} isLast={i === hops.length - 1}>
+                  <PathProfileChip
+                    name={hopName}
+                    profileUid={hop.profileUid}
+                    imageUrl={hopImage}
+                    onOpen={onOpenProfileUid}
+                    nonInteractive={isOrg}
+                    memberUid={isOrg ? null : hop.memberUid}
+                  />
+                </PathHop>
+              </span>
+            );
+          })
+        : (
+            <>
+              {connector ? (
+                <span className={s.pathHop}>
+                  <PathProfileChip
+                    name={connector.name}
+                    profileUid={connector.profileUid}
+                    imageUrl={
+                      connector.memberUid
+                        ? connector.imageUrl?.trim() || getDefaultAvatar(connector.name)
+                        : connector.imageUrl
+                    }
+                    onOpen={onOpenProfileUid}
+                    memberUid={connector.memberUid}
+                  />
+                </span>
+              ) : (
+                <span className={s.muted}>—</span>
+              )}
+              {connector && investor ? <span className={s.pathArrow}>→</span> : null}
+              {investor ? (
+                <span className={s.pathHop}>
+                  <PathProfileChip
+                    name={investor.name}
+                    profileUid={investor.profileUid}
+                    imageUrl={avatarSrc}
+                    onOpen={onOpenProfileUid}
+                    memberUid={investor.memberUid}
+                  />
+                </span>
+              ) : null}
+            </>
+          )}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/PathEvidence.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathEvidence.module.scss
@@ -90,6 +90,14 @@
  * `#cbd5e1`: the chips sit inside the drawer's other bordered blocks, and matching
  * them matters more here than matching a tile on another page.
  */
+/**
+ * A wrapping row: events run left to right and wrap when they run out of width.
+ *
+ * The trade against stacking them is height. This block is evidence hanging under
+ * a path, not the subject of the card — three tiles on one line keep it to a
+ * single row, where stacked they cost three and push `Can you refer?` off the
+ * bottom of a short drawer.
+ */
 .eventChips {
   display: flex;
   flex-wrap: wrap;

--- a/prototypes/entries/warm-intros-v2/PathEvidence.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathEvidence.module.scss
@@ -1,0 +1,169 @@
+/**
+ * Evidence under a path: where each reason came from, and which events the two
+ * ends of the path both attended.
+ *
+ * Colours are `var(--token, #fallback)` pairs per `prototypes/CLAUDE.md` §3–4 —
+ * this is new UI, not a transcription of an existing production component.
+ */
+
+/* Trailing provenance marker on a reason line. */
+.source {
+  margin-left: 6px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 12px;
+  white-space: nowrap;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+/**
+ * Model-inferred reasons get no extra colour, only the word — but they do get
+ * italics, so a guess never reads with the same authority as a verified fact at
+ * a glance.
+ */
+.sourceWeak {
+  font-style: italic;
+}
+
+.eventsBlock {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  display: flex;
+  flex-direction: column;
+  /* Rows are two lines each now, so they need more air between them than the
+     3px that separated single sentences. */
+  gap: 6px;
+}
+
+.eventsHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.eventsLabel {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 14px;
+  letter-spacing: 0.02em;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+/* One pair, its caption, and the events under it. */
+.eventGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/**
+ * The caption states the pair once for the whole group, so it recedes: it is the
+ * heading over a list, not a fact competing with the events themselves. On a
+ * two-hop chain it reads just "Both attended", because the pair is the chain
+ * directly above.
+ */
+.eventPair {
+  font-size: 11px;
+  line-height: 15px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+/**
+ * Events as chips in a wrapping row, borrowed from the team page's IRL
+ * contribution tiles (`team-irl-contributions.tsx`
+ * `.root__irlCrbts__col__event__cnt`): radius 4, the same `#f1f5f9` fill, the same
+ * 12px/500 title.
+ *
+ * Two things about that tile deliberately do **not** come across:
+ *
+ * 1. It clamps its title to `width: 93px` with an ellipsis, leaning on a tooltip
+ *    and the fact that the tile links to the event. Here the event name *is* the
+ *    evidence — "Neuro Capital Roundtable" truncated to "Neuro Capit…" deletes the
+ *    only fact the row carries — so these size to their content and wrap.
+ * 2. Its 40px height holds a 12px title over an 8px date, and `EVENTS_BY_PROFILE`
+ *    has no dates. A 40px box with one line in it is just a chip with a hole, so
+ *    the height comes down to fit what is actually there.
+ *
+ * The border is this prototype's own token pair rather than the team page's raw
+ * `#cbd5e1`: the chips sit inside the drawer's other bordered blocks, and matching
+ * them matters more here than matching a tile on another page.
+ */
+.eventChips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.eventRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  background: var(--background-neutral-subtle, #f1f5f9);
+  max-width: 100%;
+}
+
+/**
+ * `CalendarBlankIcon` ships at 20px, which is heading scale. At 14px it sits
+ * between the 12px title and the 11px meta, which is where a supporting glyph
+ * belongs — present, not announcing itself. The 1px nudge puts its optical centre
+ * on the title's cap height rather than its line box.
+ */
+.eventIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+/* 12px/500 is the team tile's own title size; inside a filled chip it does not
+   need the extra weight the bare list rows were carrying. */
+.eventName {
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/**
+ * The overflow control is the team page's `+N` tile
+ * (`.root__irlCrbts__col__event__cnts`) — same chip shape as the events it stands
+ * in for, so it reads as one of them rather than as a link beneath them.
+ *
+ * It expands in place rather than opening a modal the way the team page does:
+ * this already lives inside a drawer, and stacking a dialog on a drawer to reveal
+ * two more chips is a heavier gesture than the content deserves. Which is also why
+ * it can toggle back — a modal you must close is not a "show fewer".
+ */
+.eventsMore {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  background: var(--transparent-dark-4, rgba(14, 15, 17, 0.04));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  color: var(--foreground-neutral-secondary, #455468);
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--border-neutral-muted, rgba(27, 56, 96, 0.24));
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}

--- a/prototypes/entries/warm-intros-v2/PathEvidence.tsx
+++ b/prototypes/entries/warm-intros-v2/PathEvidence.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+/**
+ * Why a path is claimed to exist — the two halves of it.
+ *
+ * **Provenance.** The payload puts a `sourceType` on every reason and
+ * `parseWarmPathHopChain` reads it (`pickPrimaryReasonDescription` even prefers
+ * `webVerify`), but nothing has ever rendered it: the drawer flattens reasons to
+ * strings via `allReasonDescriptions`, so a web-verified fact and a model's guess
+ * arrive on screen looking identical. That's the difference between an intro
+ * request that lands and one that embarrasses someone, so it gets shown.
+ *
+ * **Shared events.** `MasterProfile.events` exists per person and the modal lists
+ * it, but nothing computes the *overlap* — today you'd open both profiles and
+ * compare by eye. The intersection is the interesting part, so it's derived here.
+ *
+ * Deliberate copy choice: **"Both attended", never "met at"**. Two people at a
+ * conference with a few thousand attendees did not necessarily meet, and a UI
+ * that says they did is asserting something the data can't support.
+ */
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { CalendarBlankIcon } from '@/components/icons';
+// The drawer's count chip, reused so one number means one thing in this panel.
+import d from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2InvestorDrawer.module.scss';
+import type { WarmPathV2HopNode } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import { reasonDescription } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import { sharedEventsBetween } from './mocks';
+import s from './PathEvidence.module.scss';
+
+/** `reasonSourceType` is module-private in production, so it is re-derived here. */
+function sourceTypeOf(reason: unknown): string | null {
+  if (!reason || typeof reason !== 'object' || Array.isArray(reason)) return null;
+  const value = (reason as Record<string, unknown>).sourceType;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+const SOURCE_LABEL: Record<string, string> = {
+  webVerify: 'Web-verified',
+  sharedEvent: 'Shared event',
+  affinity: 'Affinity',
+  directory: 'Directory',
+  llmPairing: 'Model-inferred',
+};
+
+/** Only this one is a guess; everything else is an observation of some record. */
+const WEAK_SOURCES = new Set(['llmPairing']);
+
+function sourceLabel(sourceType: string | null): string | null {
+  if (!sourceType) return null;
+  return SOURCE_LABEL[sourceType] ?? sourceType.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+/**
+ * Reason bullets that keep their provenance. Takes production's `.reasonList`
+ * class so the list itself is styled exactly as the drawer already styles it.
+ */
+export function ReasonList({ reasons, listClassName }: { reasons: unknown[]; listClassName?: string }) {
+  const seen = new Set<string>();
+  const items: Array<{ text: string; sourceType: string | null }> = [];
+
+  for (const raw of reasons) {
+    const text = reasonDescription(raw);
+    if (!text) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    items.push({ text, sourceType: sourceTypeOf(raw) });
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <ul className={listClassName}>
+      {items.map((item) => {
+        const label = sourceLabel(item.sourceType);
+        return (
+          <li key={item.text}>
+            {item.text}
+            {label ? (
+              <span className={clsx(s.source, item.sourceType && WEAK_SOURCES.has(item.sourceType) && s.sourceWeak)}>
+                · {label}
+              </span>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Events both ends of an edge attended, computed per adjacent pair — a shared
+ * event is a property of the *edge*, not of either person, so it is reported
+ * against the pair rather than hung off one chip.
+ */
+/** Past this many events the list collapses behind a toggle. */
+const EVENTS_SHOWN = 3;
+
+/**
+ * "A & B both attended" / "A, B & C all attended".
+ *
+ * `both` only works for two, and swapping to `all` past that is the difference
+ * between a claim that parses and one that quietly doesn't. Neither says they met.
+ */
+function attendedBy(people: string[]): string {
+  const verb = people.length > 2 ? 'all attended' : 'both attended';
+  const names =
+    people.length > 2 ? `${people.slice(0, -1).join(', ')} & ${people[people.length - 1]}` : people.join(' & ');
+  return `${names} ${verb}`;
+}
+
+/**
+ * Shared events, grouped by the pair rather than repeated per event.
+ *
+ * Two rewrites got us here. The first led with the names — but those names are the
+ * two chips directly above this block, so the line opened on what you already knew
+ * and put the new fact last. The second put the event first but restated
+ * "X & Y both attended" under *every* event, which is the same sentence copied
+ * down the block: the pair is the constant, the events are what vary.
+ *
+ * So the pair states itself once, as a caption, and the events list beneath it.
+ * The shape is Confluence's "Worked on" — glyph, bold subject, grouped under a
+ * heading — with Discord's count-first framing on the header.
+ *
+ * **The caption only appears when who is ambiguous.** On a two-hop chain there is
+ * exactly one possible pair — the chain sitting right above — so there is no
+ * caption at all: "Both attended" under a heading that already says "Shared
+ * events" is one idea wearing two labels. Three hops or more can pair up more than
+ * one way, and can put three people at a single event, so there the caption says
+ * who.
+ *
+ * The copy constraint stands: **never "met at"**. Two people at a conference did
+ * not necessarily meet. "Shared events" carries that on its own — it states
+ * co-attendance and claims nothing further — and where the caption does appear it
+ * says "both/all attended" for the same reason.
+ */
+export function SharedEventsNote({ hops }: { hops: WarmPathV2HopNode[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Who shares each event, accumulated across every adjacent pair. Keyed by event
+  // rather than by pair because an event can span three hops — if all three
+  // attended, that is one event with three people, not the same event twice.
+  const peopleByEvent = new Map<string, string[]>();
+  for (let i = 0; i < hops.length - 1; i += 1) {
+    const from = hops[i];
+    const to = hops[i + 1];
+    if (!from?.profileUid || !to?.profileUid) continue;
+    for (const event of sharedEventsBetween(from.profileUid, to.profileUid)) {
+      const people = peopleByEvent.get(event) ?? [];
+      for (const name of [from.name, to.name]) {
+        if (name && !people.includes(name)) people.push(name);
+      }
+      peopleByEvent.set(event, people);
+    }
+  }
+
+  // Events that involve the same people collapse under one caption, so the names
+  // are stated once however many events they share.
+  const groups: Array<{ key: string; people: string[]; events: string[] }> = [];
+  for (const [event, people] of peopleByEvent) {
+    const key = people.join('|');
+    const existing = groups.find((g) => g.key === key);
+    if (existing) existing.events.push(event);
+    else groups.push({ key, people, events: [event] });
+  }
+
+  if (groups.length === 0) return null;
+
+  const total = peopleByEvent.size;
+  // More than two hops means more than one way to pair them up, so the caption has
+  // to say who. At exactly two, the pair is the chain above.
+  const namePairs = hops.length > 2;
+  const overflow = total - EVENTS_SHOWN;
+
+  /**
+   * The visible slice of each group, worked out before rendering rather than
+   * during it. The cap is across the whole block, so when it runs out mid-way a
+   * later group can end up with nothing to show — and the `+N` chip has to hang
+   * off the last group that actually renders, not the last group that exists.
+   */
+  let budget = expanded ? Infinity : EVENTS_SHOWN;
+  const visible = groups
+    .map((group) => {
+      const events = group.events.slice(0, Math.max(0, budget));
+      budget -= events.length;
+      return { ...group, events };
+    })
+    .filter((group) => group.events.length > 0);
+
+  return (
+    <div className={s.eventsBlock}>
+      <div className={s.eventsHeader}>
+        <span className={s.eventsLabel}>Shared events</span>
+        {/* The drawer's own count chip, the same one the co-investments block
+            uses — one number treatment across the panel. Only past one, since
+            "(1)" next to a single visible row is noise. */}
+        {total > 1 ? <span className={d.count}>{total}</span> : null}
+      </div>
+
+      {visible.map((group, groupIndex) => {
+        const events = group.events;
+
+        return (
+          <div key={group.key} className={s.eventGroup}>
+            {/* No caption on a two-hop chain: "Both attended" under a heading that
+                already reads "Shared events" is the same statement twice, and the
+                pair it refers to is the chain sitting directly above. The caption
+                exists to say *who*, so it appears only when who is ambiguous. */}
+            {namePairs ? <div className={s.eventPair}>{attendedBy(group.people)}</div> : null}
+            <div className={s.eventChips}>
+              {events.map((event) => (
+                <span key={event} className={s.eventRow}>
+                  <span className={s.eventIcon} aria-hidden>
+                    <CalendarBlankIcon />
+                  </span>
+                  <span className={s.eventName}>{event}</span>
+                </span>
+              ))}
+              {/* The `+N` rides in the chip row, as it does on the team page —
+                  last in line rather than a link underneath, so the overflow reads
+                  as more of the same thing. Only on the final group, since the cap
+                  is across the block rather than per group. */}
+              {overflow > 0 && groupIndex === visible.length - 1 ? (
+                <button type="button" className={s.eventsMore} onClick={() => setExpanded((v) => !v)}>
+                  {expanded ? 'Show fewer' : `+${overflow}`}
+                </button>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/PathEvidence.tsx
+++ b/prototypes/entries/warm-intros-v2/PathEvidence.tsx
@@ -95,7 +95,12 @@ export function ReasonList({ reasons, listClassName }: { reasons: unknown[]; lis
  * event is a property of the *edge*, not of either person, so it is reported
  * against the pair rather than hung off one chip.
  */
-/** Past this many events the list collapses behind a toggle. */
+/**
+ * Past this many events the list collapses behind a `+N` tile.
+ *
+ * Three fits the wrapping row without forcing a second line at the widths this
+ * drawer runs at, so the block stays one row tall in the common case.
+ */
 const EVENTS_SHOWN = 3;
 
 /**
@@ -124,12 +129,12 @@ function attendedBy(people: string[]): string {
  * The shape is Confluence's "Worked on" — glyph, bold subject, grouped under a
  * heading — with Discord's count-first framing on the header.
  *
- * **The caption only appears when who is ambiguous.** On a two-hop chain there is
- * exactly one possible pair — the chain sitting right above — so there is no
- * caption at all: "Both attended" under a heading that already says "Shared
- * events" is one idea wearing two labels. Three hops or more can pair up more than
- * one way, and can put three people at a single event, so there the caption says
- * who.
+ * **The caption only appears when it narrows the field.** It is there to say
+ * *which* of the people on the path shared the event — so it renders when they are
+ * a subset of the chain, and not when they are all of it. On a two-hop path both
+ * hops always shared it, so there is no caption; on a longer path with only the
+ * last two involved, there is. An event all three attended gets none either, since
+ * naming all three just retypes the chain drawn directly above.
  *
  * The copy constraint stands: **never "met at"**. Two people at a conference did
  * not necessarily meet. "Shared events" carries that on its own — it states
@@ -169,9 +174,9 @@ export function SharedEventsNote({ hops }: { hops: WarmPathV2HopNode[] }) {
   if (groups.length === 0) return null;
 
   const total = peopleByEvent.size;
-  // More than two hops means more than one way to pair them up, so the caption has
-  // to say who. At exactly two, the pair is the chain above.
-  const namePairs = hops.length > 2;
+  // Everyone the chain actually names — org stubs like "Protocol Labs" have no
+  // profileUid and never take part in a pair, so they must not be counted.
+  const chainPeople = hops.filter((hop) => hop.profileUid).length;
   const overflow = total - EVENTS_SHOWN;
 
   /**
@@ -208,7 +213,14 @@ export function SharedEventsNote({ hops }: { hops: WarmPathV2HopNode[] }) {
                 already reads "Shared events" is the same statement twice, and the
                 pair it refers to is the chain sitting directly above. The caption
                 exists to say *who*, so it appears only when who is ambiguous. */}
-            {namePairs ? <div className={s.eventPair}>{attendedBy(group.people)}</div> : null}
+            {/* The caption exists to say *which* of the chain shared this event —
+                so it only appears when that is a subset of the chain. If everyone
+                on the path attended, naming them just retypes the chain drawn
+                directly above, which is what "Both attended" was doing on two-hop
+                paths before. Same rule now covers both. */}
+            {group.people.length < chainPeople ? (
+              <div className={s.eventPair}>{attendedBy(group.people)}</div>
+            ) : null}
             <div className={s.eventChips}>
               {events.map((event) => (
                 <span key={event} className={s.eventRow}>

--- a/prototypes/entries/warm-intros-v2/PathFeedback.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathFeedback.module.scss
@@ -11,9 +11,19 @@
 /* ---------------------------------------------------------------- card strip */
 
 /**
- * One quiet row at the foot of the card, divided from the path content above.
- * The referral answer sits left (it's the action), feedback sits right (it's
- * the escape hatch) — so the eye lands on the thing people actually do.
+ * One quiet row at the foot of the card. The referral answer sits left (it's the
+ * action), feedback sits right (it's the escape hatch) — so the eye lands on the
+ * thing people actually do.
+ *
+ * No rule above it. It had one, from when this strip followed the chain directly
+ * and needed something to separate two adjacent blocks of text. The evidence block
+ * (`PathEvidence.module.scss` `.eventsBlock`) now sits between them and draws its
+ * own, so the card was ending in two rules about 100px apart — banding a small
+ * card into three sections, where the last band holds two links.
+ *
+ * Space does the separating instead. The strip is already set apart by being
+ * right-aligned, quiet, and the only interactive thing in the card; a line to say
+ * so as well is the second time it is said.
  */
 .strip {
   display: flex;
@@ -21,9 +31,9 @@
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  /* Was 10 + 10 across a border; kept as one value now there is nothing to sit
+     either side of. */
+  margin-top: 14px;
 }
 
 .stripLeft,

--- a/prototypes/entries/warm-intros-v2/PathRole.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathRole.module.scss
@@ -1,0 +1,66 @@
+/**
+ * Layout only — no colours of its own beyond the muted grey production already
+ * uses for `.pathArrow` and `.subtle`.
+ *
+ * Dev puts a bordered role pill after every hop chip. Only the last one is
+ * redundant (it is always the row's own investor); every other position carries
+ * information, because a path can start at a founder just as well as at a PL
+ * member. So the labels stay, and what changes is their weight: pill chrome off,
+ * caption under the name — the pattern Workable / Aboard / Peerlist all use.
+ */
+
+.hop {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+/**
+ * Only the bridge stacks, so the caption sits under its own name.
+ *
+ * Keeping the chip on the same line as its neighbours: production centres the
+ * chain, and a caption hanging below would drag this chip upward by half the
+ * caption's height. Top-aligning the chain instead just moves the problem — the
+ * arrows and the other chips then hang off the top edge.
+ *
+ * So the hop reserves the caption's height *above* the chip as well. The column
+ * becomes symmetric (13px, chip, 1px gap, 12px caption), which puts the chip
+ * back on the row's centre line while production's `align-items: center` is left
+ * exactly as it is.
+ */
+.hopWithRole {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  margin-top: 13px; /* .roleCaption line-height (12px) + the 1px gap */
+}
+
+/**
+ * Absorbs the row's own top margin in the drawer.
+ *
+ * `.chainRow` sets `margin-top: 8px`, measured back when the chain was just chips.
+ * `.hopWithRole` now reserves another 13px above each captioned chip — symmetric
+ * padding so a chip with a caption stays centred against one without — so the
+ * apparent gap between the path description and the nodes became 21px, and read as
+ * a hole in the card.
+ *
+ * The 13px stays: it is what keeps `Ilse Brandt` and `Linnéa Holm` on the same
+ * centre line when only the first has a caption. What goes is the 8px underneath
+ * it, which was spacing for a chain that no longer exists.
+ *
+ * Doubled to clear production's own `.chainRow` without depending on which
+ * stylesheet the bundler emits last.
+ */
+.chainRowTight.chainRowTight {
+  margin-top: 0;
+}
+
+.roleCaption {
+  padding-left: 2px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 12px;
+  letter-spacing: 0.01em;
+  color: #9ca3af;
+  white-space: nowrap;
+}

--- a/prototypes/entries/warm-intros-v2/PathRole.tsx
+++ b/prototypes/entries/warm-intros-v2/PathRole.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+/**
+ * Role on a path hop, reduced to the part that carries information.
+ *
+ * Dev renders `HopRoleBadge` after every chip. Only one of those is genuinely
+ * redundant: the **last** hop is the row's own investor by definition, so
+ * labelling it restates the subject of the row.
+ *
+ * Every other position is real information. A path does *not* have to start at a
+ * PL member — `Founder → Investor` is a shape the backend emits, and production's
+ * drawer builds alternates as exactly that. `role` is a free-form string on the
+ * payload with nothing constraining hop 0, so it gets read, never inferred.
+ *
+ * What does change is the weight: the label drops its pill chrome and becomes a
+ * caption under the name, the shape Workable / Aboard / Peerlist use for a role
+ * that appears on every row.
+ *
+ * No colour system here on purpose. Proximity already colour-codes by caliber,
+ * and a second palette competing with the load-bearing one is how the column got
+ * noisy in the first place.
+ */
+
+import clsx from 'clsx';
+import s from './PathRole.module.scss';
+
+const ROLE_LABEL: Record<string, string> = {
+  pl_connector: 'PL Member',
+  founder: 'Founder',
+  co_investor: 'Co-investor',
+  investor: 'Investor',
+};
+
+export function roleLabel(role?: string | null): string | null {
+  if (!role || role === 'pl_org') return null;
+  return ROLE_LABEL[role] ?? role.replace(/_/g, ' ');
+}
+
+export function HopRoleCaption({ role }: { role?: string | null }) {
+  const label = roleLabel(role);
+  if (!label) return null;
+  return <span className={s.roleCaption}>{label}</span>;
+}
+
+/**
+ * One hop: the chip, plus its role caption. `isLast` suppresses the caption on
+ * the final hop — that one is the investor the row is about, and saying so again
+ * at the end of every chain is the only label position really does give you.
+ */
+export function PathHop({
+  role,
+  isLast = false,
+  children,
+}: {
+  role?: string | null;
+  isLast?: boolean;
+  children: React.ReactNode;
+}) {
+  const showRole = !isLast && !!roleLabel(role);
+  return (
+    <span className={clsx(s.hop, showRole && s.hopWithRole)}>
+      {children}
+      {showRole ? <HopRoleCaption role={role} /> : null}
+    </span>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/PathViaSelect.module.scss
+++ b/prototypes/entries/warm-intros-v2/PathViaSelect.module.scss
@@ -1,0 +1,24 @@
+/**
+ * The checkbox row inside a "Path via" option.
+ *
+ * Layout only — the box is the DS `Checkbox` and the label keeps the type
+ * `filterSelectStyles.option` already sets, so there is nothing here to
+ * token-swap.
+ */
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/**
+ * The DS `Checkbox` is a 1.25rem box that shrinks under a long option label
+ * ("Priya Raghunathan (2)") unless it is told not to. `display: flex` keeps its
+ * own centring intact inside this row.
+ */
+.optionBox {
+  display: flex;
+  flex-shrink: 0;
+}

--- a/prototypes/entries/warm-intros-v2/PathViaSelect.tsx
+++ b/prototypes/entries/warm-intros-v2/PathViaSelect.tsx
@@ -15,18 +15,24 @@
  * two keys don't exist there. Everything else is imported verbatim, so the
  * control matches its neighbours in the filter bar exactly.
  *
- * Single-select on purpose. One selection = one legible trigger label; and
- * combinations like "founder bridges, but only Mara's" would need two values in
- * one control, which is the two-controls problem again wearing a new coat.
+ * Multi-select, with checkboxes. It was single-select at first, on the argument
+ * that one selection keeps one legible trigger label — the control now shows a
+ * count (`Path via · 2`) instead of the label, so that objection is spent.
+ *
+ * Several selections are matched as **OR** (see `PathFilters.pathVia`): ticking a
+ * second box widens the result. The intersection would be the wrong reading and
+ * usually empty, since a path has one shape and one bridge.
  */
 
 import Select, { type GroupBase, type StylesConfig } from 'react-select';
 import type { CSSObjectWithLabel } from 'react-select';
-import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
+// The checkbox row and the settings that keep the menu still — shared with the
+// Industry / Sector select, so both behave identically.
+import { CheckboxOption, checkSelectStyles, steadyMenuProps } from './CheckSelect';
 import type { Option } from '@/components/form/FormSelect/types';
 import { MOCK_BRIDGES, MOCK_CONNECTORS, type PathVia, type PathViaFacets, type RelationKind } from './mocks';
 // Same chevron as the other two selects in the bar, so the three still match.
-import { thinChevron } from './FilterSelectThin';
+import { dsIndicators } from './FilterSelectThin';
 
 const KIND_LABEL: Record<RelationKind, string> = {
   pl_direct: 'Direct',
@@ -119,8 +125,10 @@ export function pathViaLabel(groups: GroupBase<Option>[], via: PathVia | null): 
  * Production's styles plus the two keys it never needed. Colours are lifted from
  * `filterSelectStyles`' own palette so the headings read as the same family.
  */
-const groupedStyles: StylesConfig<Option, false, GroupBase<Option>> = {
-  ...(filterSelectStyles as StylesConfig<Option, false, GroupBase<Option>>),
+const groupedStyles: StylesConfig<Option, true, GroupBase<Option>> = {
+  // Production's styles plus the placeholder-vs-value fix, shared with the
+  // Industry / Sector select so a selected control looks the same in both.
+  ...checkSelectStyles,
   group: (base: CSSObjectWithLabel) => ({ ...base, paddingTop: 4, paddingBottom: 4 }),
   groupHeading: (base: CSSObjectWithLabel) => ({
     ...base,
@@ -136,24 +144,31 @@ const groupedStyles: StylesConfig<Option, false, GroupBase<Option>> = {
 
 interface Props {
   facets: PathViaFacets;
-  value: PathVia | null;
-  onChange: (via: PathVia | null) => void;
+  /** Empty means unfiltered. Several values are matched as OR — see `PathFilters`. */
+  value: PathVia[];
+  onChange: (via: PathVia[]) => void;
 }
 
 export function PathViaSelect({ facets, value, onChange }: Props) {
   const groups = pathViaOptions(facets);
+  const selected = value.map((via) => pathViaLabel(groups, via)).filter((opt): opt is Option => !!opt);
 
   return (
-    <Select<Option, false, GroupBase<Option>>
+    <Select<Option, true, GroupBase<Option>>
+      {...steadyMenuProps}
       aria-label="Path via"
       options={groups}
-      value={pathViaLabel(groups, value)}
-      onChange={(opt) => onChange(opt ? decode(opt.value) : null)}
-      placeholder="Path via"
+      value={selected}
+      onChange={(opts) => onChange([...(opts ?? [])].map((opt) => decode(opt.value)).filter((v): v is PathVia => !!v))}
+      // The control never renders the chosen values, so this doubles as the
+      // summary line. Chips inside a 220px control wrap into two rows after the
+      // second pick, and what is selected is already spelled out by the
+      // active-filter pills under the bar — this would be the third time.
+      placeholder={selected.length > 0 ? `Path via · ${selected.length}` : 'Path via'}
       isClearable
       isSearchable
       styles={groupedStyles}
-      components={thinChevron}
+      components={{ ...dsIndicators, Option: CheckboxOption }}
       menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
       menuPosition="fixed"
       noOptionsMessage={() => 'No paths match the other filters'}

--- a/prototypes/entries/warm-intros-v2/PathViaSelect.tsx
+++ b/prototypes/entries/warm-intros-v2/PathViaSelect.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/**
+ * "Path via" — the mediation axis as one grouped selector.
+ *
+ * Replaces dev's `PL member` select **and** its three path-kind chips. Those are
+ * one question asked twice: the chips answer it coarsely (what shape), the select
+ * answers it precisely (which person). Splitting them across two controls with
+ * different affordances is what made the chips feel like facets when they are
+ * really a pick-one — and what let clicking one silently clear another.
+ *
+ * Reused from production, not re-created:
+ *   `FilterSelect`'s own react-select instance config and `filterSelectStyles`.
+ * Only `group` / `groupHeading` are added — production never grouped, so those
+ * two keys don't exist there. Everything else is imported verbatim, so the
+ * control matches its neighbours in the filter bar exactly.
+ *
+ * Single-select on purpose. One selection = one legible trigger label; and
+ * combinations like "founder bridges, but only Mara's" would need two values in
+ * one control, which is the two-controls problem again wearing a new coat.
+ */
+
+import Select, { type GroupBase, type StylesConfig } from 'react-select';
+import type { CSSObjectWithLabel } from 'react-select';
+import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
+import type { Option } from '@/components/form/FormSelect/types';
+import { MOCK_BRIDGES, MOCK_CONNECTORS, type PathVia, type PathViaFacets, type RelationKind } from './mocks';
+// Same chevron as the other two selects in the bar, so the three still match.
+import { thinChevron } from './FilterSelectThin';
+
+const KIND_LABEL: Record<RelationKind, string> = {
+  pl_direct: 'Direct',
+  founder_bridge: 'Via a founder',
+  coinvestor_bridge: 'Via a co-investor',
+};
+
+const GROUP_LABEL = {
+  kind: 'Path type',
+  member: 'PL member',
+  bridge: 'Founder / co-investor',
+} as const;
+
+/** `member:mp-pl-mara` — the group is recoverable from the value alone. */
+function encode(via: PathVia): string {
+  return `${via.type}:${via.value}`;
+}
+
+function decode(raw: string): PathVia | null {
+  const [type, ...rest] = raw.split(':');
+  const value = rest.join(':');
+  if (!value) return null;
+  if (type === 'kind') return { type: 'kind', value: value as RelationKind };
+  if (type === 'member') return { type: 'member', value };
+  if (type === 'bridge') return { type: 'bridge', value };
+  return null;
+}
+
+const withCount = (label: string, count: number) => `${label} (${count})`;
+
+export function pathViaOptions(facets: PathViaFacets): GroupBase<Option>[] {
+  const groups: GroupBase<Option>[] = [];
+
+  if (facets.kinds.length > 0) {
+    groups.push({
+      label: GROUP_LABEL.kind,
+      options: facets.kinds.map((k) => ({
+        value: encode({ type: 'kind', value: k.value }),
+        label: withCount(KIND_LABEL[k.value], k.count),
+      })),
+    });
+  }
+
+  if (facets.members.length > 0) {
+    groups.push({
+      label: GROUP_LABEL.member,
+      options: facets.members.map((m) => ({
+        value: encode({ type: 'member', value: m.profileUid }),
+        label: withCount(m.name, m.count),
+      })),
+    });
+  }
+
+  if (facets.bridges.length > 0) {
+    groups.push({
+      label: GROUP_LABEL.bridge,
+      options: facets.bridges.map((b) => ({
+        value: encode({ type: 'bridge', value: b.profileUid }),
+        label: withCount(b.name, b.count),
+      })),
+    });
+  }
+
+  return groups;
+}
+
+/**
+ * A selection's name, resolved from the data rather than from the current facet
+ * list — the active-filter pill has to stay readable even when the other filters
+ * would have dropped that option from the menu.
+ */
+export function describePathVia(via: PathVia): string {
+  if (via.type === 'kind') return KIND_LABEL[via.value];
+  const source = via.type === 'member' ? MOCK_CONNECTORS : MOCK_BRIDGES;
+  return Object.values(source).find((p) => p.profileUid === via.value)?.name ?? via.value;
+}
+
+/** The trigger's label for a live selection — resolved against the same groups. */
+export function pathViaLabel(groups: GroupBase<Option>[], via: PathVia | null): Option | null {
+  if (!via) return null;
+  const key = encode(via);
+  for (const group of groups) {
+    const hit = group.options.find((o) => o.value === key);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Production's styles plus the two keys it never needed. Colours are lifted from
+ * `filterSelectStyles`' own palette so the headings read as the same family.
+ */
+const groupedStyles: StylesConfig<Option, false, GroupBase<Option>> = {
+  ...(filterSelectStyles as StylesConfig<Option, false, GroupBase<Option>>),
+  group: (base: CSSObjectWithLabel) => ({ ...base, paddingTop: 4, paddingBottom: 4 }),
+  groupHeading: (base: CSSObjectWithLabel) => ({
+    ...base,
+    fontSize: '11px',
+    fontWeight: 600,
+    letterSpacing: '0.02em',
+    textTransform: 'none',
+    color: '#8897ae',
+    paddingTop: 6,
+    paddingBottom: 2,
+  }),
+};
+
+interface Props {
+  facets: PathViaFacets;
+  value: PathVia | null;
+  onChange: (via: PathVia | null) => void;
+}
+
+export function PathViaSelect({ facets, value, onChange }: Props) {
+  const groups = pathViaOptions(facets);
+
+  return (
+    <Select<Option, false, GroupBase<Option>>
+      aria-label="Path via"
+      options={groups}
+      value={pathViaLabel(groups, value)}
+      onChange={(opt) => onChange(opt ? decode(opt.value) : null)}
+      placeholder="Path via"
+      isClearable
+      isSearchable
+      styles={groupedStyles}
+      components={thinChevron}
+      menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+      menuPosition="fixed"
+      noOptionsMessage={() => 'No paths match the other filters'}
+    />
+  );
+}

--- a/prototypes/entries/warm-intros-v2/PlHistory.module.scss
+++ b/prototypes/entries/warm-intros-v2/PlHistory.module.scss
@@ -1,0 +1,109 @@
+/**
+ * PL relationship line: a marker plus plain text, not a pill.
+ *
+ * Attio renders connection strength this way — a small coloured glyph and plain
+ * words, no border, no fill. Once the email line went, a filled pill here was the
+ * loudest thing in the cell after the name, over-weighting a secondary fact.
+ *
+ * The violet is production's own (`HopRoleBadge.module.scss` `.investor`,
+ * `#6d28d9`). That module writes raw hex with no token pair to copy, so the pair
+ * is named here and the fallback keeps the rendered colour identical.
+ */
+
+/**
+ * Untints production's `.coInvestBlock`, which ships a filled amber box
+ * (`#fff7ed` on `#fed7aa`, label `#c2410c`).
+ *
+ * Dev's reasoning is sound in production: that triplet is `HopRoleBadge`'s
+ * `.coInvestor`, so orange consistently means co-investor. It doesn't survive
+ * here. A filled amber box with an amber border is the shape of a *warning*, and
+ * this is good news — plus it's the only tinted box in the drawer, so it alerts
+ * on the one section that should reassure. And the orange↔co-investor link it
+ * leans on is broken in this prototype, because role badges became plain grey
+ * captions and `.coInvestor` orange no longer renders anywhere nearby.
+ *
+ * **Deliberate deviation from production's visual layer** — a proposal to take
+ * back to dev, not accidental drift. Doubled class names win over the imported
+ * rules without depending on CSS-module import order.
+ */
+.coInvestPlain.coInvestPlain {
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+  border-radius: 0;
+  padding: 10px 0 0;
+}
+
+.coInvestPlainLabel.coInvestPlainLabel {
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/* Last fact-line in the investor cell, under firm · title. */
+.line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  /* Wide enough to separate the two facts without spending a `·` glyph on it. */
+  gap: 10px;
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+  /**
+   * In the MasterProfile modal this rides inside `.sectionTitle`, which is
+   * `text-transform: uppercase`. The mark is a value, not a heading, so it opts
+   * out — otherwise it shouts "BACKED PL + FIL" next to real acronyms.
+   */
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.marker {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 2px;
+  /* Rotated square — distinct from the round Directory dot on the path chips. */
+  transform: rotate(45deg);
+  background: var(--foreground-brand-secondary, #6d28d9);
+  /* Nudged onto the text baseline, since the row aligns on it. */
+  align-self: center;
+}
+
+/**
+ * The words are neutral; only the 6px marker carries the colour. Violet text at
+ * weight 600 made a secondary fact shout as loudly as the name two lines up, and
+ * it put a fourth hue into a cell that already had three.
+ */
+.backing {
+  font-weight: 500;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/**
+ * The noun repeats on every row while only the number varies, so the number
+ * takes the ink and the word recedes — you scan the digits, not the label.
+ */
+.countNum {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--foreground-neutral-primary, #0a0c11);
+}
+
+.countNoun {
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}
+
+/* In the drawer the badge sits beside a heading rather than on its own line. */
+.inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 6px;
+}

--- a/prototypes/entries/warm-intros-v2/PlHistory.tsx
+++ b/prototypes/entries/warm-intros-v2/PlHistory.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * The investor's existing relationship with PL, made visible.
+ *
+ * Dev added `plBacking` as a *filter* only — nothing in the table, drawer or
+ * profile ever shows it, so the sole way to learn an investor backed Filecoin is
+ * to toggle the chip and see who survives. This renders the fact, which turns
+ * the toggle into an ordinary filter over something you can already see.
+ *
+ * Rendered as a marker plus plain words — the shape Attio uses for connection
+ * strength. It was a filled pill until the email line came out of the cell; with
+ * only two lines left, a pill made a secondary fact the loudest thing after the
+ * name.
+ *
+ * Colour is still load-bearing everywhere else in this row — green is "directory
+ * member", indigo and amber are *which list*, and proximity owns the
+ * green/yellow/red bands — so this keeps `HopRoleBadge`'s violet (`#6d28d9`),
+ * which nothing else in the investor cell claims. Amber would have collided with
+ * the Gold PLC badge two lines up.
+ */
+
+import clsx from 'clsx';
+import type { MasterProfileDetail } from '@/services/investors/warm-intros-v2.types';
+// The drawer's own count chip — same number, same object, both surfaces.
+import d from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2InvestorDrawer.module.scss';
+import s from './PlHistory.module.scss';
+
+type PlBacking = MasterProfileDetail['plBacking'];
+
+/** Says which of the two it is — "backer" alone loses the useful half. */
+export function plBackingLabel(backing: PlBacking): string | null {
+  if (!backing) return null;
+  const { backedProtocolLabs, backedFilecoin } = backing;
+  if (backedProtocolLabs && backedFilecoin) return 'Backed PL + FIL';
+  if (backedProtocolLabs) return 'Backed PL';
+  if (backedFilecoin) return 'Backed Filecoin';
+  return null;
+}
+
+/**
+ * Marker + words, one treatment used on every surface. A pill here was the
+ * loudest thing in the row once the email line went, and having a pill in the
+ * table but plain text in the drawer would be two looks for one fact.
+ */
+interface Props {
+  backing: PlBacking;
+  coInvestmentCount: number;
+}
+
+export function PlBackingMark({ backing, className }: { backing: PlBacking; className?: string }) {
+  const label = plBackingLabel(backing);
+  if (!label) return null;
+
+  // Whether the match is on the firm or the person changes how much to trust it,
+  // so it rides along as the tooltip rather than lengthening the line.
+  const detail = [backing?.firmName, backing?.matchKind ? `matched on ${backing.matchKind}` : null]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <span className={clsx(s.mark, className)} title={detail || undefined}>
+      <span className={s.marker} aria-hidden />
+      <span className={s.backing}>{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Co-investment count — the drawer's `.count` verbatim, so the same number is the
+ * same object on both surfaces. The digit stands alone as it does there; the
+ * tooltip carries what it counts.
+ */
+export function CoInvestmentCountBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className={d.count} title={`${count} co-investment${count === 1 ? '' : 's'} with PL`}>
+      {count}
+    </span>
+  );
+}
+
+/**
+ * The PL relationship on one line: marker, a statement, then the count.
+ *
+ * The count sits here rather than up on the name line so the whole relationship
+ * reads as one thought. It keeps the same shape whether or not there is backing —
+ * without a statement in front of it the chip would be a digit with no antecedent.
+ */
+export function PlHistoryLine({ backing, coInvestmentCount }: Props) {
+  const label = plBackingLabel(backing);
+  if (!label && coInvestmentCount === 0) return null;
+
+  return (
+    <div className={s.line}>
+      {label ? (
+        <PlBackingMark backing={backing} />
+      ) : (
+        <span className={s.mark}>
+          <span className={s.marker} aria-hidden />
+          <span className={s.backing}>Co-invested with PL</span>
+        </span>
+      )}
+      <CoInvestmentCountBadge count={coInvestmentCount} />
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/SearchField.tsx
+++ b/prototypes/entries/warm-intros-v2/SearchField.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * The design system's search field, with an id and a label.
+ *
+ * `components/common/filters/SearchInput` is the DS component and this renders
+ * exactly what it renders — same `DebouncedInput`, same four class overrides from
+ * `SearchInput.module.scss`, same `SearchIcon`/`CloseIcon`. Only two things
+ * change, and both are defects rather than taste:
+ *
+ * 1. **It emits `id=""`.** `SearchInput` passes `ids={{ root: '', input: '' }}`,
+ *    and `DebouncedInput` resolves that with `ids?.input ?? 'application-search-input'`.
+ *    `??` only falls back on null/undefined, so an empty string passes straight
+ *    through: the root and the input both get an empty `id` attribute. That is
+ *    invalid HTML, it puts two elements on the page sharing one id, and it leaves
+ *    nothing for a `<label for>` to point at.
+ * 2. **It has no accessible name.** `SearchInput` takes no `aria-label` and
+ *    `DebouncedInput` does not accept one either, so the field is announced with
+ *    nothing but its placeholder — and a placeholder is not a label, since it
+ *    disappears the moment you type.
+ *
+ * Both belong to the DS, not to this prototype — worth raising with dev rather
+ * than living with. A real `<label>` is used rather than `aria-label` because it
+ * also gives the field a click target, and because a visible-to-AT label survives
+ * translation tooling that `aria-label` often doesn't.
+ *
+ * Not fixable from here: `DebouncedInput` also hardcodes `application-search-flush`
+ * and `application-search-clear` on its two buttons with no override, so those
+ * still collide with the navbar's search on any page carrying both. Same root
+ * cause as (1) — the component assumes it is the only one on the page.
+ */
+
+import { CloseIcon, SearchIcon } from '@/components/icons';
+import { DebouncedInput } from '@/components/core/application-search/components/DebouncedInput';
+import ds from '@/components/common/filters/SearchInput/SearchInput.module.scss';
+import f from './FilterBar.module.scss';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** The accessible name. Rendered as a real label, hidden visually. */
+  label: string;
+  id?: string;
+}
+
+export function SearchField({ value, onChange, placeholder, label, id = 'warm-intros-search' }: Props) {
+  return (
+    <>
+      <label htmlFor={id} className={f.srOnly}>
+        {label}
+      </label>
+      <DebouncedInput
+        value={value}
+        ids={{ root: `${id}-root`, input: id }}
+        classes={{
+          root: ds.root,
+          input: ds.input,
+          flushBtn: ds.flushBtn,
+          clearBtn: ds.clearBtn,
+        }}
+        onChange={onChange}
+        placeholder={placeholder}
+        hideFlushIconOnValueInput
+        clearIcon={<CloseIcon color="#64748b" />}
+        flushIcon={<SearchIcon color="#64748b" className={ds.searchIcon} />}
+      />
+    </>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/TableColumns.module.scss
+++ b/prototypes/entries/warm-intros-v2/TableColumns.module.scss
@@ -1,45 +1,343 @@
 /**
- * Column widths for the 3-column table fork (Investor · Path · Proximity).
- * Production apportions 22/18/18/14/28 across five columns; with Team and
- * Industry / Sector gone, the remaining three are re-balanced here.
+ * Column widths for the 2-column table fork (Investor · Path). Production
+ * apportions 22/18/18/14/28 across five columns; Team and Industry / Sector are
+ * gone, and Proximity folded into the head of the path cell, so what's left is
+ * re-balanced here.
  *
- * Layout only — no colors, so nothing to token-swap. Everything else still
- * comes from the production WarmIntrosV2Table.module.scss.
+ * Below 640px the same table lays out as cards — see the `mobile-only` block at
+ * the bottom.
+ *
+ * Layout only, apart from the card's own border and fill, which are copied from
+ * the frame production already draws around the table (`.tableWrap`) and the row
+ * fill (`.row`) — the same two values, moved from around the list onto each item.
  */
 
-.table {
-  /* Production's 960px floor was sized for five columns. */
-  min-width: 620px;
-}
+@import 'styles/media.scss';
+
+/*
+ * No `.table` rule at this width: it used to re-declare `min-width: 620px` with
+ * a comment about overriding a 960px floor, but production's `.table` already
+ * *is* 620px. The class is still applied — the mobile block below uses it.
+ */
 
 .colInvestor {
-  width: 34%;
+  width: 32%;
 }
 
-/* Name and its list badge share a line; wraps rather than squeezing the name. */
-.nameLine {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
+/*
+ * `.nameLine` and the list-chip overrides that used to live here are gone —
+ * production already ships both. `WarmIntrosV2Table.module.scss` has its own
+ * `.nameLine`, and `ListMembershipTags` is the real chip (11px, weight 500 when
+ * inline), tighter than the 12px MasterProfile pill this had been borrowing and
+ * then shrinking by hand.
+ */
+
+/**
+ * Investor name: neutral, with an arrow carrying the affordance instead of colour.
+ *
+ * **Deliberate deviation from production's visual layer** — a proposal to take
+ * back to dev, not accidental drift.
+ *
+ * Production paints the name `#1b4dff`. That is the only clickable entity name in
+ * the whole portal rendered brand-blue at rest — every other surface (members
+ * grid and list, teams, projects, forum, founders table, demo-day, global search,
+ * ~23 in all) keeps it neutral. Warm Intros v2 also disagrees with itself: its own
+ * drawer renders the same investor at `#0a0c11`
+ * (`WarmIntrosV2InvestorDrawer.module.scss` `.name`, hover → `#1b4dff`), which is
+ * exactly what this now matches.
+ *
+ * Blue was still doing a real job, though — it was the only at-rest signal that
+ * the name opens something, and it is the one element in the row with a different
+ * destination (MasterProfile modal; everything else opens the path drawer). So the
+ * signal moves to a glyph rather than being deleted: see `.nameArrow`.
+ */
+.nameNeutral.nameNeutral {
+  color: var(--foreground-neutral-primary, #0a0c11);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--foreground-brand-primary, #1b4dff);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
 }
 
 /**
- * The shared listPill is already 12px — its bulk comes from weight 600 and
- * 2px 10px padding, sized for the MasterProfile modal where it sits in a row of
- * its own. Beside a 14px name in a table row it needs to recede, so the size
- * stays and the weight and padding come down.
+ * The open-in affordance. Always visible — it is replacing a resting colour, so
+ * it has to be there at rest too, and hover doesn't exist on touch at all.
+ *
+ * `OutreachInvestorTable.module.scss` `.arrowIcon` reveals its arrow on row hover,
+ * but that is the lone exception in this codebase: every other Warm Intros surface
+ * (`RouteChip`, `WarmPathDetail`, `LabOsBadge`, `InvestorDrawer`,
+ * `MasterProfileModal`) shows its `↗` permanently. Its colour ramp is still the
+ * one borrowed — `#94a3b8`, the same tertiary grey — so the glyph sits below the
+ * name and the firm line rather than competing with them.
+ *
+ * The icon is the shared `@/components/icons/ArrowUpRightIcon` (`currentColor`),
+ * not the literal `↗` character the older surfaces type inline, and not the
+ * stroked local duplicate inside `OutreachInvestorTable.tsx`.
  */
-.listBadge {
-  font-weight: 500;
-  line-height: 16px;
-  padding: 1px 8px;
+.nameArrow {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--foreground-neutral-tertiary, #94a3b8);
+  /* `.nameLine`'s 8px gap is spacing between the name and the *list chip*; the
+     glyph belongs to the name, so it claws half of it back and hugs instead. */
+  margin-left: -4px;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
 }
 
-.colProximity {
-  width: 18%;
+/**
+ * `View all (n)` goes quiet so the name doesn't have to.
+ *
+ * **Deliberate deviation from production's visual layer** — a proposal to take
+ * back to dev, not accidental drift.
+ *
+ * Once `.nameArrow` marks the name, nothing in the row needs a link colour, and
+ * `View all` has the weakest claim on one: `onViewAllPaths` and `onRowClick` are
+ * literally the same handler, so it is a second affordance for what the whole row
+ * already does — no unique destination to advertise, and no discoverability cost
+ * if it recedes, because tapping anywhere on the row does the same thing. Its
+ * count is the part that carries information, and the count survives at any
+ * colour.
+ *
+ * The underline stays: it sits beside the grey role caption, and without it a
+ * grey `View all` would read as a second caption rather than a control.
+ */
+.viewAllQuiet.viewAllQuiet {
+  color: var(--foreground-neutral-secondary, #455468);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}
+
+/**
+ * The proximity badge leads the path cell rather than owning a column: the code
+ * *is* a description of the chain (family = which bridge, +N = hops, A/B =
+ * caliber), so it belongs with the chain it describes.
+ *
+ * Leading position is the whole trick. The badge's left edge lands at the same x
+ * on every row, so the top-to-bottom scan a dedicated column was buying survives
+ * — only the code's own width varies (`F+2A` is a character shorter than
+ * `PL+1A`), about 8px of jitter on the % that follows it. Trailing the chain
+ * instead would scatter it across a variable-width row and lose that entirely.
+ *
+ * Freeing the column pays for itself: Path goes 48% → 68%, so even after the
+ * badge takes ~95px the chain has more room than it had with its own column.
+ */
+.proximityLead {
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+
+/**
+ * Production's `.pathCell` uses `gap: 6px`, which was measured against a chain
+ * that ended at the chips. The role caption now hangs below them, so that 6px
+ * became ~19px of apparent distance between the nodes and `View all` — the link
+ * read as detached from the path it belongs to.
+ *
+ * Zero here, not a smaller gap: the caption already contributes 13px of its own
+ * between the chips and the link, which is all the separation the link needs.
+ *
+ * Doubled class name — a single `.pathCellTight` ties with production's
+ * `.pathCell` on specificity, so which one won came down to bundle order. It
+ * lost.
+ */
+.pathCellTight.pathCellTight {
+  gap: 0;
+}
+
+/**
+ * `View all` moves up onto the role caption's line instead of starting a line
+ * below it.
+ *
+ * With the cell gap already at 0, the remaining distance *was* the caption's own
+ * line box — the link was clearing a 13px band it never needed to clear, because
+ * the two don't share any horizontal space: the caption starts under the first
+ * chip (~100px in, past the proximity badge), and the link is ~70px wide at the
+ * cell's left edge, under the badge. That corner is empty on every row.
+ *
+ * `.hopWithRole` reserves 13px below the chip (12px caption + 1px gap), so -13px
+ * would put the link's box exactly level with the caption's. -11px instead: two
+ * pixels of the band are left standing, which drops the link just below the
+ * caption's line rather than flush with it — still one visual band, but the link
+ * reads as belonging to the cell rather than to the caption's row. Applied only
+ * when a caption is actually rendered — the two-chip fallback has no band to
+ * move into, and pulling up there would put the link under the chips.
+ */
+.viewAllInCaptionBand {
+  margin-top: -11px;
+}
+
+/**
+ * Proximity code + score % joined into one object instead of two floating chips.
+ *
+ * They stay two elements on purpose: the code is coloured by **caliber** and the
+ * score by **band** (green >60 / yellow 25–60 / red <25). Folding the % inside
+ * the badge via its `confidence` prop would make it inherit the caliber colour,
+ * collapsing yellow and red together — and a 33% path reading the same as a 12%
+ * one matters when the filter already cuts at 20%.
+ *
+ * So: no gap, inner corners squared, matched heights. One shape, two signals.
+ * When caliber and band agree (A is always >60, so A pairs with green) the two
+ * halves are the same fill and the seam simply disappears — which is correct,
+ * since they are saying the same thing.
+ *
+ * Doubled class names raise specificity over the imported production rules
+ * without needing !important, which would otherwise depend on CSS-module import
+ * order to win.
+ *
+ * `.joinGroup` carries its own layout rather than inheriting the wrapper's,
+ * because the two surfaces wrap it differently: the table hands it production's
+ * `.proximityCell` (`gap: 6px`, wrap, centered) and the drawer hands it a bare
+ * span. Undoubled, this tied `.proximityCell` on specificity and the seam came
+ * down to bundle order — open in the table, flush in the drawer, and liable to
+ * flip between dev and a production build. `nowrap` because a joined object that
+ * can break across two lines is no longer one object.
+ */
+.joinGroup.joinGroup {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 0;
+}
+
+.joinLeft.joinLeft {
+  border-radius: 6px 0 0 6px;
+}
+
+.joinRight.joinRight {
+  border-radius: 0 6px 6px 0;
+  /* Matches the badge's 22px box: 18px line + 2px padding top and bottom. */
+  padding: 2px 6px;
+  line-height: 18px;
 }
 
 .colPath {
-  width: 48%;
+  width: 68%;
+}
+
+/* ---------------------------------------------------------------------------
+ * Mobile: the table becomes a list of cards.
+ *
+ * 640px is the exact point where it stops working — `.table` has a 620px floor
+ * and the workspace has no page padding below 1024px, so the two columns fit
+ * down to 640 and horizontally scroll below it. A row read sideways is not a
+ * row, and the two columns are already "who they are" / "how you reach them",
+ * which is a card front and back.
+ *
+ * Same DOM, restyled — no second render tree to keep in sync, and no
+ * `useMediaQuery`, which would need a mounted flag here since prototype routes
+ * server-render.
+ *
+ * Two notes for production:
+ *   - `.tableWrap` stops being a scroll box. Production uses it as the
+ *     IntersectionObserver root for infinite scroll, so that root has to fall
+ *     back to the viewport (`root: null`) at this width. Nesting a 70vh scroller
+ *     inside the page scroller is worse on touch than a long page.
+ *   - `display: block` drops the implicit table roles in every browser, which is
+ *     why the markup names them explicitly and why `thead` is hidden visually
+ *     rather than with `display: none` — the column names stay in the a11y tree.
+ * ------------------------------------------------------------------------- */
+@include mobile-only {
+  .mobileCards {
+    max-height: none;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+  }
+
+  /* Doubled: production's `.table` carries the 620px floor, and a media query
+     adds no specificity — undoubled this tied and lost, leaving 620px-wide cards
+     on a 390px screen with the chain running off the edge. */
+  .table.table {
+    min-width: 0;
+    display: block;
+  }
+
+  /* Present for screen readers, gone visually — `display: none` would take the
+     column names out of the a11y tree along with the header row. */
+  .mobileCards thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .mobileCards tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  /* The frame and fill production draws once around the whole table, drawn
+     around each record instead. */
+  .mobileCard.mobileCard {
+    display: block;
+    border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+    border-radius: 10px;
+    background: #fff;
+  }
+
+  .cardIdentity.cardIdentity,
+  .cardRoute.cardRoute {
+    display: block;
+    border-bottom: 0;
+    padding: 12px 14px;
+  }
+
+  /* Keeps the split the column header used to carry, now that the header is
+     hidden: identity above the line, route below it. Production's own row rule
+     (#f1f5f9), reused at a smaller scale. */
+  .cardRoute.cardRoute {
+    padding-top: 10px;
+    border-top: 1px solid #f1f5f9;
+  }
+
+  /*
+   * Proximity breaks to its own line and the chain starts under it.
+   *
+   * On desktop the badge leads the chain so its left edge lands at a constant x
+   * down the column — a scanning argument that doesn't exist once each row is a
+   * card. What it costs here is ~95px off the front of the first chain line, on
+   * a line that's only ~330px wide, which is most of a name. Giving it back lets
+   * two chips share a line instead of one, so a two-hop path fits on one row and
+   * a three-hop path on two.
+   *
+   * `flex-basis: 100%` rather than a wrapper element: `.pathChain` already wraps,
+   * so a full-width first item breaks the line on its own, and its 4px row gap
+   * becomes the separation — no extra DOM, and the desktop layout is untouched.
+   */
+  .proximityLead {
+    flex-basis: 100%;
+    /* The 6px that separated it from the first chip; now they're on two lines. */
+    margin-right: 0;
+  }
+
+  /*
+   * Both of the desktop tweaks to `View all` come off here, because both were
+   * answers to a single-line chain.
+   *
+   * The chain wraps at this width, so the caption is no longer the last thing in
+   * the cell — pulling the link up would land it on a row of chips rather than in
+   * the caption's band. And with the pull gone, a 0 cell gap left the link sitting
+   * flush on the chain's bottom edge, so the cell goes back to production's own
+   * 6px.
+   */
+  .viewAllInCaptionBand {
+    margin-top: 0;
+  }
+
+  .pathCellTight.pathCellTight {
+    gap: 6px;
+  }
 }

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
@@ -4,10 +4,13 @@
  * Warm Intros v2 — mocked clone of the production workspace.
  *
  * Reused from production (imported, not copied):
- *   WarmIntrosV2GlossaryDrawer, ScorePercentPill, PathProfileChip,
+ *   WarmIntrosV2GlossaryDrawer, ScorePercentPill, PathProfileChip, HopRoleBadge,
  *   ProximityCodeBadge, SectorTagsList, FilterSelect, Drawer, Modal, CopyButton,
  *   exportWarmIntrosV2Csv, parseWarmPathHopChain, masterProfileDisplay.util,
  *   and every WarmIntrosV2Workspace `.module.scss` — so this tracks production 1:1.
+ *
+ * Synced with dev 268306185 (co-investment filters): two-hop bridge paths, hop
+ * role badges, Directory-member dots and the co-investments blocks.
  *
  * Copied + simplified here (they call the API in production):
  *   WarmIntrosV2Workspace  → this file            (nuqs + react-query → local state + mocks)
@@ -18,6 +21,15 @@
  * Design changes on top of production:
  *   - the list picker gains an "All investor lists" option, and opens on it
  *   - under that scope each row carries a list badge, so mixed results stay readable
+ *   - dev's `PL member` select + its three path-kind chips collapse into one
+ *     grouped `PathViaSelect` — they are one axis asked at two resolutions
+ *   - `Backed PL/FIL` stays its own toggle (it describes the investor, not the path)
+ *   - every facet count is computed against the other live filters, so an option
+ *     reading "(3)" returns three rows
+ *   - active-filter pills + Clear all, and an empty state that can recover
+ *   - Export CSV moves onto the results line, out of the row of filters
+ *
+ * See COMPONENTS.md for the full map of both the dev sync and these changes.
  *
  * Deliberate simplifications, all data-layer only:
  *   - filters live in component state instead of the URL (no nuqs in prototypes)
@@ -27,9 +39,13 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { FilterSelect } from '@/components/common/filters/FilterSelect/FilterSelect';
+// The DS search field, plus the id and label it ships without — see SearchField.tsx.
+import { SearchField } from './SearchField';
+import { Tabs } from '@/components/common/Tabs';
+// Production's `FilterSelect`, verbatim apart from the design system's chevron in
+// place of react-select's built-in caret — see FilterSelectThin.tsx.
+import { FilterSelectThin } from './FilterSelectThin';
 import type { Option } from '@/components/form/FormSelect/types';
-import { useDebounce } from '@/hooks/useDebounce';
 import { exportWarmIntrosV2Csv } from '@/components/page/investors/WarmIntrosV2Workspace/exportWarmIntrosV2Csv';
 import { WarmIntrosV2GlossaryDrawer } from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2GlossaryDrawer';
 import {
@@ -40,48 +56,83 @@ import {
   type WarmIntrosV2PathListItem,
 } from '@/services/investors/warm-intros-v2.types';
 import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Workspace.module.scss';
+// Active-filter pills + Clear all already exist in Warm Intros **v1** — same
+// feature family, same bar. Imported rather than re-styled.
+import v1 from '@/components/page/investors/WarmIntrosWorkspace/WarmIntrosWorkspace.module.scss';
 import {
   ALL_LISTS,
   ALL_LISTS_LABEL,
   ALL_LISTS_MEMBER_COUNT,
   MOCK_INVESTOR_LISTS,
-  facetsForTargetSet,
   filterPaths,
+  pathViaFacets,
+  plBackerCount,
+  sectorFacets,
+  type PathFilters,
+  type PathVia,
   type TargetSetScope,
 } from './mocks';
+import { PathViaSelect, describePathVia } from './PathViaSelect';
+import f from './FilterBar.module.scss';
 import shell from './PageShell.module.scss';
 import { InvestorDrawerMock } from './InvestorDrawerMock';
 import { WarmIntrosV2TableMock } from './WarmIntrosV2TableMock';
+import { WarmIntrosV2WideTableMock } from './WarmIntrosV2WideTableMock';
 import { MasterProfileModalMock } from './MasterProfileModalMock';
 
-const SEARCH_DEBOUNCE_MS = 300;
+/**
+ * Two answers to "the table has too many columns", kept side by side rather than
+ * argued about: `compact` deletes columns, `columns` redistributes into them.
+ */
+type TableVariant = 'compact' | 'columns';
+
+/**
+ * Hidden, not deleted — same convention production's `PathActions` uses for its
+ * `SHOW_CAN_REFER` flag. `WarmIntrosV2WideTableMock` and `WideColumns.module.scss`
+ * stay wired up behind this, so flipping it back is one line rather than a rebuild.
+ */
+const SHOW_COLUMNS_VARIANT = false;
 
 export default function WarmIntrosV2Prototype() {
+  const [variant, setVariant] = useState<TableVariant>('compact');
   // Opens unscoped: "All investor lists" is the default, the two real lists narrow it.
   const [targetSet, setTargetSet] = useState<TargetSetScope>(ALL_LISTS);
-  const [connectorUid, setConnectorUid] = useState<string | null>(null);
   const [sector, setSector] = useState<string | null>(null);
+  // Already debounced when it arrives — `SearchInput` holds the keystrokes and
+  // only calls back after 700ms, so this state is the settled value.
   const [searchInput, setSearchInput] = useState('');
-  const debouncedSearch = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
+
+  // One value for the whole mediation axis — a shape, a PL member, or a bridge
+  // person. Nothing to silently clear, because there is nothing beside it.
+  const [pathVia, setPathVia] = useState<PathVia | null>(null);
+  // A different question (about the investor, not the path), so it stays its own
+  // control rather than joining the axis as a fourth pretend-shape.
+  const [plBacker, setPlBacker] = useState(false);
 
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [selectedProfileUid, setSelectedProfileUid] = useState<string | null>(null);
   const [drawerRow, setDrawerRow] = useState<WarmIntrosV2PathListItem | null>(null);
 
-  const paths = useMemo(
-    () =>
-      filterPaths({
-        targetSet,
-        search: debouncedSearch.trim() || undefined,
-        connectorProfileUid: connectorUid || undefined,
-        sector: sector || undefined,
-      }),
-    [targetSet, debouncedSearch, connectorUid, sector],
+  const filters = useMemo<PathFilters>(
+    () => ({
+      targetSet,
+      search: searchInput.trim() || undefined,
+      sector: sector || undefined,
+      pathVia,
+      plBacker: plBacker || undefined,
+    }),
+    [targetSet, searchInput, sector, pathVia, plBacker],
   );
+
+  const paths = useMemo(() => filterPaths(filters), [filters]);
   const total = paths.length;
 
-  const facets = useMemo(() => facetsForTargetSet(targetSet), [targetSet]);
+  // Every facet is counted against the *other* live filters, so an option that
+  // reads "(3)" returns three rows when you pick it.
+  const viaFacets = useMemo(() => pathViaFacets(filters), [filters]);
+  const sectors = useMemo(() => sectorFacets(filters), [filters]);
+  const plBackerAvailable = useMemo(() => plBackerCount(filters), [filters]);
 
   const targetSetOptions = useMemo<Option[]>(() => {
     const withCount = (name: string, count: number | undefined) =>
@@ -101,23 +152,64 @@ export default function WarmIntrosV2Prototype() {
 
   const scopeLabel = targetSet === ALL_LISTS ? ALL_LISTS_LABEL : WARM_INTROS_V2_TARGET_SET_LABEL[targetSet];
 
-  const connectorOptions = useMemo<Option[]>(
-    () => facets.connectors.map((c) => ({ value: c.profileUid, label: `${c.name} (${c.pathCount})` })),
-    [facets],
-  );
-  const connectorValue = connectorOptions.find((o) => o.value === connectorUid) ?? null;
-
   const sectorOptions = useMemo<Option[]>(
-    () => facets.sectors.map((sec) => ({ value: sec.value, label: `${sec.value} (${sec.count})` })),
-    [facets],
+    () => sectors.map((sec) => ({ value: sec.value, label: `${sec.value} (${sec.count})` })),
+    [sectors],
   );
   const sectorValue = sectorOptions.find((o) => o.value === sector) ?? null;
 
   const onPickTargetSet = useCallback((opt: Option | null) => {
     setTargetSet((opt?.value as TargetSetScope | undefined) ?? ALL_LISTS);
-    setConnectorUid(null);
+    setPathVia(null);
     setSector(null);
   }, []);
+
+  const clearAll = useCallback(() => {
+    setPathVia(null);
+    setSector(null);
+    setPlBacker(false);
+    setSearchInput('');
+  }, []);
+
+  /**
+   * What is currently on, and how to switch each thing off individually. The
+   * scope picker is deliberately absent — it always has a value, so a pill for
+   * it would never be removable.
+   */
+  const activePills = useMemo(() => {
+    const pills: Array<{ key: string; label: string; value: string; onRemove: () => void }> = [];
+
+    if (pathVia) {
+      pills.push({
+        key: 'pathVia',
+        label: 'Path via',
+        // No count on the pill: it belongs on the option you are choosing, and
+        // the results line already says how many you got.
+        value: describePathVia(pathVia),
+        onRemove: () => setPathVia(null),
+      });
+    }
+    if (sector) {
+      pills.push({ key: 'sector', label: 'Sector', value: sector, onRemove: () => setSector(null) });
+    }
+    if (plBacker) {
+      pills.push({
+        key: 'plBacker',
+        label: 'Backed',
+        value: 'PL / Filecoin',
+        onRemove: () => setPlBacker(false),
+      });
+    }
+    if (searchInput.trim()) {
+      pills.push({
+        key: 'search',
+        label: 'Search',
+        value: searchInput.trim(),
+        onRemove: () => setSearchInput(''),
+      });
+    }
+    return pills;
+  }, [pathVia, sector, plBacker, searchInput]);
 
   const onExportCsv = useCallback(() => {
     setExporting(true);
@@ -145,8 +237,6 @@ export default function WarmIntrosV2Prototype() {
     setDrawerRow(row);
   }, []);
 
-  const clearSearch = useCallback(() => setSearchInput(''), []);
-
   return (
     <div className={shell.page}>
       <div className={s.root}>
@@ -165,7 +255,7 @@ export default function WarmIntrosV2Prototype() {
 
           <div className={s.filterBar}>
             <div className={s.filterBarItem} style={{ minWidth: 280 }}>
-              <FilterSelect
+              <FilterSelectThin
                 options={targetSetOptions}
                 value={targetSetValue}
                 placeholder="Investors list"
@@ -175,47 +265,43 @@ export default function WarmIntrosV2Prototype() {
             </div>
 
             <div className={clsx(s.filterBarItem, s.filterBarSearch)}>
-              <div className={s.searchWrap}>
-                <span className={s.searchIcon} aria-hidden>
-                  <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
-                    <circle cx="9" cy="9" r="6" />
-                    <path d="M15 15l-3.5-3.5" strokeLinecap="round" />
-                  </svg>
-                </span>
-                <input
-                  className={s.searchInput}
-                  type="text"
-                  inputMode="search"
-                  autoComplete="off"
-                  value={searchInput}
-                  onChange={(e) => setSearchInput(e.target.value)}
-                  placeholder="Search name or email…"
-                  aria-label="Search name or email"
-                />
-                {searchInput ? (
-                  <button type="button" className={s.searchClear} onClick={clearSearch} aria-label="Clear search">
-                    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-                      <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                    </svg>
-                  </button>
-                ) : null}
-              </div>
-            </div>
+              {/* The design system's own search field
+                  (`components/common/filters/SearchInput`), in place of the
+                  wrapper + inline magnifier svg + hand-rolled × button that
+                  production assembles here from `.searchWrap` / `.searchIcon` /
+                  `.searchInput` / `.searchClear`.
 
-            <div className={s.filterBarItem} style={{ minWidth: 160 }}>
-              <FilterSelect
-                options={connectorOptions}
-                value={connectorValue}
-                placeholder="PL member"
-                isClearable
-                isSearchable
-                aria-label="PL member"
-                onChange={(opt) => setConnectorUid(opt?.value || null)}
+                  It brings the DS treatment: icon on the trailing edge that hides
+                  once you type, `CloseIcon` to clear, and a hover/focus ring
+                  (`#5e718d` border + `0 0 0 4px rgba(27,56,96,0.12)`) that is
+                  character-for-character the one `filterSelectStyles.control`
+                  gives the selects beside it — so the field and the selects finally
+                  respond identically. No size override needed either:
+                  `DebouncedInput`'s root is already `height: 40px` / radius 8px,
+                  the selects' own geometry.
+
+                  Debouncing comes with it (`DebouncedInput`, 700ms), which is why
+                  the local `useDebounce` is gone. The trade: 700ms instead of the
+                  300ms this had, and `DebouncedInput` doesn't forward an
+                  `aria-label`, so the field is labelled by its placeholder alone —
+                  worth raising with dev rather than patching around here. */}
+              <SearchField
+                value={searchInput}
+                onChange={setSearchInput}
+                // The filter has always matched the firm too; the placeholder
+                // just never said so.
+                placeholder="Search name, email or firm…"
+                label="Search name, email or firm"
               />
             </div>
 
+            {/* The whole mediation axis — shape or person — in one control. */}
+            <div className={s.filterBarItem} style={{ minWidth: 220 }}>
+              <PathViaSelect facets={viaFacets} value={pathVia} onChange={setPathVia} />
+            </div>
+
             <div className={s.filterBarItem} style={{ minWidth: 160 }}>
-              <FilterSelect
+              <FilterSelectThin
                 options={sectorOptions}
                 value={sectorValue}
                 placeholder="Industry / Sector"
@@ -226,31 +312,108 @@ export default function WarmIntrosV2Prototype() {
               />
             </div>
 
-            <div className={s.filterBarItem}>
-              <button type="button" className={s.exportBtn} onClick={onExportCsv} disabled={exporting || total === 0}>
-                {exporting ? 'Exporting…' : 'Export CSV'}
+            {/* Not part of the axis: this one is about the investor, not the
+                route to them. Disabled rather than hidden when nothing in the
+                current set qualifies — a control that vanishes is worse. */}
+            <div className={clsx(s.filterBarItem, s.quickFilters)}>
+              <button
+                type="button"
+                className={clsx(s.quickChip, f.axisToggle, plBacker && s.quickChipActive)}
+                aria-pressed={plBacker}
+                disabled={!plBacker && plBackerAvailable === 0}
+                title="Investors whose firm has already backed Protocol Labs or Filecoin"
+                onClick={() => setPlBacker((v) => !v)}
+              >
+                Backed PL/FIL ({plBackerAvailable})
               </button>
             </div>
           </div>
+
+          {activePills.length > 0 && (
+            <div className={v1.filterPills}>
+              {activePills.map((pill) => (
+                <span key={pill.key} className={v1.pill}>
+                  {pill.label}: <strong>{pill.value}</strong>
+                  <button
+                    type="button"
+                    className={v1.pillRemove}
+                    onClick={pill.onRemove}
+                    aria-label={`Remove ${pill.label} filter`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <button type="button" className={v1.clearAll} onClick={clearAll}>
+                Clear all
+              </button>
+            </div>
+          )}
         </section>
 
-        {total === 0 && <div className={s.state}>No paths match these filters.</div>}
+        {total === 0 && (
+          <div className={clsx(s.state, f.emptyState)}>
+            <span>No paths match these filters.</span>
+            <button type="button" className={v1.clearAll} onClick={clearAll}>
+              Clear all
+            </button>
+          </div>
+        )}
 
         {total > 0 && (
           <div className={s.listWrap}>
-            <div className={s.meta}>
-              Showing {paths.length} paths · {scopeLabel}
+            <div className={clsx(s.meta, f.metaRow)}>
+              <span>
+                Showing {paths.length} paths · {scopeLabel}
+              </span>
+              {/* Changes how the same rows are drawn, so it sits with the count
+                  rather than in the row of controls that change which rows. */}
+              {SHOW_COLUMNS_VARIANT ? (
+                <Tabs
+                  variant="pill"
+                  value={variant}
+                  onValueChange={(v) => setVariant(v as TableVariant)}
+                  tabs={[
+                    { value: 'compact', label: 'Compact' },
+                    { value: 'columns', label: 'Columns' },
+                  ]}
+                  classes={{ root: f.viewTabs, tab: f.viewTab, label: f.viewTabLabel }}
+                />
+              ) : null}
+              {/* Export is an action on the result set, so it belongs with the
+                  result count — not in a row of things that change it. */}
+              <button
+                type="button"
+                className={clsx(s.exportBtn, f.exportPrimary, f.metaRowSpacer)}
+                onClick={onExportCsv}
+                disabled={exporting}
+              >
+                {exporting ? 'Exporting…' : 'Export CSV'}
+              </button>
             </div>
-            <WarmIntrosV2TableMock
-              rows={paths}
-              onOpenMasterProfile={onOpenMasterProfile}
-              onOpenProfileUid={onOpenProfileUid}
-              onViewAllPaths={onViewAllPaths}
-              onRowClick={onRowClick}
-              // Only under "All investor lists" — inside a single list every
-              // badge would just repeat the picker.
-              showListName={targetSet === ALL_LISTS}
-            />
+            {/* Same rows, same handlers — only the column set differs, so the two
+                stay comparable on identical data. */}
+            {!SHOW_COLUMNS_VARIANT || variant === 'compact' ? (
+              <WarmIntrosV2TableMock
+                rows={paths}
+                onOpenMasterProfile={onOpenMasterProfile}
+                onOpenProfileUid={onOpenProfileUid}
+                onViewAllPaths={onViewAllPaths}
+                onRowClick={onRowClick}
+                // Only under "All investor lists" — inside a single list every
+                // badge would just repeat the picker.
+                showListName={targetSet === ALL_LISTS}
+              />
+            ) : (
+              <WarmIntrosV2WideTableMock
+                rows={paths}
+                onOpenMasterProfile={onOpenMasterProfile}
+                onOpenProfileUid={onOpenProfileUid}
+                onViewAllPaths={onViewAllPaths}
+                onRowClick={onRowClick}
+                showListName={targetSet === ALL_LISTS}
+              />
+            )}
           </div>
         )}
 

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2Prototype.tsx
@@ -73,6 +73,7 @@ import {
   type TargetSetScope,
 } from './mocks';
 import { PathViaSelect, describePathVia } from './PathViaSelect';
+import { CheckSelect } from './CheckSelect';
 import f from './FilterBar.module.scss';
 import shell from './PageShell.module.scss';
 import { InvestorDrawerMock } from './InvestorDrawerMock';
@@ -97,14 +98,14 @@ export default function WarmIntrosV2Prototype() {
   const [variant, setVariant] = useState<TableVariant>('compact');
   // Opens unscoped: "All investor lists" is the default, the two real lists narrow it.
   const [targetSet, setTargetSet] = useState<TargetSetScope>(ALL_LISTS);
-  const [sector, setSector] = useState<string | null>(null);
+  const [sector, setSector] = useState<string[]>([]);
   // Already debounced when it arrives — `SearchInput` holds the keystrokes and
   // only calls back after 700ms, so this state is the settled value.
   const [searchInput, setSearchInput] = useState('');
 
   // One value for the whole mediation axis — a shape, a PL member, or a bridge
   // person. Nothing to silently clear, because there is nothing beside it.
-  const [pathVia, setPathVia] = useState<PathVia | null>(null);
+  const [pathVia, setPathVia] = useState<PathVia[]>([]);
   // A different question (about the investor, not the path), so it stays its own
   // control rather than joining the axis as a fourth pretend-shape.
   const [plBacker, setPlBacker] = useState(false);
@@ -118,7 +119,7 @@ export default function WarmIntrosV2Prototype() {
     () => ({
       targetSet,
       search: searchInput.trim() || undefined,
-      sector: sector || undefined,
+      sector,
       pathVia,
       plBacker: plBacker || undefined,
     }),
@@ -156,17 +157,16 @@ export default function WarmIntrosV2Prototype() {
     () => sectors.map((sec) => ({ value: sec.value, label: `${sec.value} (${sec.count})` })),
     [sectors],
   );
-  const sectorValue = sectorOptions.find((o) => o.value === sector) ?? null;
 
   const onPickTargetSet = useCallback((opt: Option | null) => {
     setTargetSet((opt?.value as TargetSetScope | undefined) ?? ALL_LISTS);
-    setPathVia(null);
-    setSector(null);
+    setPathVia([]);
+    setSector([]);
   }, []);
 
   const clearAll = useCallback(() => {
-    setPathVia(null);
-    setSector(null);
+    setPathVia([]);
+    setSector([]);
     setPlBacker(false);
     setSearchInput('');
   }, []);
@@ -179,18 +179,26 @@ export default function WarmIntrosV2Prototype() {
   const activePills = useMemo(() => {
     const pills: Array<{ key: string; label: string; value: string; onRemove: () => void }> = [];
 
-    if (pathVia) {
+    // One pill per selection, not one pill listing them all: each has to be
+    // removable on its own, and "Path via: Direct, Mara, Priya" with a single ×
+    // would only offer to drop the lot.
+    for (const via of pathVia) {
       pills.push({
-        key: 'pathVia',
+        key: `pathVia:${via.type}:${via.value}`,
         label: 'Path via',
         // No count on the pill: it belongs on the option you are choosing, and
         // the results line already says how many you got.
-        value: describePathVia(pathVia),
-        onRemove: () => setPathVia(null),
+        value: describePathVia(via),
+        onRemove: () => setPathVia((current) => current.filter((v) => !(v.type === via.type && v.value === via.value))),
       });
     }
-    if (sector) {
-      pills.push({ key: 'sector', label: 'Sector', value: sector, onRemove: () => setSector(null) });
+    for (const sec of sector) {
+      pills.push({
+        key: `sector:${sec}`,
+        label: 'Sector',
+        value: sec,
+        onRemove: () => setSector((current) => current.filter((s) => s !== sec)),
+      });
     }
     if (plBacker) {
       pills.push({
@@ -301,14 +309,12 @@ export default function WarmIntrosV2Prototype() {
             </div>
 
             <div className={s.filterBarItem} style={{ minWidth: 160 }}>
-              <FilterSelectThin
+              <CheckSelect
                 options={sectorOptions}
-                value={sectorValue}
+                value={sector}
                 placeholder="Industry / Sector"
-                isClearable
-                isSearchable
                 aria-label="Industry / Sector"
-                onChange={(opt) => setSector(opt?.value || null)}
+                onChange={setSector}
               />
             </div>
 

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2TableMock.tsx
@@ -1,31 +1,38 @@
 'use client';
 
 /**
- * Fork of production `WarmIntrosV2Table` with the **Team** and **Industry / Sector**
- * columns removed, and Path moved ahead of Proximity — Investor · Path · Proximity.
+ * Fork of production `WarmIntrosV2Table`, down to two columns — **Investor** and
+ * **Path**.
  *
  * Everything else is a verbatim transcription and still uses the production
- * `WarmIntrosV2Table.module.scss`. The only local CSS is the re-balanced column
- * widths (see `TableColumns.module.scss`), because the production widths were
- * apportioned across five columns.
+ * `WarmIntrosV2Table.module.scss`; the local CSS is layout only (see
+ * `TableColumns.module.scss`), because production's widths were apportioned
+ * across five columns.
  *
- * Firm + role no longer have a column of their own, so they ride along under the
- * investor name where the email already sits — dropping the column shouldn't lose
- * the data. Sectors are gone from the row entirely; they remain in the drawer.
+ * What went, and where it went instead:
+ *   Team, Industry / Sector  → dropped (sectors remain in the drawer)
+ *   firm · role              → under the investor name
+ *   email                    → drawer + CSV export only; nobody reads an address
+ *                              at a glance, and it re-encoded the firm above it
+ *   Proximity column         → the joined code + score badge now *leads* the path
+ *                              cell, where it describes the chain it sits on
  */
 
 import type { ReactNode, Ref } from 'react';
+import { ArrowUpRightIcon } from '@/components/icons';
 import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import type { WarmIntrosV2InvestorSummary, WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
-import { PathProfileChip } from '@/components/page/investors/WarmIntrosV2Workspace/PathProfileChip';
 import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
 import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss';
-// The MasterProfile modal already colours the two lists — Neuro blue, Gold amber.
-// Reusing those pills keeps one colour language for "which list" across surfaces.
-import p from '@/components/page/investors/WarmIntrosV2Workspace/MasterProfileModal.module.scss';
+// Dev's own list chip — 11px, tighter than the 12px modal pill this used to
+// borrow, and it already resolves the label from the target set.
+import { ListMembershipTags } from '@/components/page/investors/WarmIntrosV2Workspace/ListMembershipTags';
 import c from './TableColumns.module.scss';
-import { TARGET_SET_SHORT_LABEL } from './mocks';
+// The chain rendering is shared with the wide variant — see PathChain.tsx.
+import { PathChain, chainHopsOf, hasRoleCaption } from './PathChain';
+import { PlHistoryLine } from './PlHistory';
+import { plHistoryOf } from './mocks';
 
 interface Props {
   rows: WarmIntrosV2PathListItem[];
@@ -41,22 +48,6 @@ interface Props {
   scrollRootRef?: Ref<HTMLDivElement>;
   sentinelRef?: Ref<HTMLDivElement>;
   footer?: ReactNode;
-}
-
-const LIST_FULL_LABEL: Record<string, string> = {
-  'neuro-fund-i': 'Neuro Fund I LP Pipeline',
-  'gold-co-investors': 'Gold PLC Co-Investors',
-};
-
-function ListBadge({ targetSet }: { targetSet: string }) {
-  const short = TARGET_SET_SHORT_LABEL[targetSet as keyof typeof TARGET_SET_SHORT_LABEL];
-  if (!short) return null;
-  const tone = targetSet === 'neuro-fund-i' ? p.listNeuro : targetSet === 'gold-co-investors' ? p.listGold : undefined;
-  return (
-    <span className={`${p.listPill} ${tone ?? ''} ${c.listBadge}`} title={LIST_FULL_LABEL[targetSet] ?? short}>
-      {short}
-    </span>
-  );
 }
 
 function pathCount(row: WarmIntrosV2PathListItem): number {
@@ -80,37 +71,42 @@ export function WarmIntrosV2TableMock({
   footer,
 }: Props) {
   return (
-    <div className={s.tableWrap} ref={scrollRootRef}>
-      <table className={`${s.table} ${c.table}`}>
-        <thead>
-          <tr>
-            <th className={`${s.th} ${c.colInvestor}`} scope="col">
+    // Below 640px the same DOM lays out as cards — see `.mobileCards`. The
+    // explicit roles are what keep it a table for assistive tech once the CSS
+    // takes `display: table` away; browsers drop the implicit ones when it does.
+    <div className={`${s.tableWrap} ${c.mobileCards}`} ref={scrollRootRef}>
+      <table className={`${s.table} ${c.table}`} role="table">
+        <thead role="rowgroup">
+          <tr role="row">
+            <th className={`${s.th} ${c.colInvestor}`} scope="col" role="columnheader">
               Investor
             </th>
-            <th className={`${s.th} ${c.colPath}`} scope="col">
+            {/* Just "Path": the proximity badge rides at the head of this cell,
+                but it describes the path rather than being a second thing the
+                column holds, so naming it in the header only made the header
+                longer. The code itself is decoded in the glossary drawer. */}
+            <th className={`${s.th} ${c.colPath}`} scope="col" role="columnheader">
               Path
-            </th>
-            <th className={`${s.th} ${c.colProximity}`} scope="col">
-              Proximity
             </th>
           </tr>
         </thead>
-        <tbody>
+        <tbody role="rowgroup">
           {rows.map((row) => {
             const investor = row.investor;
             const name = investor?.name?.trim() || row.targetProfileUid;
             const org = investor?.currentOrg?.trim();
             const title = investor?.currentTitle?.trim();
             const count = pathCount(row);
-            const avatarSrc = memberAvatarSrc(investor);
-            const connector = row.bestConnector;
             // Firm · role, folded into the investor cell now that Team has no column.
             const orgLine = [org, title].filter(Boolean).join(' · ');
+            const plHistory = plHistoryOf(row);
+            const captionBand = hasRoleCaption(chainHopsOf(row));
 
             return (
               <tr
                 key={row.uid}
-                className={s.row}
+                role="row"
+                className={`${s.row} ${c.mobileCard}`}
                 onClick={() => onRowClick?.(row)}
                 tabIndex={onRowClick ? 0 : undefined}
                 onKeyDown={
@@ -124,12 +120,14 @@ export function WarmIntrosV2TableMock({
                     : undefined
                 }
               >
-                <td className={s.td}>
+                <td className={`${s.td} ${c.cardIdentity}`} role="cell">
                   <div className={s.investorText}>
-                    <div className={c.nameLine}>
+                    {/* `.nameLine` is production's own — this had a local copy of
+                        it for no reason. */}
+                    <div className={s.nameLine}>
                       <button
                         type="button"
-                        className={s.nameBtn}
+                        className={`${s.nameBtn} ${c.nameNeutral}`}
                         aria-label={`Open profile for ${name}`}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -138,43 +136,52 @@ export function WarmIntrosV2TableMock({
                       >
                         {name}
                       </button>
-                      {showListName ? <ListBadge targetSet={row.targetSet} /> : null}
+                      {/* Carries the "this opens something" signal that the blue
+                          used to. `aria-hidden` because the button's own
+                          aria-label already says it — the glyph is for the eye. */}
+                      <span className={c.nameArrow} aria-hidden>
+                        <ArrowUpRightIcon />
+                      </span>
+                      {/* No `PL Network` badge: this investor's own chip in the
+                          Path column already carries the green Directory dot, so
+                          the row was stating it twice — and its green was a
+                          fourth colour competing inside one small cell. */}
+                      {showListName ? <ListMembershipTags fallbackTargetSet={row.targetSet} inline /> : null}
                     </div>
                     {orgLine ? <div className={s.subtle}>{orgLine}</div> : null}
-                    {investor?.email ? <div className={s.subtle}>{investor.email}</div> : null}
+                    {/* Email dropped: nobody reads an address, they copy it — and
+                        the copy button is in the drawer and the CSV export has it.
+                        It also mostly re-encoded the firm on the line above. */}
+                    {/* Relationship with PL, not identity — so it gets its own
+                        line rather than a third pill up on the name row. */}
+                    <PlHistoryLine backing={plHistory.backing} coInvestmentCount={plHistory.coInvestmentCount} />
                   </div>
                 </td>
 
-                <td className={s.td}>
-                  <div className={s.pathCell}>
-                    <div className={s.pathChain}>
-                      {connector ? (
-                        <PathProfileChip
-                          name={connector.name}
-                          profileUid={connector.profileUid}
-                          imageUrl={
-                            connector.memberUid
-                              ? connector.imageUrl?.trim() || getDefaultAvatar(connector.name)
-                              : connector.imageUrl
-                          }
-                          onOpen={onOpenProfileUid}
-                        />
-                      ) : (
-                        <span className={s.muted}>—</span>
-                      )}
-                      {connector && investor ? <span className={s.pathArrow}>→</span> : null}
-                      {investor ? (
-                        <PathProfileChip
-                          name={investor.name}
-                          profileUid={investor.profileUid}
-                          imageUrl={avatarSrc}
-                          onOpen={onOpenProfileUid}
-                        />
-                      ) : null}
-                    </div>
+                <td className={`${s.td} ${c.cardRoute}`} role="cell">
+                  <div className={`${s.pathCell} ${c.pathCellTight}`}>
+                    <PathChain
+                      row={row}
+                      onOpenProfileUid={onOpenProfileUid}
+                      lead={
+                        /* Leads the cell, so its left edge is at the same x on
+                           every row — the top-to-bottom scan a separate column
+                           was buying is kept without spending a column on it. */
+                        <span className={`${s.proximityCell} ${c.joinGroup} ${c.proximityLead}`}>
+                          {row.proximityCode ? (
+                            <ProximityCodeBadge code={row.proximityCode} className={c.joinLeft} />
+                          ) : null}
+                          <ScorePercentPill
+                            scorePercent={row.scorePercent}
+                            scoreBand={row.scoreBand}
+                            className={row.proximityCode ? c.joinRight : undefined}
+                          />
+                        </span>
+                      }
+                    />
                     <button
                       type="button"
-                      className={s.viewAllLink}
+                      className={`${s.viewAllLink} ${c.viewAllQuiet} ${captionBand ? c.viewAllInCaptionBand : ''}`}
                       aria-label={`View all ${count} paths for ${name}`}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -183,17 +190,6 @@ export function WarmIntrosV2TableMock({
                     >
                       View all ({count})
                     </button>
-                  </div>
-                </td>
-
-                <td className={s.td}>
-                  <div className={s.proximityCell}>
-                    {row.proximityCode ? (
-                      <ProximityCodeBadge code={row.proximityCode} />
-                    ) : (
-                      <span className={s.muted}>—</span>
-                    )}
-                    <ScorePercentPill scorePercent={row.scorePercent} scoreBand={row.scoreBand} />
                   </div>
                 </td>
               </tr>

--- a/prototypes/entries/warm-intros-v2/WarmIntrosV2WideTableMock.tsx
+++ b/prototypes/entries/warm-intros-v2/WarmIntrosV2WideTableMock.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+/**
+ * The five-column variant — **Investor · Fund · Backed · Path · Score**.
+ *
+ * The compact fork answered "too many columns" by deleting them, which left the
+ * table narrower than its container: at 1200px the two columns ran out of content
+ * around 800px and the rest was empty. This variant answers the same complaint the
+ * other way — it puts the facts back into columns and lets the table consume the
+ * width the way a table is supposed to. The whitespace goes away as a side effect
+ * of the columns actually being columns.
+ *
+ * What moves, relative to the compact fork:
+ *   firm            → its own **Fund** column, out from under the name
+ *   PL backing      → its own **Backed** column, out from under the name
+ *   score %         → its own **Score** column, right-aligned
+ *
+ * Score right-aligned is the point of giving it a column: percentages are a
+ * quantity, and a quantity is read down its last digit. Left-aligned in a mixed
+ * cell it was a label; right-aligned in a column of its own it is a ranking you can
+ * scan without reading.
+ *
+ * The cost, stated plainly: the proximity code and the score were joined into one
+ * object in the compact fork *because* they describe the same path — caliber and
+ * band, one shape. Giving score a column breaks that pairing. The code stays with
+ * the chain it describes; the score becomes scannable. Which trade is right depends
+ * on whether you are reading one row or ranking fourteen, which is exactly what
+ * having both variants is for.
+ *
+ * Everything else — the chain, the role captions, the row and cell chrome — is the
+ * same code the compact table uses (`PathChain`, production's
+ * `WarmIntrosV2Table.module.scss`).
+ */
+
+import type { ReactNode, Ref } from 'react';
+import { ArrowUpRightIcon } from '@/components/icons';
+import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
+import type { WarmIntrosV2InvestorSummary, WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
+import { ScorePercentPill } from '@/components/page/investors/WarmIntrosV2Workspace/ScorePercentPill';
+import { ListMembershipTags } from '@/components/page/investors/WarmIntrosV2Workspace/ListMembershipTags';
+import s from '@/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.module.scss';
+import c from './TableColumns.module.scss';
+import w from './WideColumns.module.scss';
+import { PathChain } from './PathChain';
+import { PlHistoryLine } from './PlHistory';
+import { plHistoryOf } from './mocks';
+
+interface Props {
+  rows: WarmIntrosV2PathListItem[];
+  onOpenMasterProfile: (investor: WarmIntrosV2InvestorSummary) => void;
+  onOpenProfileUid: (profileUid: string) => void;
+  onViewAllPaths: (row: WarmIntrosV2PathListItem) => void;
+  onRowClick?: (row: WarmIntrosV2PathListItem) => void;
+  showListName?: boolean;
+  scrollRootRef?: Ref<HTMLDivElement>;
+  sentinelRef?: Ref<HTMLDivElement>;
+  footer?: ReactNode;
+}
+
+function pathCount(row: WarmIntrosV2PathListItem): number {
+  return (row.pathSummary?.alternateCount ?? 0) + 1;
+}
+
+export function WarmIntrosV2WideTableMock({
+  rows,
+  onOpenMasterProfile,
+  onOpenProfileUid,
+  onViewAllPaths,
+  onRowClick,
+  showListName = false,
+  scrollRootRef,
+  sentinelRef,
+  footer,
+}: Props) {
+  return (
+    // Same card fallback as the compact variant below 640px — five columns is
+    // even less viable at 390px than two were.
+    <div className={`${s.tableWrap} ${w.wideCards}`} ref={scrollRootRef}>
+      <table className={`${s.table} ${w.table}`} role="table">
+        <thead role="rowgroup">
+          <tr role="row">
+            <th className={`${s.th} ${w.colInvestor}`} scope="col" role="columnheader">
+              Investor
+            </th>
+            <th className={`${s.th} ${w.colFund}`} scope="col" role="columnheader">
+              Fund
+            </th>
+            <th className={`${s.th} ${w.colBacked}`} scope="col" role="columnheader">
+              Backed
+            </th>
+            <th className={`${s.th} ${w.colPath}`} scope="col" role="columnheader">
+              Path
+            </th>
+            {/* Right-aligned header too — a numeric column reads wrong with its
+                label hanging off the left edge of the digits. */}
+            <th className={`${s.th} ${w.colScore} ${w.scoreCell}`} scope="col" role="columnheader">
+              Score
+            </th>
+          </tr>
+        </thead>
+        <tbody role="rowgroup">
+          {rows.map((row) => {
+            const investor = row.investor;
+            const name = investor?.name?.trim() || row.targetProfileUid;
+            const org = investor?.currentOrg?.trim();
+            const title = investor?.currentTitle?.trim();
+            const count = pathCount(row);
+            const plHistory = plHistoryOf(row);
+
+            return (
+              <tr
+                key={row.uid}
+                role="row"
+                className={`${s.row} ${w.wideCard}`}
+                onClick={() => onRowClick?.(row)}
+                tabIndex={onRowClick ? 0 : undefined}
+                onKeyDown={
+                  onRowClick
+                    ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onRowClick(row);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                <td className={s.td} role="cell">
+                  <div className={s.investorText}>
+                    <div className={s.nameLine}>
+                      <button
+                        type="button"
+                        className={`${s.nameBtn} ${c.nameNeutral}`}
+                        aria-label={`Open profile for ${name}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (investor) onOpenMasterProfile(investor);
+                        }}
+                      >
+                        {name}
+                      </button>
+                      <span className={c.nameArrow} aria-hidden>
+                        <ArrowUpRightIcon />
+                      </span>
+                      {showListName ? <ListMembershipTags fallbackTargetSet={row.targetSet} inline /> : null}
+                    </div>
+                    {/* Only the role stays under the name — the firm has a column
+                        of its own now, so `firm · role` would print it twice. */}
+                    {title ? <div className={s.subtle}>{title}</div> : null}
+                  </div>
+                </td>
+
+                <td className={s.td} role="cell">
+                  {org ? <span className={w.fund}>{org}</span> : <span className={`${s.muted} ${w.emptyMark}`}>—</span>}
+                </td>
+
+                <td className={s.td} role="cell">
+                  {/* Same component as the compact variant's stacked line — one
+                      treatment for one fact, wherever it sits.
+
+                      The dash matters here in a way it didn't there: stacked under
+                      a name, "no PL history" was simply an absent line. In a column
+                      it is a gap in a grid, and a gap reads as data we failed to
+                      load rather than a fact about the investor. */}
+                  {plHistory.backing || plHistory.coInvestmentCount > 0 ? (
+                    <PlHistoryLine backing={plHistory.backing} coInvestmentCount={plHistory.coInvestmentCount} />
+                  ) : (
+                    <span className={`${s.muted} ${w.emptyMark}`}>—</span>
+                  )}
+                </td>
+
+                <td className={s.td} role="cell">
+                  {/* Production's own 6px cell gap, not the compact variant's 0 +
+                      caption-band pull. That pull assumes the chain is one line and
+                      the caption is the last thing in the cell; at 39% of the width
+                      this column wraps routinely, and on a wrapped chain the pull
+                      lands `View all` on a row of chips. Same reason it is switched
+                      off in the compact variant's mobile block. */}
+                  <div className={s.pathCell}>
+                    <PathChain
+                      row={row}
+                      onOpenProfileUid={onOpenProfileUid}
+                      lead={
+                        /* The code alone here, not the joined code+% object: the
+                           score has a column now. The code still leads, because it
+                           still describes this chain. */
+                        row.proximityCode ? (
+                          <span className={w.codeLead}>
+                            <ProximityCodeBadge code={row.proximityCode} />
+                          </span>
+                        ) : null
+                      }
+                    />
+                    <button
+                      type="button"
+                      className={`${s.viewAllLink} ${c.viewAllQuiet}`}
+                      aria-label={`View all ${count} paths for ${name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onViewAllPaths(row);
+                      }}
+                    >
+                      View all ({count})
+                    </button>
+                  </div>
+                </td>
+
+                <td className={`${s.td} ${w.scoreCell}`} role="cell">
+                  <ScorePercentPill scorePercent={row.scorePercent} scoreBand={row.scoreBand} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div ref={sentinelRef} className={s.sentinel} />
+      {footer}
+    </div>
+  );
+}

--- a/prototypes/entries/warm-intros-v2/WideColumns.module.scss
+++ b/prototypes/entries/warm-intros-v2/WideColumns.module.scss
@@ -1,0 +1,175 @@
+/**
+ * Column widths for the five-column variant — Investor · Fund · Backed · Path ·
+ * Score.
+ *
+ * Production apportioned 22/18/18/14/28 across its own five. These are re-cut for
+ * a different set: Path keeps the largest share because a three-hop chain is the
+ * only cell whose content can double in width, and Score takes the smallest
+ * because a percentage is four characters no matter what.
+ *
+ * Layout only, apart from the card border and fill in the mobile block, which are
+ * the same two values `TableColumns.module.scss` borrows from production's
+ * `.tableWrap` frame and `.row` fill.
+ */
+
+@import 'styles/media.scss';
+
+.colInvestor {
+  width: 22%;
+}
+
+.colFund {
+  width: 16%;
+}
+
+.colBacked {
+  width: 15%;
+}
+
+.colPath {
+  width: 39%;
+}
+
+.colScore {
+  width: 8%;
+}
+
+/**
+ * Right-aligned, on the header as well as the cell.
+ *
+ * This is the reason score gets a column at all. A percentage is a quantity, and a
+ * quantity is compared down its last digit — left-aligned among other content it
+ * was a label you read one row at a time. `ScorePercentPill` already sets
+ * `font-variant-numeric: tabular-nums`, so the digits line up once the edge does.
+ *
+ * The header goes with it: a numeric column with its label hanging off the left of
+ * the digits reads as belonging to the column before it.
+ */
+.scoreCell {
+  text-align: right;
+}
+
+/* Production's `.pathChain` centres its items, so the badge needs nothing but the
+   gap the chain already provides — only the trailing space is its own. */
+.codeLead {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+
+/**
+ * The firm gets a column but not emphasis — it identifies the row's subject a
+ * second time (the investor works there), so it stays at the secondary weight the
+ * name's sub-line used to give it rather than becoming a second heading.
+ */
+.fund {
+  font-size: 13px;
+  color: var(--foreground-neutral-secondary, #455468);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---------------------------------------------------------------------------
+ * Mobile: same card collapse as the compact variant.
+ *
+ * Five columns at 390px is less viable than two were, and the argument is
+ * identical — a row read sideways is not a row. The cells stack in reading order,
+ * which puts identity (name, fund, backing) above the route, so the card lands in
+ * the same shape the compact variant produces even though it starts from five
+ * cells instead of two.
+ *
+ * Score moves to the *top* of the route block rather than the bottom of the card:
+ * it is the reason to look at the row, and at the end it would sit below `View
+ * all` where nothing looks.
+ * ------------------------------------------------------------------------- */
+@include mobile-only {
+  .wideCards {
+    max-height: none;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+  }
+
+  /* Doubled — production's `.table` carries a 620px floor and a media query adds
+     no specificity, the same tie that left the compact cards 620px wide. */
+  .table.table {
+    min-width: 0;
+    display: block;
+  }
+
+  /* Visually hidden, not `display: none` — the column names stay in the a11y tree
+     even though the header row is gone. */
+  .wideCards thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .wideCards tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  /* Flex rather than block so `order` can lift score out of last place. */
+  .wideCard.wideCard {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.12));
+    border-radius: 10px;
+    background: #fff;
+  }
+
+  .wideCards td {
+    display: block;
+    border-bottom: 0;
+    padding: 2px 14px;
+  }
+
+  /* Investor cell opens the card. */
+  .wideCards td:first-child {
+    padding-top: 12px;
+  }
+
+  /*
+   * Score (source order 5) moves ahead of Path (4), so the route block reads
+   * score → chain → View all. Left where the markup puts it, the number would sit
+   * below `View all` at the very bottom of the card, which is the one place nobody
+   * looks — and it is the reason to look at the row at all.
+   *
+   * Identity cells keep the default order 0, so this only reshuffles the two.
+   */
+  .wideCards td:last-child {
+    order: 1;
+    /* The divider opens the route block here now, keeping the identity/route
+       split the hidden column headers used to carry. */
+    margin-top: 8px;
+    padding-top: 10px;
+    border-top: 1px solid #f1f5f9;
+  }
+
+  .wideCards td:nth-child(4) {
+    order: 2;
+    padding-bottom: 12px;
+  }
+
+  /* Back to the left edge: right-alignment buys a scannable column, and on a card
+     there is no column to scan. */
+  .scoreCell {
+    text-align: left;
+  }
+
+  /*
+   * The placeholder dash goes away too. It earns its place in the table because an
+   * empty cell there is a hole in a grid, which reads as data that failed to load.
+   * On a card there is no grid and no hole — the line is simply absent, which is
+   * what the compact variant does with the same fact.
+   */
+  .emptyMark {
+    display: none;
+  }
+}

--- a/prototypes/entries/warm-intros-v2/mocks.ts
+++ b/prototypes/entries/warm-intros-v2/mocks.ts
@@ -6,7 +6,11 @@
  * All people, firms, emails and Affinity ids below are invented.
  */
 
-import { derivePathProximity } from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
+import {
+  derivePathProximity,
+  hopCountFromRelationKind,
+  proximityFamilyFromRelationKind,
+} from '@/components/page/investors/WarmIntrosV2Workspace/parseWarmPathHopChain';
 import type {
   MasterProfileDetail,
   WarmIntrosV2ConnectorSummary,
@@ -15,6 +19,12 @@ import type {
   WarmIntrosV2PathListItem,
   WarmIntrosV2TargetSet,
 } from '@/services/investors/warm-intros-v2.types';
+
+/**
+ * The three path shapes v2 emits. `pl_direct` is one hop (PL member → investor);
+ * the two bridges are two hops, through a portfolio founder or a co-investor.
+ */
+export type RelationKind = 'pl_direct' | 'founder_bridge' | 'coinvestor_bridge';
 
 /** v1 InvestorList rows the target-set picker reads names + counts from. */
 export const MOCK_INVESTOR_LISTS: Array<{ slug: string; name: string; member_count: number }> = [
@@ -32,15 +42,11 @@ export type TargetSetScope = typeof ALL_LISTS | WarmIntrosV2TargetSet;
 
 export const ALL_LISTS_LABEL = 'All investor lists';
 
-/**
- * Short list names for the per-row badge. The full labels
- * ("Neuro Fund I LP Pipeline") are too long to sit beside a name, so the badge
- * abbreviates and carries the full label as its tooltip.
+/*
+ * Short list names used to live here for the per-row badge. Production already
+ * has them as `WARM_INTROS_V2_LIST_TAG_LABEL`, and `ListMembershipTags` reads
+ * that itself — so the row renders dev's chip and this copy is gone.
  */
-export const TARGET_SET_SHORT_LABEL: Record<WarmIntrosV2TargetSet, string> = {
-  'neuro-fund-i': 'Neuro Fund I',
-  'gold-co-investors': 'Gold PLC',
-};
 
 /** Total members across the mocked lists — the count shown on the "All" option. */
 export const ALL_LISTS_MEMBER_COUNT = MOCK_INVESTOR_LISTS.reduce((sum, l) => sum + l.member_count, 0);
@@ -106,19 +112,169 @@ export const MOCK_CONNECTORS: Record<string, WarmIntrosV2ConnectorSummary> = {
   },
 };
 
+// ── Bridges ──────────────────────────────────────────────────────────────────
+// The middle hop on a two-hop path: a portfolio founder the PL member knows, or
+// a co-investor who already shares a cap table with the target. Same summary
+// shape as a connector — they render through the same chip.
+
+export const MOCK_BRIDGES: Record<string, WarmIntrosV2ConnectorSummary> = {
+  'fd-anais': {
+    profileUid: 'mp-fd-anais',
+    personKey: 'anais.leclerc',
+    name: 'Anaïs Leclerc',
+    currentOrg: 'Synapse Foundry',
+    currentTitle: 'Co-founder & CEO',
+    memberUid: 'member-anais',
+    imageUrl: null,
+  },
+  'fd-oskar': {
+    profileUid: 'mp-fd-oskar',
+    personKey: 'oskar.lindqvist',
+    name: 'Oskar Lindqvist',
+    currentOrg: 'Meshgrid Labs',
+    currentTitle: 'Founder & CTO',
+    memberUid: 'member-oskar',
+    imageUrl: null,
+  },
+  'fd-priya': {
+    profileUid: 'mp-fd-priya',
+    personKey: 'priya.raghunathan',
+    name: 'Priya Raghunathan',
+    currentOrg: 'Corticon Bio',
+    currentTitle: 'Co-founder',
+    memberUid: null,
+    imageUrl: null,
+  },
+  'ci-johan': {
+    profileUid: 'mp-ci-johan',
+    personKey: 'johan.brekke',
+    name: 'Johan Brekke',
+    currentOrg: 'Fjord Ventures',
+    currentTitle: 'Partner',
+    memberUid: null,
+    imageUrl: null,
+  },
+  'ci-renata': {
+    profileUid: 'mp-ci-renata',
+    personKey: 'renata.duarte',
+    name: 'Renata Duarte',
+    currentOrg: 'Atlantica Capital',
+    currentTitle: 'General Partner',
+    memberUid: null,
+    imageUrl: null,
+  },
+};
+
+// ── Events ───────────────────────────────────────────────────────────────────
+/**
+ * Per-person event attendance, keyed by profileUid — the same source the
+ * MasterProfile `events` field reads from, so the modal and the derived overlap
+ * can never disagree.
+ *
+ * Overlaps are deliberate and sparse: if everyone shared LabWeek the note would
+ * fire on every row and mean nothing.
+ */
+const EVENTS_BY_PROFILE: Record<string, string[]> = {
+  // PL connectors.
+  //
+  // Mara and Elena deliberately overlap on four events, so the drawer's shared-
+  // events block exercises its crowded state: a pair with more events than the
+  // list shows, and therefore its "Show N more" toggle. Every other pair overlaps
+  // on one or none, which is the ordinary case.
+  'mp-pl-mara': ['LabWeek 2025', 'Neuro Capital Roundtable', 'Token2049 2025', 'FIL Dev Summit 2025'],
+  'mp-pl-tomas': ['Open Science Summit 2025', 'LabWeek 2025'],
+  'mp-pl-ilse': ['LabWeek 2025'],
+  'mp-pl-quan': ['ETHDenver 2024'],
+  // Bridges
+  'mp-fd-anais': ['ETHDenver 2024', 'LabWeek 2025'],
+  'mp-fd-oskar': ['Hardware Summit 2025'],
+  'mp-ci-renata': ['Climate Capital Forum 2025'],
+  // Priya sits mid-chain on the Arjun path, so she overlaps with the hop on each
+  // side of her — that is the case where the block has two groups and has to name
+  // which pair each one belongs to.
+  'mp-fd-priya': ['Open Science Summit 2025'],
+  // Investors — only some overlap with the person who reaches them
+  'mp-inv-elena-marchand': ['LabWeek 2025', 'Token2049 2025', 'Neuro Capital Roundtable', 'FIL Dev Summit 2025'],
+  'mp-inv-arjun-pillai': ['Open Science Summit 2025'],
+  'mp-inv-ken-abelard': ['ETHDenver 2024', 'Token2049 2025'],
+  'mp-inv-linnea-holm': ['Neuro Capital Roundtable'],
+  'mp-inv-sofia-marchetti': ['Frontier Robotics Expo 2025'],
+  'mp-inv-ingrid-lundqvist': ['Climate Capital Forum 2025'],
+};
+
+function eventsFor(profileUid: string): string[] {
+  return EVENTS_BY_PROFILE[profileUid] ?? [];
+}
+
+/**
+ * Events both people attended. A shared event belongs to the *pair*, which is
+ * why this takes two uids rather than hanging off either profile.
+ */
+export function sharedEventsBetween(a: string, b: string): string[] {
+  const other = new Set(eventsFor(b));
+  return eventsFor(a).filter((event) => other.has(event));
+}
+
 // ── Investors ────────────────────────────────────────────────────────────────
+
+/** Proven PL co-investment, as MasterProfile.coInvestments carries it. */
+type CoInvestmentSeed = {
+  name: string;
+  teamUid: string;
+  dealStage?: string;
+  dealDate?: string;
+  dealAmount?: string;
+  isLeadInvestor?: boolean;
+};
+
+/** PL/FIL prior-backer flags — the "PL/FIL investors" chip filters on this. */
+export type PlBackingSeed = {
+  backedProtocolLabs: boolean;
+  backedFilecoin: boolean;
+  matchKind: string;
+  firmName?: string;
+};
 
 type InvestorSeed = WarmIntrosV2InvestorSummary & {
   /** Which mocked list this investor belongs to. */
   targetSet: WarmIntrosV2TargetSet;
   /** Best connector key into MOCK_CONNECTORS. */
   connector: keyof typeof MOCK_CONNECTORS;
+  /**
+   * Path shape. Defaults to `pl_direct`; the two bridge kinds add a middle hop
+   * and shift the proximity family to F+2 / VC+2.
+   */
+  relationKind?: RelationKind;
+  /** The middle hop — required when relationKind is a bridge. */
+  bridge?: keyof typeof MOCK_BRIDGES;
+  /**
+   * When true the chain is `bridge → investor` and the PL member is not a node
+   * at all. Real payloads emit this shape — production's drawer builds its
+   * alternates exactly this way — so it has to be represented here, or the
+   * prototype only ever tests the 3-node chain and code starts assuming hop 0
+   * is always a PL member. It isn't.
+   */
+  bridgeLeads?: boolean;
   /** 0–1 path strength; drives proximity code, caliber, score % and band. */
   score: number;
-  /** Reason lines the drawer lists under "Best path". */
-  reasons: string[];
+  /**
+   * Reason lines the drawer lists under "Best path". A bare string keeps the
+   * default provenance (first is web-verified, the rest are model-inferred);
+   * the object form states its own `sourceType`.
+   */
+  reasons: Array<string | { text: string; source: string }>;
   /** Alternate connectors, weaker than the best path. */
-  alternates: Array<{ connector: keyof typeof MOCK_CONNECTORS; score: number; reason: string }>;
+  alternates: Array<{
+    connector: keyof typeof MOCK_CONNECTORS;
+    score: number;
+    reason: string;
+    /** An alternate can reach the investor a different way than the best path. */
+    relationKind?: RelationKind;
+  }>;
+  /** Proven co-investments alongside PL — shown in the drawer and the modal. */
+  coInvestments?: CoInvestmentSeed[];
+  /** Set when this investor has already backed PL or Filecoin. */
+  plBacking?: PlBackingSeed;
 };
 
 const INVESTOR_SEEDS: InvestorSeed[] = [
@@ -136,6 +292,29 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     imageUrl: null,
     connector: 'pl-mara',
     score: 0.87,
+    plBacking: {
+      backedProtocolLabs: true,
+      backedFilecoin: false,
+      matchKind: 'firm',
+      firmName: 'North Axis Capital',
+    },
+    coInvestments: [
+      {
+        name: 'Synapse Foundry',
+        teamUid: 'team-synapse',
+        dealStage: 'Seed',
+        dealDate: '2025-03',
+        dealAmount: '$4.2M',
+        isLeadInvestor: true,
+      },
+      {
+        name: 'Corticon Bio',
+        teamUid: 'team-corticon',
+        dealStage: 'Series A',
+        dealDate: '2024-09',
+        dealAmount: '$11M',
+      },
+    ],
     reasons: [
       'Mara and Linnéa co-hosted the Neuro Capital roundtable at LabWeek 2025 and have exchanged mail since.',
       'North Axis is an existing LP in two Protocol Labs–adjacent funds.',
@@ -158,10 +337,12 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     memberUid: null,
     imageUrl: null,
     connector: 'pl-tomas',
+    relationKind: 'founder_bridge',
+    bridge: 'fd-priya',
     score: 0.74,
     reasons: [
-      'Tomás and Arjun co-authored a 2024 position paper on open neuro datasets.',
-      'Meridian Bio backed a portfolio company Tomás sourced.',
+      'Tomás backed Priya’s seed round at Corticon Bio and still sits on her monthly investor call.',
+      'Priya raised her Series A from Meridian Bio — Arjun led it.',
     ],
     alternates: [
       { connector: 'pl-nadia', score: 0.31, reason: 'Nadia supported a shared portfolio company through diligence.' },
@@ -184,7 +365,12 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     reasons: ['Ilse and Sofia served together on the LabWeek programme committee.'],
     alternates: [
       { connector: 'pl-mara', score: 0.44, reason: 'Warm but dated — one intro thread in early 2024.' },
-      { connector: 'pl-quan', score: 0.19, reason: 'Weak signal: shared alumni network only.' },
+      {
+        connector: 'pl-quan',
+        score: 0.19,
+        reason: 'Via Oskar Lindqvist (Meshgrid) — Cortex led his seed, Quan knows him well.',
+        relationKind: 'founder_bridge',
+      },
     ],
   },
   {
@@ -200,8 +386,13 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     memberUid: null,
     imageUrl: null,
     connector: 'pl-devin',
+    relationKind: 'coinvestor_bridge',
+    bridge: 'ci-johan',
     score: 0.55,
-    reasons: ['Devin and Hendrik are both mentors in the same hardware accelerator cohort.'],
+    reasons: [
+      'Fjord and Delft Seed have co-led two hardware rounds; Johan and Hendrik share three cap tables.',
+      'Devin ran the Fjord co-investment process himself, so the ask goes through a live relationship.',
+    ],
     alternates: [],
   },
   {
@@ -236,8 +427,10 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     memberUid: null,
     imageUrl: null,
     connector: 'pl-nadia',
+    relationKind: 'founder_bridge',
+    bridge: 'fd-oskar',
     score: 0.33,
-    reasons: ['Nadia and Callum overlapped on one diligence call in 2025 — thin but real.'],
+    reasons: ['Oskar pitched Severnhill last spring; Callum passed but stayed in touch. Nadia backed Oskar in 2023.'],
     alternates: [{ connector: 'pl-ilse', score: 0.21, reason: 'Shared conference panel, no direct correspondence.' }],
   },
   {
@@ -271,6 +464,15 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     imageUrl: null,
     connector: 'pl-devin',
     score: 0.63,
+    plBacking: {
+      backedProtocolLabs: false,
+      backedFilecoin: true,
+      matchKind: 'firm',
+      firmName: 'Kalahari Capital',
+    },
+    coInvestments: [
+      { name: 'Meshgrid Labs', teamUid: 'team-meshgrid', dealStage: 'Seed', dealDate: '2025-01', dealAmount: '$2.8M' },
+    ],
     reasons: [
       'Devin ran a joint founder session with Kalahari in Cape Town.',
       'Two live email threads in the last quarter.',
@@ -293,6 +495,30 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     imageUrl: null,
     connector: 'pl-mara',
     score: 0.91,
+    plBacking: {
+      backedProtocolLabs: true,
+      backedFilecoin: true,
+      matchKind: 'firm',
+      firmName: 'Au Ventures',
+    },
+    coInvestments: [
+      {
+        name: 'Meshgrid Labs',
+        teamUid: 'team-meshgrid',
+        dealStage: 'Series A',
+        dealDate: '2025-06',
+        dealAmount: '$14M',
+        isLeadInvestor: true,
+      },
+      { name: 'Synapse Foundry', teamUid: 'team-synapse', dealStage: 'Seed', dealDate: '2025-03' },
+      {
+        name: 'Halide Storage',
+        teamUid: 'team-halide',
+        dealStage: 'Series B',
+        dealDate: '2024-11',
+        dealAmount: '$30M',
+      },
+    ],
     reasons: [
       'Au Ventures co-invested with Gold PLC in two consecutive rounds; Mara led both syndicates.',
       'Standing quarterly call between Mara and Elena.',
@@ -315,8 +541,19 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     memberUid: null,
     imageUrl: null,
     connector: 'pl-quan',
+    relationKind: 'founder_bridge',
+    bridge: 'fd-anais',
+    // 2-node shape: Anaïs reaches Ken directly, no PL member in the chain.
+    bridgeLeads: true,
     score: 0.71,
-    reasons: ['Quan has introduced three founders to Ken since 2024; two converted to term sheets.'],
+    reasons: [
+      'Anaïs raised her Series A from Bluerock — Ken took the board seat.',
+      {
+        text: 'Anaïs and Ken both spoke on the open-infrastructure track at ETHDenver 2024.',
+        source: 'sharedEvent',
+      },
+      'Quan has worked with Anaïs since Synapse Foundry’s first PL grant.',
+    ],
     alternates: [{ connector: 'pl-ilse', score: 0.4, reason: 'Ilse and Ken sit on the same standards working group.' }],
   },
   {
@@ -332,8 +569,12 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     memberUid: null,
     imageUrl: null,
     connector: 'pl-ilse',
+    relationKind: 'coinvestor_bridge',
+    bridge: 'ci-renata',
+    // 2-node shape again, on the co-investor side.
+    bridgeLeads: true,
     score: 0.58,
-    reasons: ['Ilse and Ingrid co-chaired the open-infrastructure track at two conferences.'],
+    reasons: ['Atlantica and Norrsken have co-invested four times; Ilse and Renata speak monthly.'],
     alternates: [],
   },
   {
@@ -350,6 +591,9 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     imageUrl: null,
     connector: 'pl-devin',
     score: 0.42,
+    coInvestments: [
+      { name: 'Halide Storage', teamUid: 'team-halide', dealStage: 'Seed', dealDate: '2023-08', dealAmount: '$3.1M' },
+    ],
     reasons: ['Devin and Rafael have an open thread from a 2025 co-investment that did not close.'],
     alternates: [{ connector: 'pl-mara', score: 0.27, reason: 'Indirect: shared LP base, no direct contact.' }],
   },
@@ -384,6 +628,12 @@ const INVESTOR_SEEDS: InvestorSeed[] = [
     imageUrl: null,
     connector: 'pl-tomas',
     score: 0.66,
+    plBacking: {
+      backedProtocolLabs: true,
+      backedFilecoin: false,
+      matchKind: 'person',
+      firmName: 'Lagos Delta Fund',
+    },
     reasons: ['Tomás and Samuel ran a joint research grant programme in 2025.'],
     alternates: [
       { connector: 'pl-quan', score: 0.38, reason: 'Quan referred one founder that Lagos Delta later backed.' },
@@ -408,20 +658,36 @@ function toInvestorSummary(seed: InvestorSeed): WarmIntrosV2InvestorSummary {
   };
 }
 
+/** The middle hop's role — what the bridge person is to the target. */
+function bridgeRole(relationKind: RelationKind): string {
+  return relationKind === 'founder_bridge' ? 'founder' : 'co_investor';
+}
+
 function buildRow(seed: InvestorSeed, index: number): WarmIntrosV2PathListItem {
   const investor = toInvestorSummary(seed);
   const connector = MOCK_CONNECTORS[seed.connector];
-  const proximity = derivePathProximity(seed.score, 1);
+  const relationKind: RelationKind = seed.relationKind ?? 'pl_direct';
+  const bridge = seed.bridge ? MOCK_BRIDGES[seed.bridge] : null;
+  // Production derives the code from the path shape, not the hop array: two hops
+  // for either bridge, and the family letter says which bridge (F / VC / PL).
+  const hopCount = hopCountFromRelationKind(relationKind);
+  const proximity = derivePathProximity(seed.score, hopCount, proximityFamilyFromRelationKind(relationKind));
 
   const alternates = seed.alternates.map((alt) => {
     const c = MOCK_CONNECTORS[alt.connector];
-    const altProximity = derivePathProximity(alt.score, 1);
+    const altKind: RelationKind = alt.relationKind ?? 'pl_direct';
+    const altProximity = derivePathProximity(
+      alt.score,
+      hopCountFromRelationKind(altKind),
+      proximityFamilyFromRelationKind(altKind),
+    );
     return {
       profileUid: c.profileUid,
       name: c.name,
       score: alt.score,
       memberUid: c.memberUid,
       imageUrl: c.imageUrl,
+      relationKind: altKind,
       reasons: [{ description: alt.reason, sourceType: 'llmPairing' }],
       proximityCode: altProximity?.proximityCode ?? null,
       caliber: altProximity?.caliber ?? null,
@@ -430,39 +696,60 @@ function buildRow(seed: InvestorSeed, index: number): WarmIntrosV2PathListItem {
     };
   });
 
+  const bridgeHop = bridge
+    ? {
+        profileUid: bridge.profileUid,
+        name: bridge.name,
+        role: bridgeRole(relationKind),
+        memberUid: bridge.memberUid,
+        imageUrl: bridge.imageUrl,
+      }
+    : null;
+
+  const plHop = {
+    profileUid: connector.profileUid,
+    name: connector.name,
+    role: 'pl_connector',
+    score: seed.score,
+    memberUid: connector.memberUid,
+    imageUrl: connector.imageUrl,
+  };
+
+  const lead = bridge && seed.bridgeLeads ? bridge : connector;
+
+  const hops = [
+    // `bridgeLeads` drops the PL member from the chain entirely: the founder or
+    // co-investor *is* hop 0. Both shapes occur, which is exactly why nothing
+    // downstream may infer a hop's role from its index.
+    ...(bridgeHop && seed.bridgeLeads ? [bridgeHop] : [plHop, ...(bridgeHop ? [bridgeHop] : [])]),
+    {
+      profileUid: investor.profileUid,
+      name: investor.name,
+      role: 'investor',
+      memberUid: investor.memberUid,
+      imageUrl: investor.imageUrl,
+    },
+  ];
+
   return {
     uid: `wp2-${index + 1}`,
     targetProfileUid: seed.profileUid,
     targetSet: seed.targetSet,
     rank: 1,
     score: seed.score,
-    hopCount: 1,
+    hopCount,
     hopChain: {
-      relationKind: 'pl_direct',
-      hops: [
-        {
-          profileUid: connector.profileUid,
-          name: connector.name,
-          role: 'pl_connector',
-          score: seed.score,
-          memberUid: connector.memberUid,
-          imageUrl: connector.imageUrl,
-        },
-        {
-          profileUid: investor.profileUid,
-          name: investor.name,
-          role: 'investor',
-          memberUid: investor.memberUid,
-          imageUrl: investor.imageUrl,
-        },
-      ],
-      reasons: seed.reasons.map((description, i) => ({
-        description,
-        sourceType: i === 0 ? 'webVerify' : 'llmPairing',
-      })),
+      relationKind,
+      hops,
+      reasons: seed.reasons.map((reason, i) =>
+        typeof reason === 'string'
+          ? { description: reason, sourceType: i === 0 ? 'webVerify' : 'llmPairing' }
+          : { description: reason.text, sourceType: reason.source },
+      ),
       alternates,
     },
-    bestConnectorProfileUid: connector.profileUid,
+    // Whoever actually starts the chain — the bridge when it leads, else the PL member.
+    bestConnectorProfileUid: lead.profileUid,
     alternateConnectorProfileUids: alternates.map((a) => a.profileUid),
     runId: 'mock-run-2026-07',
     computedAt: '2026-07-21T09:00:00.000Z',
@@ -471,62 +758,109 @@ function buildRow(seed: InvestorSeed, index: number): WarmIntrosV2PathListItem {
     scorePercent: proximity?.scorePercent ?? 0,
     scoreBand: proximity?.scoreBand,
     investor,
-    bestConnector: connector,
+    bestConnector: lead,
     pathSummary: {
-      explanation: seed.reasons[0] ?? null,
+      explanation: (typeof seed.reasons[0] === 'string' ? seed.reasons[0] : seed.reasons[0]?.text) ?? null,
       alternateCount: alternates.length,
     },
   };
 }
+
+/** Seed lookup by target profile — the filters read plBacking off it. */
+const SEED_BY_PROFILE_UID = new Map(INVESTOR_SEEDS.map((seed) => [seed.profileUid, seed]));
 
 /** Every mocked path row, both target sets, already rank-1 sorted by score. */
 export const MOCK_PATHS: WarmIntrosV2PathListItem[] = INVESTOR_SEEDS.map(buildRow).sort(
   (a, b) => b.scorePercent - a.scorePercent,
 );
 
-/** Facets for the PL member + sector selects, derived from the rows in scope. */
-export function facetsForTargetSet(targetSet: TargetSetScope): WarmIntrosV2Facets {
-  const rows = targetSet === ALL_LISTS ? MOCK_PATHS : MOCK_PATHS.filter((p) => p.targetSet === targetSet);
+/**
+ * "Path via" — one axis, one value. It answers *how does this intro get made*,
+ * at whichever resolution you want to ask it:
+ *
+ *   kind   → any path of this shape       (all founder bridges)
+ *   member → this PL person starts it     (anything Mara can reach, any shape)
+ *   bridge → this founder / co-investor mediates it
+ *
+ * Dev ships the coarse half as three chips and the person half as a separate
+ * "PL member" select. They are the same question, so here they are one control.
+ */
+export type PathVia =
+  | { type: 'kind'; value: RelationKind }
+  | { type: 'member'; value: string }
+  | { type: 'bridge'; value: string };
 
-  const connectorCounts = new Map<string, { profileUid: string; name: string; pathCount: number }>();
-  const sectorCounts = new Map<string, number>();
+export type PathFilters = {
+  targetSet: TargetSetScope;
+  search?: string;
+  sector?: string;
+  pathVia?: PathVia | null;
+  /** Only investors whose MasterProfile carries plBacking. */
+  plBacker?: boolean;
+};
 
-  for (const row of rows) {
-    const c = row.bestConnector;
-    if (c) {
-      const prev = connectorCounts.get(c.profileUid);
-      connectorCounts.set(c.profileUid, {
-        profileUid: c.profileUid,
-        name: c.name,
-        pathCount: (prev?.pathCount ?? 0) + 1,
-      });
-    }
-    for (const sector of row.investor.sectors) {
-      sectorCounts.set(sector, (sectorCounts.get(sector) ?? 0) + 1);
-    }
-  }
+/** The seed a row was built from — `hopChain` is typed `unknown` on the row. */
+function seedForRow(row: WarmIntrosV2PathListItem): InvestorSeed | undefined {
+  return SEED_BY_PROFILE_UID.get(row.targetProfileUid);
+}
 
+export function relationKindOf(row: WarmIntrosV2PathListItem): RelationKind {
+  return seedForRow(row)?.relationKind ?? 'pl_direct';
+}
+
+/** The bridge person, whether it leads the chain or sits in the middle. */
+export function bridgeOf(row: WarmIntrosV2PathListItem): WarmIntrosV2ConnectorSummary | null {
+  const key = seedForRow(row)?.bridge;
+  return key ? MOCK_BRIDGES[key] : null;
+}
+
+/**
+ * True when a PL member actually starts this path. On a `bridgeLeads` row the
+ * chain opens on the founder / co-investor and no PL member is a node — so the
+ * "PL member" facet group must not claim its `bestConnector`.
+ */
+export function hasPlLead(row: WarmIntrosV2PathListItem): boolean {
+  const seed = seedForRow(row);
+  return !(seed?.bridge && seed.bridgeLeads);
+}
+
+/**
+ * The investor's standing relationship with PL. The row itself carries neither
+ * field — both live on the MasterProfile — so the table reads them from here
+ * rather than fetching a profile per row.
+ */
+export function plHistoryOf(row: WarmIntrosV2PathListItem): {
+  backing: PlBackingSeed | null;
+  coInvestmentCount: number;
+} {
+  const seed = seedForRow(row);
   return {
-    connectors: Array.from(connectorCounts.values()).sort((a, b) => b.pathCount - a.pathCount),
-    sectors: Array.from(sectorCounts.entries())
-      .map(([value, count]) => ({ value, count }))
-      .sort((a, b) => b.count - a.count),
+    backing: seed?.plBacking ?? null,
+    coInvestmentCount: seed?.coInvestments?.length ?? 0,
   };
 }
 
-/** Client-side stand-in for the list endpoint's filtering. */
-export function filterPaths(params: {
-  targetSet: TargetSetScope;
-  search?: string;
-  connectorProfileUid?: string;
-  sector?: string;
-}): WarmIntrosV2PathListItem[] {
+function matchesPathVia(row: WarmIntrosV2PathListItem, via: PathVia): boolean {
+  if (via.type === 'kind') return relationKindOf(row) === via.value;
+  if (via.type === 'member') return hasPlLead(row) && row.bestConnector?.profileUid === via.value;
+  return bridgeOf(row)?.profileUid === via.value;
+}
+
+/**
+ * Client-side stand-in for the list endpoint's filtering.
+ *
+ * `omit` drops one axis so a facet can be counted against everything *except*
+ * itself — otherwise every option in an open dropdown reads "1", which is just
+ * the current selection reflected back.
+ */
+export function filterPaths(params: PathFilters, omit?: 'pathVia' | 'sector' | 'plBacker'): WarmIntrosV2PathListItem[] {
   const q = params.search?.trim().toLowerCase();
 
   return MOCK_PATHS.filter((row) => {
     if (params.targetSet !== ALL_LISTS && row.targetSet !== params.targetSet) return false;
-    if (params.connectorProfileUid && row.bestConnector?.profileUid !== params.connectorProfileUid) return false;
-    if (params.sector && !row.investor.sectors.includes(params.sector)) return false;
+    if (omit !== 'sector' && params.sector && !row.investor.sectors.includes(params.sector)) return false;
+    if (omit !== 'pathVia' && params.pathVia && !matchesPathVia(row, params.pathVia)) return false;
+    if (omit !== 'plBacker' && params.plBacker && !seedForRow(row)?.plBacking) return false;
     if (q) {
       const haystack =
         `${row.investor.name} ${row.investor.email ?? ''} ${row.investor.currentOrg ?? ''}`.toLowerCase();
@@ -534,6 +868,73 @@ export function filterPaths(params: {
     }
     return true;
   });
+}
+
+export type PathViaFacets = {
+  kinds: Array<{ value: RelationKind; count: number }>;
+  members: Array<{ profileUid: string; name: string; count: number }>;
+  bridges: Array<{ profileUid: string; name: string; role: 'founder' | 'co_investor'; count: number }>;
+};
+
+/**
+ * Every "Path via" option counted against the *other* active filters, so the
+ * number on an option is what you will actually get if you pick it.
+ */
+export function pathViaFacets(filters: PathFilters): PathViaFacets {
+  const rows = filterPaths(filters, 'pathVia');
+
+  const kinds = new Map<RelationKind, number>();
+  const members = new Map<string, { profileUid: string; name: string; count: number }>();
+  const bridges = new Map<
+    string,
+    { profileUid: string; name: string; role: 'founder' | 'co_investor'; count: number }
+  >();
+
+  for (const row of rows) {
+    const kind = relationKindOf(row);
+    kinds.set(kind, (kinds.get(kind) ?? 0) + 1);
+
+    const c = row.bestConnector;
+    if (c && hasPlLead(row)) {
+      const prev = members.get(c.profileUid);
+      members.set(c.profileUid, { profileUid: c.profileUid, name: c.name, count: (prev?.count ?? 0) + 1 });
+    }
+
+    const bridge = bridgeOf(row);
+    if (bridge) {
+      const prev = bridges.get(bridge.profileUid);
+      bridges.set(bridge.profileUid, {
+        profileUid: bridge.profileUid,
+        name: bridge.name,
+        role: kind === 'founder_bridge' ? 'founder' : 'co_investor',
+        count: (prev?.count ?? 0) + 1,
+      });
+    }
+  }
+
+  const KIND_ORDER: RelationKind[] = ['pl_direct', 'founder_bridge', 'coinvestor_bridge'];
+
+  return {
+    kinds: KIND_ORDER.filter((k) => kinds.has(k)).map((value) => ({ value, count: kinds.get(value) ?? 0 })),
+    members: Array.from(members.values()).sort((a, b) => b.count - a.count || a.name.localeCompare(b.name)),
+    bridges: Array.from(bridges.values()).sort((a, b) => b.count - a.count || a.name.localeCompare(b.name)),
+  };
+}
+
+/** Sector facet, counted against everything except the sector filter itself. */
+export function sectorFacets(filters: PathFilters): WarmIntrosV2Facets['sectors'] {
+  const counts = new Map<string, number>();
+  for (const row of filterPaths(filters, 'sector')) {
+    for (const sector of row.investor.sectors) counts.set(sector, (counts.get(sector) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** How many rows the PL/FIL lens would leave, given everything else. */
+export function plBackerCount(filters: PathFilters): number {
+  return filterPaths({ ...filters, plBacker: true }, undefined).length;
 }
 
 // ── Master profiles ──────────────────────────────────────────────────────────
@@ -568,6 +969,8 @@ function investorProfile(seed: InvestorSeed): MasterProfileDetail {
       sectors: seed.sectors,
       thesis: 'Backs research-dense teams commercialising open scientific infrastructure.',
     },
+    coInvestments: seed.coInvestments ?? [],
+    plBacking: seed.plBacking ?? null,
     locations: [{ city: 'Lisbon', country: 'Portugal' }],
     listMemberships: [
       {
@@ -579,7 +982,9 @@ function investorProfile(seed: InvestorSeed): MasterProfileDetail {
     currentOrg: seed.currentOrg,
     currentTitle: seed.currentTitle,
     projects: [{ name: 'Open Neuro Data Commons' }, { name: 'Frontier Compute Alliance' }],
-    events: [{ name: 'LabWeek 2025' }, { name: 'Neuro Capital Roundtable' }],
+    // Same source the shared-event overlap is derived from, so the modal's list
+    // and the drawer's "both attended" line can never disagree.
+    events: eventsFor(seed.profileUid).map((name) => ({ name })),
     sourceSnapshots: {
       affinity: { sourceType: 'affinity', fetchedAt: '2026-07-18T00:00:00.000Z' },
       web: { sourceType: 'webVerify', fetchedAt: '2026-07-20T00:00:00.000Z' },
@@ -603,6 +1008,7 @@ function connectorProfile(connector: WarmIntrosV2ConnectorSummary): MasterProfil
     organizations: [{ name: 'Protocol Labs' }],
     experience: [{ company: 'Protocol Labs', title: connector.currentTitle, startYear: 2021 }],
     locations: [{ city: 'Remote' }],
+    events: eventsFor(connector.profileUid).map((name) => ({ name })),
     bio: `${connector.name} is ${connector.currentTitle} at Protocol Labs and is one of the six connectors v2 ranks.`,
     currentOrg: connector.currentOrg,
     currentTitle: connector.currentTitle,
@@ -610,9 +1016,46 @@ function connectorProfile(connector: WarmIntrosV2ConnectorSummary): MasterProfil
   };
 }
 
+/**
+ * Bridge people get their own profile so the middle chip on a two-hop path
+ * opens something — a founder reads as a founder, not as a second investor.
+ */
+function bridgeProfile(bridge: WarmIntrosV2ConnectorSummary, isFounder: boolean): MasterProfileDetail {
+  return {
+    uid: bridge.profileUid,
+    personKey: bridge.personKey,
+    types: [isFounder ? 'founder' : 'investor'],
+    canonicalName: bridge.name,
+    memberUid: bridge.memberUid ?? null,
+    affinityPersonId: null,
+    emails: [
+      {
+        value: `${bridge.personKey.split('.')[0]}@${(bridge.currentOrg ?? 'example')
+          .toLowerCase()
+          .replace(/[^a-z]+/g, '')}.com`,
+        sources: [{ type: 'affinity', confidence: 0.8 }],
+      },
+    ],
+    socials: { linkedin: `https://www.linkedin.com/in/${bridge.personKey.replace(/\./g, '-')}` },
+    organizations: [{ name: bridge.currentOrg }],
+    experience: [{ company: bridge.currentOrg, title: bridge.currentTitle, startYear: 2020 }],
+    locations: [{ city: 'Berlin', country: 'Germany' }],
+    events: eventsFor(bridge.profileUid).map((name) => ({ name })),
+    bio: isFounder
+      ? `${bridge.name} founded ${bridge.currentOrg} and has raised from the PL network — which is what makes this path work.`
+      : `${bridge.name} is ${bridge.currentTitle} at ${bridge.currentOrg} and shares cap tables with Protocol Labs.`,
+    currentOrg: bridge.currentOrg,
+    currentTitle: bridge.currentTitle,
+    enrichedAt: '2026-07-20T11:42:00.000Z',
+  };
+}
+
 export const MOCK_MASTER_PROFILES: Record<string, MasterProfileDetail> = {
   ...Object.fromEntries(INVESTOR_SEEDS.map((seed) => [seed.profileUid, investorProfile(seed)])),
   ...Object.fromEntries(Object.values(MOCK_CONNECTORS).map((c) => [c.profileUid, connectorProfile(c)])),
+  ...Object.fromEntries(
+    Object.entries(MOCK_BRIDGES).map(([key, b]) => [b.profileUid, bridgeProfile(b, key.startsWith('fd-'))]),
+  ),
 };
 
 /** Detail-endpoint stand-in: every rank-1 path recorded for one investor. */

--- a/prototypes/entries/warm-intros-v2/mocks.ts
+++ b/prototypes/entries/warm-intros-v2/mocks.ts
@@ -793,8 +793,16 @@ export type PathVia =
 export type PathFilters = {
   targetSet: TargetSetScope;
   search?: string;
-  sector?: string;
-  pathVia?: PathVia | null;
+  /** A set, matched as OR — same reading as `pathVia`. */
+  sector?: string[];
+  /**
+   * A set, matched as OR: a row survives if it satisfies *any* selected route.
+   * That is the standard reading of several values in one facet, and it is what
+   * the checkboxes in the menu promise — ticking a second box should widen the
+   * result, never narrow it to the intersection (which for these is usually
+   * empty, since a path has one shape and one bridge).
+   */
+  pathVia?: PathVia[] | null;
   /** Only investors whose MasterProfile carries plBacking. */
   plBacker?: boolean;
 };
@@ -858,8 +866,15 @@ export function filterPaths(params: PathFilters, omit?: 'pathVia' | 'sector' | '
 
   return MOCK_PATHS.filter((row) => {
     if (params.targetSet !== ALL_LISTS && row.targetSet !== params.targetSet) return false;
-    if (omit !== 'sector' && params.sector && !row.investor.sectors.includes(params.sector)) return false;
-    if (omit !== 'pathVia' && params.pathVia && !matchesPathVia(row, params.pathVia)) return false;
+    if (omit !== 'sector' && params.sector?.length && !params.sector.some((sec) => row.investor.sectors.includes(sec)))
+      return false;
+    if (
+      omit !== 'pathVia' &&
+      params.pathVia?.length &&
+      !params.pathVia.some((via) => matchesPathVia(row, via))
+    ) {
+      return false;
+    }
     if (omit !== 'plBacker' && params.plBacker && !seedForRow(row)?.plBacking) return false;
     if (q) {
       const haystack =


### PR DESCRIPTION
Filters
- Search → DS SearchInput; give it a real id + hidden label (was id="" and unlabelled)
- DS chevron on selects; square off Backed PL/FIL to match; Export CSV → blue, on results line

Table
- Header "Path"; neutral names with ↗ affordance; quiet View all
- Collapse to cards below 640px; proximity on its own line there
- Extract shared PathChain; 5-column variant added but flagged off

Drawer
- Shared events → chips with +N expand; group by people; dedupe events spanning 3 hops
- Press/focus states on person chips; drop divider above the actions strip