### PR TITLE
feat(newsfeed): add top-stories band and reason-first follow suggestions

### DIFF
--- a/__tests__/page/home/select-top-stories.test.ts
+++ b/__tests__/page/home/select-top-stories.test.ts
@@ -1,0 +1,133 @@
+import { selectTopStories, TOP_STORIES_TOTAL } from '@/components/page/home/TeamNews/utils/selectTopStories';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+const makeItem = (uid: string, overrides: Partial<ITeamNewsItem> = {}): ITeamNewsItem => ({
+  uid,
+  teamUid: `team-${uid}`,
+  teamName: `Team ${uid}`,
+  teamLogoUrl: null,
+  eventType: 'ANNOUNCEMENT',
+  eventDate: '2026-05-01T12:00:00.000Z',
+  title: `Headline ${uid}`,
+  summary: null,
+  sourceUrl: `https://example.com/${uid}`,
+  sourceDomain: 'example.com',
+  tags: [],
+  focusAreas: [],
+  subFocusAreas: [],
+  createdAt: '2026-05-01T12:00:00.000Z',
+  discussion: { count: 0, latestTopicUrl: null },
+  ...overrides,
+});
+
+const counts = (entries: Record<string, number>): ReadonlyMap<string, number> => new Map(Object.entries(entries));
+
+/** Ranking cases pass 0 so the corpus gate is out of the way; the function still
+ *  floors at TOP_STORIES_TOTAL, which the gating cases below cover. */
+const NO_MINIMUM = 0;
+
+describe('selectTopStories', () => {
+  it('returns an empty selection for an empty window', () => {
+    const result = selectTopStories([], counts({}), NO_MINIMUM);
+
+    expect(result.lead).toBeNull();
+    expect(result.also).toEqual([]);
+    expect(result.uids.size).toBe(0);
+  });
+
+  it('ranks by upvote count, highest first', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c'), makeItem('d')];
+    const result = selectTopStories(items, counts({ a: 2, b: 40, c: 9, d: 30 }), NO_MINIMUM);
+
+    expect(result.lead?.uid).toBe('b');
+    expect(result.also.map((i) => i.uid)).toEqual(['d', 'c']);
+  });
+
+  it('takes at most three items, whatever the window size', () => {
+    const items = Array.from({ length: 10 }, (_, i) => makeItem(`i${i}`));
+    const result = selectTopStories(items, counts({}), NO_MINIMUM);
+
+    expect(result.uids.size).toBe(3);
+    expect(result.also).toHaveLength(2);
+  });
+
+  it('exposes every picked uid as the exclusion set', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c'), makeItem('d')];
+    const result = selectTopStories(items, counts({ a: 5, b: 4, c: 3, d: 2 }), NO_MINIMUM);
+
+    expect([...result.uids]).toEqual(['a', 'b', 'c']);
+    expect(result.uids.has('d')).toBe(false);
+  });
+
+  // The tie-break is what makes a zero-engagement window still produce a
+  // sensible block rather than an arbitrary one — see selectTopStories' docblock.
+  it('breaks ties on eventDate, most recent first', () => {
+    const items = [
+      makeItem('old', { eventDate: '2026-05-01T00:00:00.000Z' }),
+      makeItem('new', { eventDate: '2026-05-09T00:00:00.000Z' }),
+      makeItem('mid', { eventDate: '2026-05-05T00:00:00.000Z' }),
+    ];
+    const result = selectTopStories(items, counts({ old: 7, new: 7, mid: 7 }), NO_MINIMUM);
+
+    expect([result.lead?.uid, ...result.also.map((i) => i.uid)]).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('falls back to pure recency when nothing has been upvoted', () => {
+    const items = [
+      makeItem('a', { eventDate: '2026-05-02T00:00:00.000Z' }),
+      makeItem('b', { eventDate: '2026-05-08T00:00:00.000Z' }),
+      makeItem('c', { eventDate: '2026-05-05T00:00:00.000Z' }),
+    ];
+    const result = selectTopStories(items, counts({}), NO_MINIMUM);
+
+    expect(result.lead?.uid).toBe('b');
+    expect(result.also.map((i) => i.uid)).toEqual(['c', 'a']);
+  });
+
+  describe('corpus gate', () => {
+    // The band sits ABOVE a feed. If it would swallow most of the window there
+    // is no feed under it, and the band is just the feed restyled.
+    it('renders nothing below the caller-supplied minimum', () => {
+      const items = Array.from({ length: 8 }, (_, i) => makeItem(`i${i}`));
+      const result = selectTopStories(items, counts({}), 9);
+
+      expect(result.lead).toBeNull();
+      expect(result.uids.size).toBe(0);
+    });
+
+    it('renders once the minimum is met exactly', () => {
+      const items = Array.from({ length: 9 }, (_, i) => makeItem(`i${i}`));
+      const result = selectTopStories(items, counts({}), 9);
+
+      expect(result.lead).not.toBeNull();
+      expect(result.also).toHaveLength(2);
+    });
+
+    // A caller passing 0 (or anything under three) must not get a partial band —
+    // the floor is what guarantees `also` is always two rows when `lead` is set.
+    it('floors the minimum at the three stories the band needs', () => {
+      const twoItems = [makeItem('a'), makeItem('b')];
+
+      expect(selectTopStories(twoItems, counts({}), NO_MINIMUM).lead).toBeNull();
+      expect(selectTopStories([makeItem('solo')], counts({}), NO_MINIMUM).lead).toBeNull();
+      expect(selectTopStories(twoItems, counts({}), TOP_STORIES_TOTAL).lead).toBeNull();
+    });
+  });
+
+  // The mount-time snapshot is the whole point: a live count would let an
+  // optimistic like re-rank the block under the cursor that just clicked it.
+  it('ignores live item upvoteCount in favour of the pinned snapshot', () => {
+    const items = [makeItem('a', { upvoteCount: 99 }), makeItem('b', { upvoteCount: 1 }), makeItem('c')];
+    const result = selectTopStories(items, counts({ a: 1, b: 50, c: 0 }), NO_MINIMUM);
+
+    expect(result.lead?.uid).toBe('b');
+  });
+
+  it('does not mutate the input array', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    const order = items.map((i) => i.uid);
+    selectTopStories(items, counts({ c: 10 }), NO_MINIMUM);
+
+    expect(items.map((i) => i.uid)).toEqual(order);
+  });
+});

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -46,6 +46,8 @@ const mockOnPopularStoryClicked = jest.fn();
 const mockOnDetailModalOpened = jest.fn();
 const mockOnShared = jest.fn();
 const mockOnForumPostModalOpened = jest.fn();
+const mockOnTopStoriesBlockViewed = jest.fn();
+const mockOnTopStoryClicked = jest.fn();
 
 jest.mock('@/analytics/team-news.analytics', () => ({
   useTeamNewsAnalytics: () => ({
@@ -68,6 +70,8 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onPopularStoryFallbackOpened: (...a: unknown[]) => mockOnFallbackOpened(...a),
     onTeamsToFollowViewed: (...a: unknown[]) => mockOnTeamsToFollowViewed(...a),
     onTeamsToFollowHidden: (...a: unknown[]) => mockOnTeamsToFollowHidden(...a),
+    onTopStoriesBlockViewed: (...a: unknown[]) => mockOnTopStoriesBlockViewed(...a),
+    onTopStoryClicked: (...a: unknown[]) => mockOnTopStoryClicked(...a),
   }),
 }));
 
