### PR TITLE
feat(notifications): add search to Updates panel

### DIFF
--- a/__tests__/core/updates-panel-mark-all.test.tsx
+++ b/__tests__/core/updates-panel-mark-all.test.tsx
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mockOnMarkAllClicked = jest.fn();
 const mockOnMarkAllFailed = jest.fn();
+const mockOnSearchOpened = jest.fn();
+const mockOnSearchQueried = jest.fn();
 
 jest.mock('@/analytics/notification.analytics', () => ({
   useNotificationAnalytics: () => ({
@@ -11,6 +13,8 @@ jest.mock('@/analytics/notification.analytics', () => ({
     onViewAllUpdatesClicked: jest.fn(),
     onMarkAllUpdatesReadClicked: (...a: unknown[]) => mockOnMarkAllClicked(...a),
     onMarkAllUpdatesReadFailed: (...a: unknown[]) => mockOnMarkAllFailed(...a),
+    onUpdatesSearchOpened: (...a: unknown[]) => mockOnSearchOpened(...a),
+    onUpdatesSearchQueried: (...a: unknown[]) => mockOnSearchQueried(...a),
   }),
 }));
 
@@ -107,5 +111,131 @@ describe('UpdatesPanel mark all as read', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Show all updates' }));
     expect(screen.getByText('Read thing')).toBeInTheDocument();
+  });
+});
+
+describe('UpdatesPanel search', () => {
+  const now = new Date().toISOString();
+  const notification = (id: string, title: string, category: string, description = '') =>
+    ({ id, uid: id, title, description, isRead: false, category, createdAt: now }) as never;
+
+  const SEARCH_PLACEHOLDER = 'Search by team or keyword…';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  function typeAndSettle(input: HTMLElement, value: string) {
+    fireEvent.change(input, { target: { value } });
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+  }
+
+  it('is never shown to logged-out viewers', () => {
+    renderPanel({ isLoggedIn: false });
+    expect(screen.queryByRole('button', { name: 'Search updates' })).not.toBeInTheDocument();
+  });
+
+  it('renders collapsed for logged-in viewers', () => {
+    renderPanel();
+    const toggle = screen.getByRole('button', { name: 'Search updates' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByPlaceholderText(SEARCH_PLACEHOLDER)).not.toBeInTheDocument();
+  });
+
+  it('expands on click, focuses the input, and reports the open event', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    const input = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    expect(input).toHaveFocus();
+    expect(mockOnSearchOpened).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters by title and reports the queried event with the match count', () => {
+    renderPanel({
+      notifications: [
+        notification('n1', 'Founder office hours', 'EVENT'),
+        notification('n2', 'Quarterly update', 'SYSTEM'),
+      ],
+      unreadCount: 2,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    typeAndSettle(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), 'office');
+
+    expect(screen.getByText('Founder office hours')).toBeInTheDocument();
+    expect(screen.queryByText('Quarterly update')).not.toBeInTheDocument();
+    expect(mockOnSearchQueried).toHaveBeenCalledWith('office', 1);
+  });
+
+  it('filters by the same category label NotificationItem renders (not the raw CATEGORY_CONFIG label)', () => {
+    // GUIDE_POST renders as "Founder Guides" via getCategoryLabel(), but as
+    // "Forum" in CATEGORY_CONFIG — searching "guide" must use the former.
+    renderPanel({
+      notifications: [notification('n1', 'New guide posted', 'GUIDE_POST'), notification('n2', 'A forum reply', 'FORUM_POST')],
+      unreadCount: 2,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    typeAndSettle(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), 'guide');
+
+    expect(screen.getByText('New guide posted')).toBeInTheDocument();
+    expect(screen.queryByText('A forum reply')).not.toBeInTheDocument();
+  });
+
+  it('shows a distinct empty state when the search has zero matches', () => {
+    renderPanel({ notifications: [notification('n1', 'Founder office hours', 'EVENT')], unreadCount: 1 });
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    typeAndSettle(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), 'nonexistent');
+
+    expect(screen.getByText(/No results for/)).toBeInTheDocument();
+    expect(screen.queryByText('Founder office hours')).not.toBeInTheDocument();
+  });
+
+  it('Escape clears the query first, then collapses the field and returns focus to the toggle on a second press', () => {
+    renderPanel({ notifications: [notification('n1', 'Founder office hours', 'EVENT')], unreadCount: 1 });
+    const toggle = screen.getByRole('button', { name: 'Search updates' });
+    fireEvent.click(toggle);
+
+    const input = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    fireEvent.change(input, { target: { value: 'office' } });
+    expect(input).toHaveValue('office');
+
+    fireEvent.keyUp(input, { key: 'Escape' });
+    expect(screen.getByPlaceholderText(SEARCH_PLACEHOLDER)).toHaveValue('');
+
+    fireEvent.keyUp(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), { key: 'Escape' });
+    expect(screen.queryByPlaceholderText(SEARCH_PLACEHOLDER)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search updates' })).toHaveFocus();
+  });
+
+  it('does not collapse on blur when focus moves to a notification link inside the panel', () => {
+    renderPanel({ notifications: [notification('n1', 'Founder office hours', 'EVENT')], unreadCount: 1 });
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    const input = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    const notificationLink = screen.getByText('Founder office hours').closest('a') as HTMLElement;
+
+    fireEvent.blur(input, { relatedTarget: notificationLink });
+    expect(screen.getByPlaceholderText(SEARCH_PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it('collapses on blur to somewhere outside the panel when the field is empty', () => {
+    renderPanel({ notifications: [notification('n1', 'Founder office hours', 'EVENT')], unreadCount: 1 });
+    fireEvent.click(screen.getByRole('button', { name: 'Search updates' }));
+
+    const input = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    fireEvent.blur(input, { relatedTarget: document.body });
+
+    expect(screen.queryByPlaceholderText(SEARCH_PLACEHOLDER)).not.toBeInTheDocument();
   });
 });

--- a/analytics/notification.analytics.ts
+++ b/analytics/notification.analytics.ts
@@ -109,6 +109,14 @@ export const useNotificationAnalytics = () => {
     });
   }
 
+  function onUpdatesSearchOpened() {
+    captureEvent(NOTIFICATION_ANALYTICS_EVENTS.UPDATES_SEARCH_OPENED);
+  }
+
+  function onUpdatesSearchQueried(query: string, resultCount: number) {
+    captureEvent(NOTIFICATION_ANALYTICS_EVENTS.UPDATES_SEARCH_QUERIED, { query, resultCount });
+  }
+
   return {
     onNotificationCardClicked,
     onSeeAllNotificationsClicked,
@@ -122,5 +130,7 @@ export const useNotificationAnalytics = () => {
     onMarkAllUpdatesReadClicked,
     onMarkAllUpdatesReadFailed,
     onRecentUpdatesNotificationClicked,
+    onUpdatesSearchOpened,
+    onUpdatesSearchQueried,
   };
 };

--- a/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.module.scss
+++ b/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.module.scss
@@ -3,12 +3,16 @@
    the panel is already a full-screen sheet below 480px with room to expand
    the field in place, unlike the newsfeed page these were built for. */
 
+/* 40px to match SearchInput/DebouncedInput's own rendered height
+   (DebouncedInput.module.scss's .root sets height: 40px) — the prototype's
+   30px button was sized for a different search field and caused a visible
+   height jump in .titleRow when toggling open. */
 .searchToggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   flex-shrink: 0;
   border-radius: 8px;
   border: 1px solid var(--action-border-neutral-light_normal, rgba(14, 15, 17, 0.16));
@@ -21,8 +25,8 @@
     color 0.12s ease;
 
   svg {
-    width: 15px;
-    height: 15px;
+    width: 18px;
+    height: 18px;
   }
 
   &:hover {

--- a/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.module.scss
+++ b/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.module.scss
@@ -1,0 +1,53 @@
+/* Adapted from prototypes/entries/newsfeed-v0/NewsfeedV0.module.scss's
+   .headerSearchBtn / .headerSearchField — no mobile-only hiding here, since
+   the panel is already a full-screen sheet below 480px with room to expand
+   the field in place, unlike the newsfeed page these were built for. */
+
+.searchToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid var(--action-border-neutral-light_normal, rgba(14, 15, 17, 0.16));
+  background: var(--background-base-white, #fff);
+  color: var(--foreground-neutral-secondary, #455468);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+
+  svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  &:hover {
+    border-color: #5e718d;
+    color: var(--foreground-neutral-primary, #0a0c11);
+  }
+}
+
+.searchToggleHidden {
+  display: none;
+}
+
+.searchField {
+  flex: 1 1 auto;
+  min-width: 0;
+  animation: searchFieldIn 0.16s ease;
+}
+
+@keyframes searchFieldIn {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.tsx
+++ b/components/core/UpdatesPanel/HeaderSearch/HeaderSearch.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { FocusEvent, KeyboardEvent, RefObject } from 'react';
+import { clsx } from 'clsx';
+
+import { SearchIcon } from '@/components/icons';
+import { SearchInput } from '@/components/common/filters/SearchInput';
+import { PushNotification } from '@/types/push-notifications.types';
+
+import { getCategoryLabel } from '../NotificationItem/utils/getCategoryLabel';
+
+import s from './HeaderSearch.module.scss';
+
+interface Props {
+  open: boolean;
+  value: string;
+  onOpen: () => void;
+  onChange: (value: string) => void;
+  onBlur: (e: FocusEvent<HTMLDivElement>) => void;
+  onKeyUp: (e: KeyboardEvent<HTMLDivElement>) => void;
+  fieldRef: RefObject<HTMLDivElement | null>;
+  toggleRef: RefObject<HTMLButtonElement | null>;
+}
+
+/**
+ * Ported from prototypes/entries/newsfeed-v0/HeaderSearch.tsx. Unlike the
+ * prototype, the toggle button stays mounted (just hidden) while the field is
+ * open, so aria-expanded reflects real state on one persistent element and
+ * Escape/blur can reliably return focus to it — the prototype's hard
+ * button/field swap loses the button node while expanded.
+ */
+export function HeaderSearch({ open, value, onOpen, onChange, onBlur, onKeyUp, fieldRef, toggleRef }: Props) {
+  return (
+    <>
+      <button
+        type="button"
+        ref={toggleRef}
+        className={clsx(s.searchToggle, { [s.searchToggleHidden]: open })}
+        aria-label="Search updates"
+        aria-expanded={open}
+        aria-hidden={open}
+        tabIndex={open ? -1 : 0}
+        onClick={onOpen}
+      >
+        <SearchIcon />
+      </button>
+      {open && (
+        <div className={s.searchField} ref={fieldRef} onBlur={onBlur} onKeyUp={onKeyUp}>
+          <SearchInput value={value} onChange={onChange} placeholder="Search by team or keyword…" />
+        </div>
+      )}
+    </>
+  );
+}
+
+/** Uses getCategoryLabel(), not CATEGORY_CONFIG — they disagree for at least
+ *  the Guide categories, and this is the source NotificationItem renders. */
+export function matchesQuery(notification: PushNotification, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = [notification.title, notification.description ?? '', getCategoryLabel(notification.category)]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(q);
+}

--- a/components/core/UpdatesPanel/UpdatesPanel.module.scss
+++ b/components/core/UpdatesPanel/UpdatesPanel.module.scss
@@ -61,27 +61,6 @@
   margin: 0;
 }
 
-.unreadBadge {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2px;
-  padding: 2px 8px;
-  background: rgba(27, 77, 255, 0.02);
-  border: 1px solid #aebfff;
-  border-radius: 9999px;
-}
-
-.unreadBadgeText {
-  font-family: 'Inter', sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
-  letter-spacing: -0.2px;
-  color: #4174ff;
-  padding: 0 2px;
-}
-
 /* The prototype's filter row between the header and the list: All/Unread/Read
    tabs on the left, the bulk action on the right (.searchRow chrome). */
 .actionRow {

--- a/components/core/UpdatesPanel/UpdatesPanel.tsx
+++ b/components/core/UpdatesPanel/UpdatesPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { PushNotification } from '@/types/push-notifications.types';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -10,6 +10,7 @@ import { EmptyState } from './EmptyState';
 import { NotLoggedInState } from './NotLoggedInState';
 import { NotificationItem } from './NotificationItem';
 import { ViewSwitch, applyView, type UpdatesView } from './ViewSwitch/ViewSwitch';
+import { HeaderSearch, matchesQuery } from './HeaderSearch/HeaderSearch';
 import s from './UpdatesPanel.module.scss';
 
 interface UpdatesPanelProps {
@@ -38,12 +39,82 @@ export function UpdatesPanel({
   // by design), and on failure the only signal a person gets at all.
   const [statusMessage, setStatusMessage] = useState('');
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // All / Unread / Read scoping (prototype behavior). Deliberately NOT reset
   // on close: reopening where you left off matches the proto's session-scoped
   // view state.
   const [view, setView] = useState<UpdatesView>('all');
-  const visibleNotifications = applyView(notifications, view);
+
+  // Search state, same "not reset on close" precedent as `view` above.
+  const [query, setQuery] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchFieldRef = useRef<HTMLDivElement>(null);
+  const searchToggleRef = useRef<HTMLButtonElement>(null);
+  // Set on mousedown inside the list, cleared next tick — long enough to
+  // survive the blur that fires between mousedown and click on a
+  // notification, so an in-flight list click never gets collapsed out from
+  // under itself.
+  const listMouseDownRef = useRef(false);
+
+  const visibleNotifications = useMemo(
+    () => applyView(notifications, view).filter((n) => matchesQuery(n, query)),
+    [notifications, view, query],
+  );
+  const isSearching = query.trim().length > 0;
+
+  useEffect(() => {
+    if (searchOpen) searchFieldRef.current?.querySelector('input')?.focus();
+  }, [searchOpen]);
+
+  // Fires once per settled (already-debounced by SearchInput) query change —
+  // no separate debounce needed for the analytics call.
+  useEffect(() => {
+    if (!isSearching) return;
+    analytics.onUpdatesSearchQueried(query, visibleNotifications.length);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const handleSearchOpen = useCallback(() => {
+    setSearchOpen(true);
+    analytics.onUpdatesSearchOpened();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Stable identity is required here: SearchInput's DebouncedInput memoizes
+  // its debounce timer on this callback's identity (see DebouncedInput.tsx),
+  // so a fresh function each render would silently reset in-flight typing.
+  const handleSearchChange = useCallback((value: string) => setQuery(value), []);
+
+  const handleSearchBlur = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    const related = e.relatedTarget as Node | null;
+    const staysInsidePanel = !!related && !!panelRef.current?.contains(related);
+    const liveValue = searchFieldRef.current?.querySelector('input')?.value ?? '';
+    if (liveValue || staysInsidePanel || listMouseDownRef.current) return;
+    setSearchOpen(false);
+  }, []);
+
+  // DebouncedInput's own onKeyUp (on the nested <input>) runs first and
+  // clears the field synchronously on Escape, but React doesn't commit that
+  // state to the DOM until after this bubbled handler also finishes — so
+  // reading the live input value here still sees the pre-clear text on the
+  // first Escape (skip collapsing, let the clear stand alone) and only sees
+  // empty on a second, separate Escape press (collapse + return focus to the
+  // toggle button, per standard expand/collapse keyboard convention).
+  const handleSearchKeyUp = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Escape') return;
+    const liveValue = searchFieldRef.current?.querySelector('input')?.value ?? '';
+    if (liveValue) return;
+    setSearchOpen(false);
+    searchToggleRef.current?.focus();
+  }, []);
+
+  const handleListMouseDown = useCallback(() => {
+    listMouseDownRef.current = true;
+    setTimeout(() => {
+      listMouseDownRef.current = false;
+    }, 0);
+  }, []);
 
   const handleNotificationClick = (notification: PushNotification) => {
     analytics.onUpdatesPanelNotificationClicked(notification);
@@ -88,6 +159,7 @@ export function UpdatesPanel({
             transition={{ duration: 0.15 }}
           />
           <motion.div
+            ref={panelRef}
             className={s.panel}
             onClick={(e) => e.stopPropagation()}
             initial={{ opacity: 0, scale: 0.95, y: -10 }}
@@ -98,10 +170,17 @@ export function UpdatesPanel({
             <div className={s.header}>
               <div className={s.titleRow}>
                 <h2 className={s.title}>Updates</h2>
-                {isLoggedIn && unreadCount > 0 && (
-                  <div className={s.unreadBadge}>
-                    <span className={s.unreadBadgeText}>Unread {unreadCount}</span>
-                  </div>
+                {isLoggedIn && (
+                  <HeaderSearch
+                    open={searchOpen}
+                    value={query}
+                    onOpen={handleSearchOpen}
+                    onChange={handleSearchChange}
+                    onBlur={handleSearchBlur}
+                    onKeyUp={handleSearchKeyUp}
+                    fieldRef={searchFieldRef}
+                    toggleRef={searchToggleRef}
+                  />
                 )}
               </div>
               <button ref={closeButtonRef} className={s.closeButton} onClick={onClose} aria-label="Close">
@@ -138,6 +217,13 @@ export function UpdatesPanel({
                 <NotLoggedInState onClose={onClose} />
               ) : notifications.length === 0 ? (
                 <EmptyState />
+              ) : isSearching && visibleNotifications.length === 0 ? (
+                // Distinct from the tab-empty state below: the list (and this
+                // tab) has items, search just didn't match any of them.
+                <div className={s.viewEmptyState}>
+                  <p className={s.viewEmptyTitle}>No results for &lsquo;{query}&rsquo;</p>
+                  <p className={s.viewEmptyBody}>Try a different keyword.</p>
+                </div>
               ) : visibleNotifications.length === 0 ? (
                 // The list has items — just none in this segment. The proto's
                 // per-view copy, with an escape back to All where one helps.
@@ -174,7 +260,7 @@ export function UpdatesPanel({
                   )}
                 </div>
               ) : (
-                <div className={s.notificationsList}>
+                <div className={s.notificationsList} onMouseDown={handleListMouseDown}>
                   {visibleNotifications.map((notification) => (
                     <NotificationItem
                       key={notification.id}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -185,6 +185,8 @@ export const NOTIFICATION_ANALYTICS_EVENTS = {
   RECENT_UPDATES_NOTIFICATION_CLICKED: 'recent-updates-notification-clicked',
   MARK_ALL_UPDATES_READ_CLICKED: 'mark-all-updates-read-clicked',
   MARK_ALL_UPDATES_READ_FAILED: 'mark-all-updates-read-failed',
+  UPDATES_SEARCH_OPENED: 'updates-search-opened',
+  UPDATES_SEARCH_QUERIED: 'updates-search-queried',
 };
 
 export const SETTINGS_ANALYTICS_EVENTS = {


### PR DESCRIPTION
## Summary
- The production Updates dropdown (`components/core/UpdatesPanel/UpdatesPanel.tsx`) had a decorative "Unread {count}" badge and no search. A QA bug report's screenshots were actually from a prototype sandbox (`prototypes/entries/notifications-hub`), which has a working search icon that expands into an input — this ports that interaction into production.
- Replaces the badge with a search icon (`components/core/UpdatesPanel/HeaderSearch/`) that expands in place, filtering the already-loaded notifications by title, description, and category label (via the existing `getCategoryLabel()`, matching what `NotificationItem` renders — not the disagreeing `CATEGORY_CONFIG` labels).
- All/Unread/Read tabs (`ViewSwitch`) and mark-all-as-read are unchanged; search composes as an additional AND'd filter, and tab counts stay unfiltered.
- Two real issues were caught and fixed during a multi-angle plan review before implementation: (1) a category-label mismatch that would have broken search for "Guide" notifications, and (2) a blur/click race where the search field could collapse mid-click on a notification, misattributing the click.
- Escape has a deliberate two-stage behavior: first press clears the query (existing `DebouncedInput` behavior), a second press collapses the field and returns focus to the toggle button.
- Added `onUpdatesSearchOpened`/`onUpdatesSearchQueried` analytics events following the existing per-action PostHog pattern.

## Testing
- 8 new tests added to `__tests__/core/updates-panel-mark-all.test.tsx`: collapsed/expanded rendering, open + focus + analytics, filtering by title, filtering by category label (regression test for the label-mismatch bug), zero-match empty state, Escape two-stage behavior, and the blur/click race fix.
- Full suite: 1343 passed, 1 pre-existing unrelated failure (date-boundary test, confirmed failing identically on `develop` with no changes applied).
- Lint and `tsc --noEmit` clean on all touched files.

## Docs
- Brainstorm: `docs/brainstorms/2026-08-04-updates-panel-search-brainstorm.md` (local-only, gitignored)
- Plan (reviewed by 8 agents across TypeScript quality, simplicity, performance, security, patterns, architecture, race conditions, and UX best practices): `docs/plans/2026-08-04-feat-updates-panel-search-plan.md` (local-only, gitignored)

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)