@@ -1411,6 +1415,145 @@ describe('TeamNews', () => {
 
       expect(firstRow).not.toHaveClass('storyHighlighted');
       expect(secondRow).toHaveClass('storyHighlighted');
+    });
+  });
+
+  describe('top stories band', () => {
+    // TOP_STORIES_MIN_CORPUS is 9: the band's three plus a full default page.
+    const bandItems = (count: number, upvotesByIndex: Record<number, number> = {}): ITeamNewsItem[] =>
+      Array.from({ length: count }, (_, i) => ({
+        ...makeItem(`b-${i}`, 'FUNDING', ['AI & Robotics']),
+        upvoteCount: upvotesByIndex[i] ?? 0,
+        eventDate: `2026-05-${String(count - i).padStart(2, '0')}T12:00:00.000Z`,
+      }));
+
+    const bandGroups = (items: ITeamNewsItem[]): ITeamNewsGroup[] => [{ focusArea: FA_AI, total: items.length, items }];
+
+    /** The stream under the band — the band renders its own copies of the same
+     *  stories, so feed assertions must not query globally. */
+    const feed = () => within(document.querySelector('[data-news-feed-list]') as HTMLElement);
+    const band = () => screen.queryByRole('region', { name: 'Top stories' });
+
+    it('renders nothing below the minimum corpus', () => {
+      renderTeamNews(<TeamNews groups={bandGroups(bandItems(8))} />);
+
+      expect(band()).not.toBeInTheDocument();
+      expect(feed().getByText('Headline b-0')).toBeInTheDocument();
+    });
+
+    it('renders the lead plus two rows once the corpus is met', () => {
+      renderTeamNews(<TeamNews groups={bandGroups(bandItems(9, { 4: 50, 7: 40, 1: 30 }))} />);
+
+      const region = band()!;
+      expect(region).toBeInTheDocument();
+      expect(within(region).getByRole('heading', { level: 2 })).toHaveTextContent('Headline b-4');
+      expect(within(region).getByText('Headline b-7')).toBeInTheDocument();
+      expect(within(region).getByText('Headline b-1')).toBeInTheDocument();
+      expect(within(region).getByText('Last 14 days')).toBeInTheDocument();
+    });
+
+    it('removes the band stories from the stream below it', () => {
+      renderTeamNews(<TeamNews groups={bandGroups(bandItems(9, { 4: 50, 7: 40, 1: 30 }))} pageSize={20} />);
+
+      for (const uid of ['b-4', 'b-7', 'b-1']) {
+        expect(feed().queryByText(`Headline ${uid}`)).not.toBeInTheDocument();
+      }
+      expect(feed().getByText('Headline b-0')).toBeInTheDocument();
+      expect(feed().getByText('Headline b-8')).toBeInTheDocument();
+    });
+
+    it('hides the band on a focus-area tab, a category pill, and a search query', () => {
+      const items = bandItems(9, { 4: 50 });
+      renderTeamNews(
+        <TeamNews
+          groups={[
+            { focusArea: FA_AI, total: items.length, items },
+            { focusArea: FA_DHR, total: dhrItems.length, items: dhrItems },
+          ]}
+        />,
+      );
+      expect(band()).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('tab', { name: /Digital Human Rights/ }));
+      expect(band()).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('tab', { name: /^All/ }));
+      expect(band()).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /^Funding\b/ }));
+      expect(band()).not.toBeInTheDocument();
+    });
+
+    // Both rank by likes, so left alone they show the same three stories a few
+    // hundred pixels apart.
+    it('keeps band stories out of the rail’s Popular this week', () => {
+      const items = bandItems(9, { 4: 50, 7: 40, 1: 30 });
+      renderTeamNews(
+        <TeamNews
+          groups={bandGroups(items)}
+          popularItems={[
+            {
+              uid: 'b-4',
+              teamUid: 'team-b-4',
+              teamName: 'Team b-4',
+              title: 'Headline b-4',
+              sourceUrl: 'x',
+              upvoteCount: 50,
+            },
+            {
+              uid: 'b-0',
+              teamUid: 'team-b-0',
+              teamName: 'Team b-0',
+              title: 'Headline b-0',
+              sourceUrl: 'y',
+              upvoteCount: 2,
+            },
+          ]}
+        />,
+      );
+
+      const rail = screen.getByRole('complementary', { name: /sidebar/i });
+      expect(within(rail).queryByText('Headline b-4')).not.toBeInTheDocument();
+      expect(within(rail).getByText('Headline b-0')).toBeInTheDocument();
+    });
+
+    it('reports its own view and click analytics with slot and position', () => {
+      renderTeamNews(<TeamNews groups={bandGroups(bandItems(9, { 4: 50, 7: 40, 1: 30 }))} />);
+
+      expect(mockOnTopStoriesBlockViewed).toHaveBeenCalledWith('b-4', 2);
+
+      fireEvent.click(within(band()!).getByRole('button', { name: 'Headline b-7' }));
+      expect(mockOnTopStoryClicked).toHaveBeenCalledWith(expect.objectContaining({ uid: 'b-7' }), 'row', 1);
+      // The band never routes through the feed's card-clicked event: its items
+      // aren't in visibleEntries, so that handler's position lookup is -1.
+      expect(mockOnCardClicked).not.toHaveBeenCalled();
+    });
+
+    it('opens the detail modal and writes ?news= when a band story is clicked', () => {
+      renderTeamNews(<TeamNews groups={bandGroups(bandItems(9, { 4: 50 }))} />);
+
+      fireEvent.click(within(band()!).getByRole('button', { name: 'Headline b-4' }));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(new URLSearchParams(window.location.search).get('news')).toBe('b-4');
+    });
+
+    // The band ranks from the mount-time snapshot for the same reason the feed
+    // does (#2677) — otherwise liking the lead demotes it under the cursor.
+    it('does not re-rank when the lead is liked', () => {
+      // Same reason the upvotes block above signs in: UpvoteButton has no
+      // isHydrated gate, so an anonymous click just redirects to login.
+      useCurrentUserStore.setState({ currentUser: { uid: 'user-1' }, isHydrated: true });
+      try {
+        renderTeamNews(<TeamNews groups={bandGroups(bandItems(9, { 4: 50, 7: 40, 1: 30 }))} />);
+
+        const leadBefore = within(band()!).getByRole('heading', { level: 2 }).textContent;
+        fireEvent.click(within(band()!).getAllByRole('button', { name: /^Like/ })[0]);
+
+        expect(within(band()!).getByRole('heading', { level: 2 })).toHaveTextContent(leadBefore!);
+      } finally {
+        useCurrentUserStore.setState({ currentUser: null, isHydrated: false });
+      }
     });
   });
 });

--- a/__tests__/page/home/teams-to-follow-card.test.tsx
+++ b/__tests__/page/home/teams-to-follow-card.test.tsx
@@ -97,7 +97,9 @@ describe('TeamsToFollowCard', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('prefers the short description as the subtitle when available', () => {
+  // A tagline says what a team is, which its profile already does; the reason
+  // says why it is in front of *you*, which is what earns a follow here.
+  it('prefers the recommendation reason as the subtitle, stripped of the follower count', () => {
     render(
       <TeamsToFollowCard
         suggestions={[
@@ -113,24 +115,29 @@ describe('TeamsToFollowCard', () => {
         onFollowToggle={mockOnFollowToggle}
       />,
     );
-    expect(screen.getByText('Decentralized hot storage for large datasets.')).toBeInTheDocument();
-    expect(screen.queryByText('Storage')).not.toBeInTheDocument();
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.queryByText('Decentralized hot storage for large datasets.')).not.toBeInTheDocument();
   });
 
-  it('falls back to the focus-area reason when the short description is missing or blank', () => {
+  it('falls back to the short description when the reason is missing or blank', () => {
     render(
       <TeamsToFollowCard
         suggestions={[
-          team({ uid: 't1', name: 'Banyan Storage', shortDescription: '   ' }),
-          team({ uid: 't2', name: 'Other Team', reason: 'Infrastructure · 890 followers' }),
+          team({
+            uid: 't1',
+            name: 'Banyan Storage',
+            reason: '',
+            shortDescription: 'Decentralized hot storage for large datasets.',
+          }),
+          team({ uid: 't2', name: 'Other Team', reason: '   ', shortDescription: 'Runs the indexer.' }),
         ]}
         isLoading={false}
         followedTeamUids={emptyFollowed}
         onFollowToggle={mockOnFollowToggle}
       />,
     );
-    expect(screen.getByText('Storage')).toBeInTheDocument();
-    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+    expect(screen.getByText('Decentralized hot storage for large datasets.')).toBeInTheDocument();
+    expect(screen.getByText('Runs the indexer.')).toBeInTheDocument();
   });
 
   it('redirects to login on follow click when anonymous, without calling onFollowToggle', () => {

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -262,6 +262,31 @@ export const useTeamNewsAnalytics = () => {
 
   /** The Popular-this-week card appeared with stories on it — the denominator
    *  for its click-through, which was measured with no impression count. */
+  const onTopStoriesBlockViewed = (leadUid: string, rowCount: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_TOP_STORIES_BLOCK_VIEWED, {
+      leadUid,
+      rowCount,
+      source: 'home' satisfies TeamNewsAnalyticsSource,
+    });
+  };
+
+  /** Block items aren't in `visibleEntries`, so the feed's position lookup
+   *  reports -1 for all of them — the block passes its own slot and position
+   *  instead. `slot` separates the lead's pull from the runners-up's, which is
+   *  the only way to tell whether the asymmetry is earning anything. */
+  const onTopStoryClicked = (item: ITeamNewsItem, slot: 'lead' | 'row', position: number) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_TOP_STORY_CLICKED, {
+      itemUid: item.uid,
+      teamUid: item.teamUid,
+      teamName: item.teamName,
+      eventType: item.eventType,
+      upvoteCount: item.upvoteCount ?? 0,
+      slot,
+      position,
+      source: 'home' satisfies TeamNewsAnalyticsSource,
+    });
+  };
+
   const onPopularCardViewed = (itemCount: number) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_CARD_VIEWED, { itemCount });
   };
@@ -548,6 +573,8 @@ export const useTeamNewsAnalytics = () => {
     onPopularCardViewed,
     onPopularStoryScrollSucceeded,
     onPopularStoryFallbackOpened,
+    onTopStoriesBlockViewed,
+    onTopStoryClicked,
     onTeamsToFollowViewed,
     onTeamsToFollowHidden,
     onFeedForumPostCardClicked,

--- a/components/page/home/TeamNews/TeamNews.module.scss
+++ b/components/page/home/TeamNews/TeamNews.module.scss
@@ -113,6 +113,12 @@
   min-width: 0;
 }
 
+// `.main` has no gap of its own, so the band carries its own separation from
+// the stream — same 16px the feed uses between cards.
+.topStories {
+  margin-bottom: 16px;
+}
+
 .feed {
   display: flex;
   flex-direction: column;

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -31,6 +31,7 @@ import {
   ALL_TAB,
   ALL_CAT,
   CATEGORIES,
+  TOP_STORIES_WINDOW_LABEL,
   type TeamNewsCategoryId,
 } from './constants';
 
@@ -40,6 +41,7 @@ import { dedupeByUid } from './utils/dedupeByUid';
 import { applyUpvoteOverlay } from './utils/applyUpvoteOverlay';
 import { resolveForumPostLike } from './utils/resolveForumPostLike';
 import { clusterByTeam } from './utils/clusterByTeam';
+import { selectTopStories, TOP_STORIES_MIN_CORPUS } from './utils/selectTopStories';
 import { assertNever, feedEntryKey, mergeFeedEntries } from './utils/mergeFeedEntries';
 import { categoryIncludesForumPosts, filterFeedForumPosts } from './utils/matchesFeedForumPost';
 import { useStoryReveal } from './hooks/useStoryReveal';
@@ -51,6 +53,7 @@ import { NewsDetailModal } from './components/NewsDetailModal';
 import { ForumPostModal } from './components/ForumPostModal/ForumPostModal';
 
 import { NewsGroupCard } from './components/NewsGroupCard';
+import { TopStoriesBlock, type TopStorySlot } from './components/TopStories';
 import { ForumPostCard } from './components/ForumPostCard/ForumPostCard';
 import { NewsBase } from './components/NewsBase';
 import { NewsRail } from './components/NewsRail';
@@ -253,7 +256,33 @@ export const TeamNews = ({
     return filteredItems.filter((i) => matchesTeamNewsQuery(i, q));
   }, [filteredItems, query]);
 
-  const clusters = useMemo(() => clusterByTeam(searchedItems), [searchedItems]);
+  // The band is network-wide, so it only exists on the unfiltered view: ranking
+  // it inside a focus area or a category pill would make "Top stories" mean
+  // something different on every filter. This one flag drives the band's
+  // visibility, the stream exclusion below, and the rail's Popular dedup — three
+  // separate conditions would drift.
+  const isNarrowedView = activeTab !== ALL_TAB || activeCategory !== ALL_CAT || Boolean(query.trim());
+
+  // Ranked from the frozen snapshot, rendered from the live overlay (allItems is
+  // already overlay-merged): liking the featured story updates its count without
+  // re-ranking the band under the cursor that just clicked it.
+  // The band exists to sit above a feed, so it only appears once the window can
+  // supply both it and a full first page (TOP_STORIES_MIN_CORPUS).
+  const topStories = useMemo(
+    () => (isNarrowedView ? null : selectTopStories(allItems, initialUpvoteCounts, TOP_STORIES_MIN_CORPUS)),
+    [isNarrowedView, allItems, initialUpvoteCounts],
+  );
+  const hasTopStories = Boolean(topStories?.lead);
+
+  // Excluded BEFORE clusterByTeam: pulling items out of already-built clusters
+  // would leave one with a hole, or leave an empty card behind. A team whose
+  // only story is in the band simply produces no cluster.
+  const streamItems = useMemo(
+    () => (topStories && hasTopStories ? searchedItems.filter((i) => !topStories.uids.has(i.uid)) : searchedItems),
+    [searchedItems, topStories, hasTopStories],
+  );
+
+  const clusters = useMemo(() => clusterByTeam(streamItems), [streamItems]);
 
   const sortedClusters = useMemo(
     () => sortTeamNewsClusters(clusters, sort, initialFollowedTeamUids, initialUpvoteCounts),
@@ -285,6 +314,14 @@ export const TeamNews = ({
 
   const visibleEntries = expanded ? entries : entries.slice(0, pageSize);
   const newCount = allItems.length + (forumPosts?.length ?? 0);
+
+  // Both the band and the rail's "Popular this week" rank by likes, so left
+  // alone they show the same three stories a few hundred pixels apart. The rail
+  // surfaces #4–#6 instead; it hides itself when the list comes back empty.
+  const railPopularItems = useMemo(
+    () => (topStories && hasTopStories ? popularItems.filter((p) => !topStories.uids.has(p.uid)) : popularItems),
+    [popularItems, topStories, hasTopStories],
+  );
 
   // ?news=<uid> ↔ detail-modal sync (declared after the allItems memo — the
   // validator closes over it). All URL writes are history.replaceState; see
@@ -398,6 +435,16 @@ export const TeamNews = ({
     analytics.onTeamNewsCardClicked(item, position >= 0 ? position : 0, 'home', via);
     // One modal, one URL param at a time — closing the other side first keeps
     // ?news= and ?post= mutually exclusive (both writes are synchronous).
+    if (activePostUid) closePost();
+    openNews(item.uid);
+  };
+
+  // Top-stories counterpart of handleStoryOpen. Its own event, not
+  // onTeamNewsCardClicked: band items aren't in `visibleEntries`, so that
+  // handler's position lookup would report -1 for every one of them, and the
+  // lead's pull can't be told from a runner-up's without `slot`.
+  const handleTopStoryOpen = (item: ITeamNewsItem, slot: TopStorySlot, position: number) => {
+    analytics.onTopStoryClicked(item, slot, position);
     if (activePostUid) closePost();
     openNews(item.uid);
   };
@@ -727,13 +774,34 @@ export const TeamNews = ({
             the originating row is gone (deep link to a folded story) — focus must
             land somewhere in the feed, never on <body>. */}
         <div className={s.main} data-news-feed-root tabIndex={-1}>
-          {entries.length === 0 ? (
-            <div className={s.empty}>
-              {query.trim() ? `No network news matches "${query.trim()}".` : 'No network news in this filter.'}
+          {topStories?.lead && (
+            <div className={s.topStories}>
+              <TopStoriesBlock
+                lead={topStories.lead}
+                also={topStories.also}
+                windowLabel={TOP_STORIES_WINDOW_LABEL}
+                followedTeamUids={followedTeamUids}
+                onFollowToggle={handleFollowToggle}
+                onUpvoteToggle={handleUpvoteToggle}
+                onStoryOpen={handleTopStoryOpen}
+              />
             </div>
+          )}
+          {/* Suppressed when the band is showing: a window whose every story is
+              in the band leaves the stream empty, and "No network news in this
+              filter" directly under three stories reads as a bug. */}
+          {entries.length === 0 ? (
+            !topStories?.lead && (
+              <div className={s.empty}>
+                {query.trim() ? `No network news matches "${query.trim()}".` : 'No network news in this filter.'}
+              </div>
+            )
           ) : (
             <>
-              <div className={s.feed}>
+              {/* The stream, marked so it can be addressed apart from the
+                  top-stories band above it — which renders its own copies of
+                  the same stories. */}
+              <div className={s.feed} data-news-feed-list>
                 {visibleEntries.map((entry, index) => {
                   // Composite key intentionally forces a remount on every tab/category
                   // change so each card's local state (expanded stories, open comment
@@ -788,7 +856,7 @@ export const TeamNews = ({
         </div>
         <NewsRail
           initialDigestSettings={initialDigestSettings}
-          popularItems={popularItems}
+          popularItems={railPopularItems}
           suggestedTeams={suggestedTeams}
           isLoadingSuggestedTeams={isLoadingSuggestedTeams}
           followedTeamUids={followedTeamUids}

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.tsx
@@ -31,24 +31,35 @@ interface CommentButtonProps {
   itemUid: string;
   open: boolean;
   onToggle: () => void;
-  /** id of the thread region this button discloses. */
-  controls: string;
+  /** id of the thread region this button discloses. Unused (and not required)
+   *  when `opensDetail` — there is no thread region to point at. */
+  controls?: string;
+  /**
+   * Opens the detail modal instead of disclosing an inline thread — the
+   * top-stories band, where an expanding thread would push the runners-up a
+   * screen down. Swaps the disclosure ARIA (`aria-expanded`/`aria-controls`,
+   * which would be a lie here: nothing expands and `controls` points at
+   * nothing) for `aria-haspopup="dialog"`, matching how NewsGroupCard's story
+   * rows announce the same modal.
+   */
+  opensDetail?: boolean;
 }
 
-export function CommentButton({ itemUid, open, onToggle, controls }: CommentButtonProps) {
+export function CommentButton({ itemUid, open, onToggle, controls, opensDetail = false }: CommentButtonProps) {
   const count = useFeedCommentCount(itemUid);
   const noun = count === 1 ? 'Comment' : 'Comments';
   const visibleLabel = count !== undefined ? `${count} ${noun}` : noun;
   // The accessible name has to CARRY the visible text, not replace it: a bare
   // "Show comments" hides the count from screen readers and leaves voice
   // control with no way to say what it can see.
-  const label = `${visibleLabel}, ${open ? 'hide' : 'show'}`;
+  const label = opensDetail ? `${visibleLabel}, open` : `${visibleLabel}, ${open ? 'hide' : 'show'}`;
   return (
     <button
       type="button"
       className={clsx(s.comment, open && s.commentOpen)}
-      aria-expanded={open}
-      aria-controls={controls}
+      aria-expanded={opensDetail ? undefined : open}
+      aria-controls={opensDetail ? undefined : controls}
+      aria-haspopup={opensDetail ? 'dialog' : undefined}
       aria-label={label}
       title={label}
       onClick={(e) => {

--- a/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/components/TeamsToFollowCard/TeamsToFollowCard.tsx
@@ -90,9 +90,11 @@ export function TeamsToFollowCard({
       <h3 className={s.railTitle}>Teams to follow</h3>
       {suggestions.map((team, position) => {
         const isFollowing = followedTeamUids.has(team.uid);
-        // Prefer the team's own one-liner (same field the teams grid shows);
-        // the recommendation reason (focus area) is only the fallback.
-        const subtitle = team.shortDescription?.trim() || stripFollowerCountFromReason(team.reason);
+        // Reason first, tagline as the fallback. A tagline says what a team is,
+        // which its profile already does; the reason says why it is in front of
+        // *you*, which is the only thing that earns a follow from a module
+        // nobody asked for.
+        const subtitle = stripFollowerCountFromReason(team.reason || '') || team.shortDescription?.trim() || '';
         return (
           <div key={team.uid} className={s.railRow}>
             {team.logo ? (

--- a/components/page/home/TeamNews/components/TopStories/TopStories.module.scss
+++ b/components/page/home/TeamNews/components/TopStories/TopStories.module.scss
@@ -1,0 +1,211 @@
+@import '../../../../../../styles/media';
+
+/* One band holding a lead plus two rows. Without the shared border the rows read
+   as feed items that happen to sit high, rather than as part of the pick.
+
+   No `overflow: hidden` — the prototype clips here to round the lead's gradient,
+   but SourceList renders a popover that must escape the card bounds (the same
+   reason production's `.card` refuses `overflow: hidden`). The lead rounds its
+   own top corners instead, and the last row rounds the bottom ones. */
+.block {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  border: 1px solid var(--transparent-brand-16, rgba(27, 77, 255, 0.16));
+  background: #ffffff;
+
+  /* Production `NewsCard.module.scss .card:hover`, verbatim — the block is a card
+     among cards, and the lift belongs to the whole band. A per-item hover inside
+     it reads as a grey wash, because an inset blur is a fill. */
+  transition: box-shadow 0.12s ease;
+
+  &:hover {
+    box-shadow:
+      0px 0px 1px 0px rgba(15, 23, 42, 0.16),
+      0px 6px 8px 0px rgba(15, 23, 42, 0.06);
+  }
+}
+
+/* ---------- The lead ---------- */
+
+.lead {
+  display: flex;
+  flex-direction: column;
+  /* 20px matches production `.card` padding, so the lead sits on the same rhythm
+     as every other card in the column. */
+  gap: 12px;
+  padding: 20px;
+  border-radius: 11px 11px 0 0; /* 11 = .block's 12 minus its own 1px border */
+  background: linear-gradient(
+    180deg,
+    var(--transparent-brand-8, rgba(27, 77, 255, 0.06)) 0%,
+    #ffffff 140px,
+    #ffffff 100%
+  );
+}
+
+/* Lead with no runners-up — round the bottom too, or the band shows square
+   corners under a rounded border. */
+.leadOnly {
+  border-radius: 11px;
+}
+
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* An editorial kicker, not a chip. A filled pill is what this app uses for an
+   *active filter*, and this label sits directly under a row of them — so a fill
+   would read as "selected tab". Uppercase + letterspaced + no fill is a shape
+   nothing interactive in the app has. */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--foreground-brand-primary, #1b4dff);
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* 12px = the filled pin's native size in production's asset, and the same size
+   as the uppercase eyebrow beside it — so it renders unscaled and reads as a
+   mark next to the caps rather than an icon leading them. */
+.badgeIcon {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+.window {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/* Headline + summary only. The team row and the meta line sit outside it, so
+   this holds no nested interactive elements and can stay a single click target
+   (production `NewsGroupCard .storyRow` splits the same way). */
+.leadBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  text-align: left;
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 4px;
+    border-radius: 8px;
+  }
+
+  &:hover .leadTitle {
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}
+
+.leadTitle {
+  margin: 0;
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 600;
+  letter-spacing: -0.6px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  transition: color 0.12s ease;
+
+  @include mobile-only {
+    font-size: 20px;
+    line-height: 28px;
+    letter-spacing: -0.4px;
+  }
+}
+
+.leadSummary {
+  margin: 0;
+  font-size: 16px;
+  line-height: 24px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+}
+
+/* ---------- The runners-up ---------- */
+
+.alsoList {
+  margin: 0;
+  padding: 0 20px 6px;
+  list-style: none;
+}
+
+/* Same anatomy as a feed card — head row, headline, summary, meta — just without
+   the card's own border and shadow, because the band supplies those. */
+.alsoRow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 8px;
+  margin: 0 -8px;
+
+  /* One rule above every row — including the first, so the line separating the
+     lead from story two is the same line that separates two from three. */
+  border-top: 1px solid var(--border-neutral-subtle, rgba(27, 56, 96, 0.1));
+
+  &:last-child {
+    border-radius: 0 0 11px 11px;
+  }
+
+  &:hover .alsoTitle {
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}
+
+/* The headline is the click target: the row holds a Follow button and a team
+   link, and a button can't nest inside a button. Production hit exactly this in
+   `ReferRoleRow`. */
+.alsoTitleBtn {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 3px;
+    border-radius: 4px;
+  }
+}
+
+.alsoTitle {
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  transition: color 0.12s ease;
+}
+
+/* These are top stories too, so they get a summary — a bare headline reads as an
+   afterthought. Two lines each, or three summaries push the stream off screen. */
+.alsoSummary {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-secondary, #455468);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { useCurrentUserStore } from '@/services/auth/store';
+import { FollowButton } from '@/components/ui/FollowButton';
+import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
+import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
+import { hasNewsSource } from '../../utils/getNewsSources';
+import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
+import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
+import { NewsShareMenu } from '../NewsShareMenu';
+import { SourceList } from '../SourceList/SourceList';
+import { TopStoryCard } from './TopStoryCard';
+
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+import s from './TopStories.module.scss';
+
+export type TopStorySlot = 'lead' | 'row';
+
+interface TopStoriesBlockProps {
+  lead: ITeamNewsItem;
+  /** The runners-up, 0–2. Rendered as rows, not cards. */
+  also: ITeamNewsItem[];
+  windowLabel: string;
+  followedTeamUids: ReadonlySet<string>;
+  onFollowToggle: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
+  onUpvoteToggle: (item: ITeamNewsItem) => void;
+  /** Opens the detail modal. `slot` + `position` are this block's own position
+   *  math: block items are not in `visibleEntries`, so the feed's findIndex
+   *  would report -1 for every one of them. */
+  onStoryOpen: (item: ITeamNewsItem, slot: TopStorySlot, position: number) => void;
+  analyticsSource?: TeamNewsAnalyticsSource;
+}
+
+/**
+ * The window's editorial block: one lead plus up to two secondary rows.
+ *
+ * Asymmetric on purpose — three equal heroes would push the stream under the
+ * fold. The lead keeps the eyebrow and the full summary; the runners-up are
+ * rows carrying the same anatomy as a feed card (head row, headline, clamped
+ * summary, meta) minus the card's own border, because the band supplies it.
+ *
+ * One band, not three cards: separate cards would read as feed items that
+ * happen to sit high, rather than as part of one pick.
+ */
+export function TopStoriesBlock({
+  lead,
+  also,
+  windowLabel,
+  followedTeamUids,
+  onFollowToggle,
+  onUpvoteToggle,
+  onStoryOpen,
+  analyticsSource = 'home',
+}: TopStoriesBlockProps) {
+  const router = useRouter();
+  const { currentUser, isHydrated } = useCurrentUserStore();
+  const analytics = useTeamNewsAnalytics();
+
+  // Fire-once view event, same guard as NewsRail's popularShownRef — the click
+  // events below need a denominator or they measure nothing.
+  const viewedRef = useRef(false);
+  useEffect(() => {
+    if (viewedRef.current) return;
+    viewedRef.current = true;
+    analytics.onTopStoriesBlockViewed(lead.uid, also.length);
+  }, [analytics, lead.uid, also.length]);
+
+  const requireSignIn = () => {
+    router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
+  };
+
+  const handleFollowClick = (item: ITeamNewsItem) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!currentUser) return requireSignIn();
+    onFollowToggle(item.teamUid, item.teamName, followedTeamUids.has(item.teamUid));
+  };
+
+  const handleUpvoteClick = (item: ITeamNewsItem) => () => {
+    if (!currentUser) return requireSignIn();
+    onUpvoteToggle(item);
+  };
+
+  return (
+    <section className={s.block} aria-label="Top stories">
+      <TopStoryCard
+        story={lead}
+        windowLabel={windowLabel}
+        isOnly={also.length === 0}
+        isFollowing={followedTeamUids.has(lead.teamUid)}
+        onFollowToggle={onFollowToggle}
+        onUpvoteToggle={onUpvoteToggle}
+        onOpen={(item) => onStoryOpen(item, 'lead', 0)}
+        analyticsSource={analyticsSource}
+      />
+
+      {also.length > 0 && (
+        <ul className={s.alsoList}>
+          {also.map((item, index) => {
+            const { label: eventTypeLabel, dotClassName } = getEventTypeConfig(item.eventType);
+            const isFollowing = followedTeamUids.has(item.teamUid);
+            return (
+              <li key={item.uid} className={s.alsoRow}>
+                <div className={newsCardStyles.head}>
+                  {item.teamLogoUrl ? (
+                    <img className={newsCardStyles.logo} src={item.teamLogoUrl} alt="" loading="lazy" />
+                  ) : (
+                    <div className={newsCardStyles.logoFallback}>{getTeamLogoFallback(item.teamName)}</div>
+                  )}
+                  <a
+                    href={`/teams/${item.teamUid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={newsCardStyles.teamName}
+                  >
+                    {item.teamName}
+                  </a>
+                  {isHydrated && (
+                    <FollowButton
+                      following={isFollowing}
+                      onClick={handleFollowClick(item)}
+                      name={item.teamName}
+                      size="compact"
+                    />
+                  )}
+                </div>
+
+                {/* The headline is the click target, not the row: the row holds a
+                    Follow button and a team link, and a button can't nest inside
+                    a button (production hit exactly this in ReferRoleRow). */}
+                <button
+                  type="button"
+                  aria-haspopup="dialog"
+                  aria-label={item.title}
+                  className={s.alsoTitleBtn}
+                  onClick={() => onStoryOpen(item, 'row', index + 1)}
+                >
+                  <span className={s.alsoTitle}>{item.title}</span>
+                </button>
+
+                {item.summary && <p className={s.alsoSummary}>{item.summary}</p>}
+
+                <div className={newsCardStyles.metaLine}>
+                  <div className={newsCardStyles.meta}>
+                    <span className={newsCardStyles.eventType}>
+                      <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
+                      <span className={newsCardStyles.eventLabel}>{eventTypeLabel}</span>
+                    </span>
+                    {hasNewsSource(item) && (
+                      <>
+                        <span className={newsCardStyles.sep} aria-hidden="true" />
+                        <SourceList item={item} position={index + 1} analyticsSource={analyticsSource} />
+                      </>
+                    )}
+                    <span className={newsCardStyles.sep} aria-hidden="true" />
+                    <span className={newsCardStyles.time}>{formatTimeAgo(item.eventDate)}</span>
+                  </div>
+                  <div className={newsCardStyles.actions}>
+                    <NewsShareMenu item={item} source={analyticsSource} />
+                    <UpvoteButton
+                      count={item.upvoteCount ?? 0}
+                      voted={Boolean(item.viewerHasUpvoted)}
+                      onToggle={handleUpvoteClick(item)}
+                    />
+                    <CommentButton
+                      itemUid={item.uid}
+                      open={false}
+                      onToggle={() => onStoryOpen(item, 'row', index + 1)}
+                      opensDetail
+                    />
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import type { SVGProps } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { useCurrentUserStore } from '@/services/auth/store';
+import { FollowButton } from '@/components/ui/FollowButton';
+import type { TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
+import { getEventTypeConfig } from '../../utils/getEventTypeConfig';
+import { hasNewsSource } from '../../utils/getNewsSources';
+import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
+import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
+import { NewsShareMenu } from '../NewsShareMenu';
+import { SourceList } from '../SourceList/SourceList';
+
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+import s from './TopStories.module.scss';
+
+/**
+ * Filled pin. `@/components/icons/PushPinIcon` is the hairline outline at 24px —
+ * at eyebrow size its 1px contour dissolves into the uppercase letterforms next
+ * to it. This is the same diagonal pin production ships filled at 12px
+ * (`public/icons/pin-black.svg`), transcribed so the geometry stays production's;
+ * only the hardcoded `#64748B` becomes `currentColor` so it inherits the brand
+ * blue from `.badge`. Pin rather than sparkles — nothing here is AI-picked.
+ */
+function PinFilledIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M8.07526 0.140046L8.13792 0.19538L11.8046 3.86205C11.917 3.97503 11.9852 4.12453 11.9968 4.28347C12.0085 4.4424 11.9628 4.60025 11.8681 4.72841C11.7734 4.85657 11.6359 4.94657 11.4805 4.98209C11.3252 5.01761 11.1623 4.99631 11.0213 4.92205L8.90659 7.03605L7.95726 9.56738C7.93225 9.63417 7.89669 9.69652 7.85192 9.75205L7.80526 9.80538L6.80526 10.8054C6.69038 10.9201 6.5376 10.9889 6.37558 10.999C6.21357 11.009 6.05345 10.9596 5.92526 10.86L5.86192 10.8047L3.99992 8.94338L1.47126 11.4714C1.35128 11.5909 1.1903 11.6604 1.021 11.6655C0.851701 11.6707 0.686781 11.6112 0.559737 11.4992C0.432694 11.3872 0.353053 11.231 0.33699 11.0624C0.320928 10.8938 0.369648 10.7254 0.473256 10.5914L0.52859 10.5287L3.05659 8.00005L1.19526 6.13805C1.08047 6.02325 1.01152 5.87052 1.00133 5.7085C0.991143 5.54648 1.04042 5.38632 1.13992 5.25805L1.19526 5.19538L2.19526 4.19538C2.24556 4.1449 2.30363 4.10281 2.36726 4.07071L2.43259 4.04271L4.96326 3.09271L7.07726 0.97938C7.00517 0.844601 6.98158 0.689144 7.01045 0.539049C7.03932 0.388954 7.11888 0.253336 7.23582 0.154911C7.35276 0.0564862 7.49997 0.00123267 7.65279 -0.00159482C7.80561 -0.00442232 7.95476 0.0460147 8.07526 0.140046Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+interface TopStoryCardProps {
+  story: ITeamNewsItem;
+  /** e.g. "Last 14 days" — the window the ranking was taken over, stated so the
+   *  claim "top" is bounded by something the reader can see. */
+  windowLabel: string;
+  /** True when there are no runners-up, so the lead rounds its own bottom corners. */
+  isOnly: boolean;
+  isFollowing: boolean;
+  onFollowToggle: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
+  onUpvoteToggle: (item: ITeamNewsItem) => void;
+  onOpen: (item: ITeamNewsItem) => void;
+  analyticsSource?: TeamNewsAnalyticsSource;
+}
+
+/**
+ * The window's lead story, above the feed.
+ *
+ * Visibly a different object from a feed card rather than a larger one: a brand
+ * eyebrow, a 24px headline, and a full (unclamped) summary inside a band that
+ * carries its own border.
+ *
+ * The prototype's "why this won" line and curation attribution are deliberately
+ * absent — this pick is ranked by network likes, so there is no editor to
+ * attribute it to and no written rationale to show. An honest omission beats a
+ * fabricated one; see the brainstorm.
+ */
+export function TopStoryCard({
+  story,
+  windowLabel,
+  isOnly,
+  isFollowing,
+  onFollowToggle,
+  onUpvoteToggle,
+  onOpen,
+  analyticsSource = 'home',
+}: TopStoryCardProps) {
+  const router = useRouter();
+  const { currentUser, isHydrated } = useCurrentUserStore();
+  const { label: eventTypeLabel, dotClassName } = getEventTypeConfig(story.eventType);
+
+  const requireSignIn = () => {
+    router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
+  };
+
+  const handleFollowClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!currentUser) return requireSignIn();
+    onFollowToggle(story.teamUid, story.teamName, isFollowing);
+  };
+
+  const handleUpvoteClick = () => {
+    if (!currentUser) return requireSignIn();
+    onUpvoteToggle(story);
+  };
+
+  return (
+    <article className={isOnly ? `${s.lead} ${s.leadOnly}` : s.lead}>
+      <div className={s.eyebrow}>
+        <span className={s.badge}>
+          <PinFilledIcon className={s.badgeIcon} aria-hidden />
+          Top stories
+        </span>
+        <span className={s.window}>{windowLabel}</span>
+      </div>
+
+      {/* Outside the click target below, so the lead holds no interactive
+          element inside another — the same split NewsGroupCard uses between its
+          head row and its story rows. */}
+      <div className={newsCardStyles.head}>
+        {story.teamLogoUrl ? (
+          <img className={newsCardStyles.logo} src={story.teamLogoUrl} alt="" loading="lazy" />
+        ) : (
+          <div className={newsCardStyles.logoFallback}>{getTeamLogoFallback(story.teamName)}</div>
+        )}
+        <a
+          href={`/teams/${story.teamUid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={newsCardStyles.teamName}
+        >
+          {story.teamName}
+        </a>
+        {isHydrated && (
+          <FollowButton following={isFollowing} onClick={handleFollowClick} name={story.teamName} size="compact" />
+        )}
+      </div>
+
+      {/* Concise accessible name: without it the button's name is its entire text
+          content (title + summary), which is screen-reader noise. */}
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-label={story.title}
+        className={s.leadBody}
+        onClick={() => onOpen(story)}
+      >
+        <h2 className={s.leadTitle}>{story.title}</h2>
+        {story.summary && <p className={s.leadSummary}>{story.summary}</p>}
+      </button>
+
+      <div className={newsCardStyles.metaLine}>
+        <div className={newsCardStyles.meta}>
+          <span className={newsCardStyles.eventType}>
+            <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
+            <span className={newsCardStyles.eventLabel}>{eventTypeLabel}</span>
+          </span>
+          {hasNewsSource(story) && (
+            <>
+              <span className={newsCardStyles.sep} aria-hidden="true" />
+              <SourceList item={story} position={0} analyticsSource={analyticsSource} />
+            </>
+          )}
+          <span className={newsCardStyles.sep} aria-hidden="true" />
+          <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
+        </div>
+        <div className={newsCardStyles.actions}>
+          <NewsShareMenu item={story} source={analyticsSource} />
+          <UpvoteButton
+            count={story.upvoteCount ?? 0}
+            voted={Boolean(story.viewerHasUpvoted)}
+            onToggle={handleUpvoteClick}
+          />
+          {/* The band has no inline thread: an expanding thread here would push
+              the runners-up a screen down. Comments live in the detail modal. */}
+          <CommentButton itemUid={story.uid} open={false} onToggle={() => onOpen(story)} opensDetail />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/components/page/home/TeamNews/components/TopStories/index.ts
+++ b/components/page/home/TeamNews/components/TopStories/index.ts
@@ -1,0 +1,1 @@
+export { TopStoriesBlock, type TopStorySlot } from './TopStoriesBlock';

--- a/components/page/home/TeamNews/constants.ts
+++ b/components/page/home/TeamNews/constants.ts
@@ -1,4 +1,5 @@
 import type { TeamNewsEventType } from '@/types/team-news.types';
+import { TEAM_NEWS_DEFAULT_WINDOW_DAYS } from '@/services/team-news/constants';
 
 import { EVENT_TYPE_LABEL } from './utils/getEventTypeConfig';
 
@@ -32,3 +33,11 @@ export const CATEGORIES: Array<{ id: TeamNewsEventType | typeof ALL_CAT; label: 
   // so its keys are exactly TeamNewsEventType (Object.keys itself only returns string[]).
   ...(Object.keys(EVENT_TYPE_LABEL) as TeamNewsEventType[]).map((id) => ({ id, label: EVENT_TYPE_LABEL[id] })),
 ];
+
+/**
+ * The window the top-stories band ranks over, stated on the band itself so the
+ * claim "top" is bounded by something the reader can see. Derived from the same
+ * constant the grouped-by-focus-area fetch sends as `?windowDays=`, so the label
+ * can't drift from the data behind it.
+ */
+export const TOP_STORIES_WINDOW_LABEL = `Last ${TEAM_NEWS_DEFAULT_WINDOW_DAYS} days`;

--- a/components/page/home/TeamNews/utils/selectTopStories.ts
+++ b/components/page/home/TeamNews/utils/selectTopStories.ts
@@ -1,0 +1,79 @@
+import type { ITeamNewsItem } from '@/types/team-news.types';
+
+/** The lead card. */
+export const TOP_STORIES_LEAD_COUNT = 1;
+/** The secondary rows under the lead. Two, not three: the band sits above the
+ *  whole feed, and a third row pushes the stream under the fold. */
+export const TOP_STORIES_ROW_COUNT = 2;
+
+/** How many stories the band consumes when it renders. */
+export const TOP_STORIES_TOTAL = TOP_STORIES_LEAD_COUNT + TOP_STORIES_ROW_COUNT;
+
+/** The feed's default first page — see TeamNews' `pageSize` default. */
+const DEFAULT_FEED_PAGE = 6;
+
+/**
+ * The corpus the band needs to exist: its own three plus a full first page
+ * beneath it.
+ *
+ * Absolute rather than derived from the caller's `pageSize`: whether a window
+ * is rich enough to warrant an editorial band is a property of the window, not
+ * of a paging knob, and tying the two would let a `pageSize` override silently
+ * decide whether the band appears.
+ */
+export const TOP_STORIES_MIN_CORPUS = TOP_STORIES_TOTAL + DEFAULT_FEED_PAGE;
+
+export interface TopStoriesSelection {
+  /** null when the window is below `minItems` — the caller renders nothing. */
+  lead: ITeamNewsItem | null;
+  /** The runners-up. Always two when `lead` is set, since `minItems` is floored
+   *  at TOP_STORIES_TOTAL — but typed as a list so the band's own render still
+   *  guards on length rather than trusting the caller. */
+  also: ITeamNewsItem[];
+  /** Every uid in the block. The one exclusion set — used for the stream below
+   *  and for the rail's "Popular this week", so the two can't drift. */
+  uids: Set<string>;
+}
+
+const EMPTY: TopStoriesSelection = { lead: null, also: [], uids: new Set() };
+
+/**
+ * Picks the block's stories: most-upvoted in the window, ties broken by
+ * `eventDate` descending.
+ *
+ * `upvoteCounts` must be the MOUNT-TIME snapshot (TeamNews.tsx's
+ * `initialUpvoteCounts`), never live counts. Same reason `sortTeamNewsClusters`
+ * takes the same map: liking the featured story would otherwise re-rank the
+ * block under the cursor that just clicked it. Display reads the live overlay;
+ * only the ordering is frozen.
+ *
+ * A window where nothing has been upvoted degenerates to "the three most recent
+ * stories" via the tie-break, which is a defensible top-stories block rather
+ * than a broken one — so there is no zero-engagement special case.
+ *
+ * `minItems` is the corpus the band needs to exist at all — normally
+ * `TOP_STORIES_MIN_CORPUS`. The band's whole premise is that it sits ABOVE a
+ * feed: on a quiet window it would swallow most of the stories and leave one or
+ * two below, at which point it isn't a pick over a stream, it's the stream with
+ * different styling. Parameterised rather than hardcoded so the gate is
+ * directly testable.
+ */
+export function selectTopStories(
+  items: ITeamNewsItem[],
+  upvoteCounts: ReadonlyMap<string, number>,
+  minItems: number,
+): TopStoriesSelection {
+  if (items.length < Math.max(minItems, TOP_STORIES_TOTAL)) return EMPTY;
+
+  const ranked = [...items].sort((a, b) => {
+    const byUpvotes = (upvoteCounts.get(b.uid) ?? 0) - (upvoteCounts.get(a.uid) ?? 0);
+    return byUpvotes !== 0 ? byUpvotes : b.eventDate.localeCompare(a.eventDate);
+  });
+
+  const picked = ranked.slice(0, TOP_STORIES_TOTAL);
+  return {
+    lead: picked[0] ?? null,
+    also: picked.slice(1),
+    uids: new Set(picked.map((i) => i.uid)),
+  };
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -609,6 +609,10 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   TEAM_NEWS_POPULAR_STORY_CLICKED: 'team-news-popular-story-clicked',
   TEAM_NEWS_POPULAR_STORY_SCROLL_SUCCEEDED: 'team-news-popular-story-scroll-succeeded',
   TEAM_NEWS_POPULAR_STORY_FALLBACK_OPENED: 'team-news-popular-story-fallback-opened',
+  // Top-stories band above the feed. VIEWED is the denominator CLICKED needs —
+  // without it a low click count can't be told apart from a block nobody saw.
+  TEAM_NEWS_TOP_STORIES_BLOCK_VIEWED: 'team-news-top-stories-block-viewed',
+  TEAM_NEWS_TOP_STORY_CLICKED: 'team-news-top-story-clicked',
   // Feed social layer (forum posts in the feed + feed-only comments).
   TEAM_NEWS_FEED_FORUM_POST_CARD_CLICKED: 'team-news-feed-forum-post-card-clicked',
   TEAM_NEWS_FEED_FORUM_POST_MODAL_OPENED: 'team-news-feed-forum-post-modal-opened',


### PR DESCRIPTION
## Summary

Phase 1 of the newsfeed redesign: an editorial band above the home feed carrying one lead card plus two secondary rows, ranked by upvote count within the 14-day window and tie-broken by `eventDate`.

No new endpoints — reuses the `groups` and `popularItems` already fetched SSR in `app/home/page.tsx`.

Also flips `TeamsToFollowCard`'s subtitle to prefer the recommendation `reason` over the team tagline: a tagline says what a team is, which its profile already does; the reason says why it's in front of *you*, which is what earns a follow from a module nobody asked for.

Prototype: `prototypes/entries/newsfeed/` (`TopStoriesBlock.tsx`, `TopStoryCard.tsx`, `FollowTeamsCard.tsx`).

## Key decisions

**Ranking reads the mount-time upvote snapshot**, rendering the live overlay — the same split `sortTeamNewsClusters` uses (#2677). Liking the featured story updates its count without demoting it under the cursor that just clicked it.

**The band requires a corpus of 9**, not just the three stories it shows — its own three plus a full default page beneath it. A band that swallows a quiet window isn't a pick over a stream, it's the stream with different styling. The floor is absolute rather than derived from `pageSize`, so a paging override can't silently decide whether the band appears.

**Band stories are excluded before `clusterByTeam`**, not after — pulling items out of already-built clusters would leave one with a hole. They're also filtered out of the rail's Popular this week, which ranks by likes too and would otherwise repeat the same three stories a few hundred pixels away.

**The band is network-wide, so it hides on any narrowed view** — focus tab, category pill, or search query. One flag drives visibility, stream exclusion and the Popular dedup together, so the three can't drift.

## Deliberately not built

- **No hero image.** The ticket asks for one, but `ITeamNewsItem` has no image field and the prototype's own `TopStoryCard` renders none. Needs a backend `imageUrl`/`ogImage` field first.
- **No "why this won" line, no curation attribution.** The prototype hardcodes both in `mocks.ts`. A likes ranking has no editor to attribute and no written rationale to show — an honest omission beats a fabricated one.
- **No `ViewCount`.** Prototype-only mock; there are no production view counts.

## Notable implementation details

- `CommentButton` gains an `opensDetail` variant. It's a disclosure control for the feed's inline threads; the band has none (one would push the runners-up a screen down), so its button opens the detail modal. Reusing it as-is would have shipped a permanent `aria-expanded={false}` and an `aria-controls` pointing at nothing — `opensDetail` swaps both for `aria-haspopup="dialog"`, matching how `NewsGroupCard`'s rows announce the same modal. The prototype's own comment button carries the identical prop.
- **No `overflow: hidden` on the band.** The prototype clips `.topBlock` to round the lead's gradient; production can't, because `SourceList` renders a popover that must escape the card bounds (the same reason production's `.card` refuses it). The lead rounds its own top corners and the last row the bottom ones.
- The band's rows split their click target the way `ReferRoleRow` had to: the headline is the button, not the row, since the row holds a Follow button and a team link.
- New analytics: `team-news-top-stories-block-viewed` (the denominator) and `team-news-top-story-clicked` with `slot` + `position`. The band doesn't route through `onTeamNewsCardClicked` because its items aren't in `visibleEntries`, so that handler's position lookup would report `-1` for every one of them.

## Testing

- 11 new unit tests for `selectTopStories` (ranking, tie-break, corpus gate, snapshot pinning, no input mutation).
- 8 new `TeamNews` tests: corpus gate either side of the threshold, stream exclusion, hiding on tab/pill/search, Popular dedup, analytics slot/position, modal + `?news=` deep link, no re-rank on like.
- Existing feed assertions scoped to the new `[data-news-feed-list]` region so the band's own copies of the same stories don't match them — original intent preserved.
- Full suite: 1377 pass. The one failure (`getCurrentRoundNumber` month boundary) is date-dependent and reproduces on a clean tree — unrelated to this branch.
- `npm run build` passes; lint clean across every touched file.

Verified live against the dev API: band renders with real data (lead at 9 likes, rows at 7 and 6) while Popular this week shows different stories at 5/5/4/3, confirming the dedup. Clicking the Funding pill hides the band. No horizontal overflow at 390px or 900px and no console errors from the new code.

## Follow-ups

Phase 2 (jobs + deals in the feed) and Phase 3 (mobile horizontal rails) ship separately. Two findings worth carrying forward:

- `GET /v1/job-openings` already returns `IJobTeamGroup { team, totalRoles, roles[] }` — the hiring roll-up needs no client-side grouping, and `windowDays` forwards through `/api/jobs/list` untouched.
- The rail stacks at **1200px** (`$breakpoint-lg`), not the prototype's 960px. Neither `useIsNarrow` (1024) nor `useIsMobile` (768) fits, so Phase 3 needs a third hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
