### PR TITLE
feat(newsfeed): mix hiring roll-ups and deals into the feed

### DIFF
--- a/__tests__/page/home/inject-feed-signals.test.ts
+++ b/__tests__/page/home/inject-feed-signals.test.ts
@@ -1,0 +1,189 @@
+import {
+  injectFeedSignals,
+  hiringGroupDate,
+  MAX_HIRING_ENTRIES,
+  MAX_DEAL_ENTRIES,
+  SUPPORTING_CADENCE,
+} from '@/components/page/home/TeamNews/utils/injectFeedSignals';
+import type { RankedFeedEntry } from '@/components/page/home/TeamNews/utils/mergeFeedEntries';
+import type { IDeal } from '@/types/deals.types';
+import type { IJobTeamGroup } from '@/types/jobs.types';
+import type { TeamCluster } from '@/types/team-news.types';
+
+const newsEntry = (teamUid: string): RankedFeedEntry => ({
+  kind: 'news',
+  cluster: { teamUid, teamName: `Team ${teamUid}`, teamLogoUrl: null, items: [] } as unknown as TeamCluster,
+});
+
+const stream = (n: number): RankedFeedEntry[] => Array.from({ length: n }, (_, i) => newsEntry(`t${i}`));
+
+const group = (
+  uid: string,
+  lastUpdated = '2026-08-01T00:00:00.000Z',
+  postedDate: string | null = null,
+): IJobTeamGroup =>
+  ({
+    team: { uid, name: `Team ${uid}`, logoUrl: null, focusAreas: [], subFocusAreas: [] },
+    totalRoles: 3,
+    roles: [
+      {
+        uid: `${uid}-r1`,
+        roleTitle: 'Engineer',
+        roleCategory: null,
+        seniority: null,
+        location: ['Remote'],
+        workMode: null,
+        applyUrl: 'https://example.com/apply',
+        lastUpdated,
+        postedDate,
+        detectionDate: null,
+      },
+    ],
+  }) as IJobTeamGroup;
+
+const deal = (uid: string, createdAt = '2026-08-01T00:00:00.000Z'): IDeal =>
+  ({
+    uid,
+    vendorName: `Vendor ${uid}`,
+    vendorTeamUid: null,
+    logoUid: null,
+    category: 'Infrastructure',
+    audience: 'ALL_FOUNDERS',
+    shortDescription: 'A deal.',
+    status: 'ACTIVE',
+    createdAt,
+    updatedAt: createdAt,
+    isRedeemed: false,
+    isUsing: false,
+    teamsRedemptionCount: 0,
+    teamsUsingCount: 0,
+    logoUrl: null,
+  }) as IDeal;
+
+const kinds = (entries: ReturnType<typeof injectFeedSignals>) => entries.map((e) => e.kind);
+
+describe('injectFeedSignals', () => {
+  it('returns the entries untouched when neither stream loaded', () => {
+    const entries = stream(6);
+    expect(injectFeedSignals({ entries, hiring: undefined, deals: undefined })).toBe(entries);
+  });
+
+  it('returns the entries untouched when both streams are empty', () => {
+    const entries = stream(6);
+    expect(injectFeedSignals({ entries, hiring: [], deals: [] })).toBe(entries);
+  });
+
+  // The feed's own empty state is the honest answer — not a page of only jobs.
+  it('drops the signals entirely when there are no ranked entries', () => {
+    const result = injectFeedSignals({ entries: [], hiring: [group('a')], deals: [deal('d1')] });
+    expect(result).toEqual([]);
+  });
+
+  it('never places a signal before the cadence is met', () => {
+    const result = injectFeedSignals({ entries: stream(12), hiring: [group('a')], deals: [deal('d1')] });
+
+    const firstSignal = result.findIndex((e) => e.kind === 'hiring' || e.kind === 'deal');
+    expect(firstSignal).toBe(SUPPORTING_CADENCE);
+    expect(result.slice(0, SUPPORTING_CADENCE).every((e) => e.kind === 'news')).toBe(true);
+  });
+
+  it('alternates hiring and deals so neither kind clusters', () => {
+    const result = injectFeedSignals({
+      entries: stream(20),
+      hiring: [group('a'), group('b')],
+      deals: [deal('d1'), deal('d2')],
+    });
+
+    expect(kinds(result).filter((k) => k !== 'news')).toEqual(['hiring', 'deal', 'hiring', 'deal']);
+  });
+
+  it('caps each kind independently', () => {
+    const result = injectFeedSignals({
+      entries: stream(40),
+      hiring: [group('a'), group('b'), group('c'), group('d')],
+      deals: [deal('d1'), deal('d2'), deal('d3')],
+    });
+
+    expect(kinds(result).filter((k) => k === 'hiring')).toHaveLength(MAX_HIRING_ENTRIES);
+    expect(kinds(result).filter((k) => k === 'deal')).toHaveLength(MAX_DEAL_ENTRIES);
+  });
+
+  it('keeps the ranked entries in their original order', () => {
+    const entries = stream(12);
+    const result = injectFeedSignals({ entries, hiring: [group('a')], deals: [deal('d1')] });
+
+    expect(result.filter((e) => e.kind === 'news')).toEqual(entries);
+  });
+
+  it('takes the most recent of each kind when over the cap', () => {
+    const result = injectFeedSignals({
+      entries: stream(20),
+      hiring: [
+        group('old', '2026-07-01T00:00:00.000Z'),
+        group('new', '2026-08-05T00:00:00.000Z'),
+        group('mid', '2026-07-20T00:00:00.000Z'),
+      ],
+      deals: [deal('d-old', '2026-07-02T00:00:00.000Z'), deal('d-new', '2026-08-04T00:00:00.000Z')],
+    });
+
+    const hiringUids = result.flatMap((e) => (e.kind === 'hiring' ? [e.group.team.uid] : []));
+    const dealUids = result.flatMap((e) => (e.kind === 'deal' ? [e.deal.uid] : []));
+
+    expect(hiringUids).toEqual(['new', 'mid']);
+    expect(dealUids).toEqual(['d-new', 'd-old']);
+  });
+
+  // Fetched but unplaceable beats silently dropped: the reader can still act on them.
+  it('appends leftover signals when the feed is shorter than the cadence allows', () => {
+    const result = injectFeedSignals({
+      entries: stream(SUPPORTING_CADENCE),
+      hiring: [group('a'), group('b')],
+      deals: [deal('d1'), deal('d2')],
+    });
+
+    expect(kinds(result).filter((k) => k !== 'news')).toHaveLength(4);
+    expect(result).toHaveLength(SUPPORTING_CADENCE + 4);
+    expect(result.slice(0, SUPPORTING_CADENCE).every((e) => e.kind === 'news')).toBe(true);
+  });
+
+  it('handles one stream loading without the other', () => {
+    const hiringOnly = injectFeedSignals({ entries: stream(12), hiring: [group('a')], deals: undefined });
+    expect(kinds(hiringOnly).filter((k) => k !== 'news')).toEqual(['hiring']);
+
+    const dealsOnly = injectFeedSignals({ entries: stream(12), hiring: undefined, deals: [deal('d1')] });
+    expect(kinds(dealsOnly).filter((k) => k !== 'news')).toEqual(['deal']);
+  });
+
+  it('does not mutate its inputs', () => {
+    const entries = stream(12);
+    const hiring = [group('a'), group('b')];
+    const deals = [deal('d1')];
+    const hiringOrder = hiring.map((g) => g.team.uid);
+
+    injectFeedSignals({ entries, hiring, deals });
+
+    expect(entries).toHaveLength(12);
+    expect(hiring.map((g) => g.team.uid)).toEqual(hiringOrder);
+  });
+});
+
+describe('hiringGroupDate', () => {
+  it('prefers postedDate over lastUpdated', () => {
+    expect(hiringGroupDate(group('a', '2026-07-01T00:00:00.000Z', '2026-08-09T00:00:00.000Z'))).toBe(
+      '2026-08-09T00:00:00.000Z',
+    );
+  });
+
+  it('falls back to lastUpdated when the board has no postedDate', () => {
+    expect(hiringGroupDate(group('a', '2026-07-01T00:00:00.000Z', null))).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('takes the most recent role in the group', () => {
+    const g = group('a');
+    g.roles = [
+      { ...g.roles[0], uid: 'r1', lastUpdated: '2026-07-01T00:00:00.000Z' },
+      { ...g.roles[0], uid: 'r2', lastUpdated: '2026-08-08T00:00:00.000Z' },
+    ];
+    expect(hiringGroupDate(g)).toBe('2026-08-08T00:00:00.000Z');
+  });
+});

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -6,6 +6,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TeamNews } from '@/components/page/home/TeamNews/TeamNews';
 import { useCurrentUserStore } from '@/services/auth/store';
 import type { IFeedForumPost } from '@/types/feed.types';
+import type { IDeal } from '@/types/deals.types';
+import type { IJobTeamGroup } from '@/types/jobs.types';
 import type {
   ITeamNewsDiscussion,
   ITeamNewsGroup,
@@ -48,6 +50,9 @@ const mockOnShared = jest.fn();
 const mockOnForumPostModalOpened = jest.fn();
 const mockOnTopStoriesBlockViewed = jest.fn();
 const mockOnTopStoryClicked = jest.fn();
+const mockOnFeedHiringRoleClicked = jest.fn();
+const mockOnFeedHiringViewAllClicked = jest.fn();
+const mockOnFeedDealClicked = jest.fn();
 
 jest.mock('@/analytics/team-news.analytics', () => ({
   useTeamNewsAnalytics: () => ({
@@ -72,6 +77,9 @@ jest.mock('@/analytics/team-news.analytics', () => ({
     onTeamsToFollowHidden: (...a: unknown[]) => mockOnTeamsToFollowHidden(...a),
     onTopStoriesBlockViewed: (...a: unknown[]) => mockOnTopStoriesBlockViewed(...a),
     onTopStoryClicked: (...a: unknown[]) => mockOnTopStoryClicked(...a),
+    onFeedHiringRoleClicked: (...a: unknown[]) => mockOnFeedHiringRoleClicked(...a),
+    onFeedHiringViewAllClicked: (...a: unknown[]) => mockOnFeedHiringViewAllClicked(...a),
+    onFeedDealClicked: (...a: unknown[]) => mockOnFeedDealClicked(...a),
   }),
 }));
 
@@ -92,6 +100,18 @@ function feedSocial(posts: IFeedForumPost[] | undefined, hasAccess: boolean): Fe
 const mockUseFeedSocial = jest.fn((): FeedSocialResult => feedSocial(undefined, false));
 jest.mock('@/components/page/home/TeamNews/hooks/useFeedSocial', () => ({
   useFeedSocial: (...a: unknown[]) => mockUseFeedSocial(...(a as [])),
+}));
+
+// Hiring roll-ups and deals reach the feed through these two. Default: neither
+// loaded, which is what the globally-mocked useQuery already produced — so every
+// other test in this file behaves exactly as before.
+const mockUseFeedHiring = jest.fn((): { hiring: IJobTeamGroup[] | undefined } => ({ hiring: undefined }));
+jest.mock('@/components/page/home/TeamNews/hooks/useFeedHiring', () => ({
+  useFeedHiring: () => mockUseFeedHiring(),
+}));
+const mockUseFeedDeals = jest.fn((): { deals: IDeal[] | undefined } => ({ deals: undefined }));
+jest.mock('@/components/page/home/TeamNews/hooks/useFeedDeals', () => ({
+  useFeedDeals: () => mockUseFeedDeals(),
 }));
 
 // The global jest.setup.js mock returns a NEW object with fresh jest.fn()s on
@@ -184,6 +204,8 @@ describe('TeamNews', () => {
     // clearAllMocks clears calls, NOT return values — without this, a describe
     // that supplies forum posts leaks them into every later test's feed.
     mockUseFeedSocial.mockReturnValue(feedSocial(undefined, false));
+    mockUseFeedHiring.mockReturnValue({ hiring: undefined });
+    mockUseFeedDeals.mockReturnValue({ deals: undefined });
     // useNewsDeepLink reads the real jsdom URL on mount — reset it so a
     // ?news= param written by one test can't open the modal in the next.
     window.history.replaceState(null, '', '/home');
@@ -1415,6 +1437,146 @@ describe('TeamNews', () => {
 
       expect(firstRow).not.toHaveClass('storyHighlighted');
       expect(secondRow).toHaveClass('storyHighlighted');
+    });
+  });
+
+  describe('hiring and deals in the feed', () => {
+    const jobRole = (uid: string, overrides: Partial<IJobTeamGroup['roles'][number]> = {}) => ({
+      uid,
+      roleTitle: `Role ${uid}`,
+      roleCategory: null,
+      seniority: null,
+      location: ['Remote'],
+      workMode: null,
+      applyUrl: `https://jobs.example.com/${uid}`,
+      lastUpdated: '2026-08-01T00:00:00.000Z',
+      postedDate: null,
+      detectionDate: null,
+      ...overrides,
+    });
+
+    const hiringGroup = (uid: string, overrides: Partial<IJobTeamGroup> = {}): IJobTeamGroup =>
+      ({
+        team: { uid, name: `Hiring ${uid}`, logoUrl: null, focusAreas: [], subFocusAreas: [] },
+        totalRoles: 5,
+        roles: [jobRole(`${uid}-r1`), jobRole(`${uid}-r2`)],
+        ...overrides,
+      }) as IJobTeamGroup;
+
+    const feedDeal = (uid: string, overrides: Partial<IDeal> = {}): IDeal =>
+      ({
+        uid,
+        vendorName: `Vendor ${uid}`,
+        vendorTeamUid: null,
+        logoUid: null,
+        category: 'Infrastructure',
+        audience: 'ALL_FOUNDERS',
+        shortDescription: `Perk ${uid}`,
+        status: 'ACTIVE',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: '2026-08-01T00:00:00.000Z',
+        isRedeemed: false,
+        isUsing: false,
+        teamsRedemptionCount: 0,
+        teamsUsingCount: 0,
+        logoUrl: null,
+      }) as IDeal;
+
+    // Nine items clears TOP_STORIES_MIN_CORPUS, so the band takes three and six
+    // ranked entries remain — enough for the cadence to place both signals.
+    const wideItems = Array.from({ length: 9 }, (_, i) => makeItem(`w-${i}`, 'FUNDING', ['AI & Robotics']));
+    const wideGroups: ITeamNewsGroup[] = [{ focusArea: FA_AI, total: wideItems.length, items: wideItems }];
+
+    it('renders a hiring roll-up and a deal card in the stream', () => {
+      mockUseFeedHiring.mockReturnValue({ hiring: [hiringGroup('acme')] });
+      mockUseFeedDeals.mockReturnValue({ deals: [feedDeal('d1')] });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      expect(screen.getByText('Hiring acme is hiring')).toBeInTheDocument();
+      expect(screen.getByText('View all 5 open roles at Hiring acme')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Vendor d1' })).toBeInTheDocument();
+      expect(screen.getByText('Perk d1')).toBeInTheDocument();
+    });
+
+    it('never lets a signal lead the feed', () => {
+      mockUseFeedHiring.mockReturnValue({ hiring: [hiringGroup('acme')] });
+      mockUseFeedDeals.mockReturnValue({ deals: [feedDeal('d1')] });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      const first = document.querySelector('[data-news-feed-list]')!.firstElementChild!;
+      expect(first.textContent).not.toContain('is hiring');
+      expect(first.textContent).not.toContain('Vendor d1');
+    });
+
+    it('carries the job board attribution params on role links', () => {
+      mockUseFeedHiring.mockReturnValue({ hiring: [hiringGroup('acme')] });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      expect(screen.getByRole('link', { name: 'Role acme-r1' })).toHaveAttribute(
+        'href',
+        'https://jobs.example.com/acme-r1?utm_source=os.pl.xyz&utm_medium=job_board',
+      );
+    });
+
+    it('renders a role without an apply link as plain text, not a dead anchor', () => {
+      mockUseFeedHiring.mockReturnValue({
+        hiring: [hiringGroup('acme', { roles: [jobRole('no-url', { applyUrl: null })] })],
+      });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      expect(screen.getByText('Role no-url')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Role no-url' })).not.toBeInTheDocument();
+    });
+
+    it('renders no location rather than an empty one', () => {
+      mockUseFeedHiring.mockReturnValue({
+        hiring: [hiringGroup('acme', { roles: [jobRole('bare', { location: [] })] })],
+      });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      const row = screen.getByRole('link', { name: 'Role bare' }).closest('li')!;
+      expect(row.textContent).toBe('Role bare');
+    });
+
+    // Neither kind carries a focus area or an event type, so every narrowed
+    // view drops them — the same flag that hides the band.
+    it('drops both kinds on a category pill', () => {
+      mockUseFeedHiring.mockReturnValue({ hiring: [hiringGroup('acme')] });
+      mockUseFeedDeals.mockReturnValue({ deals: [feedDeal('d1')] });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+      expect(screen.getByText('Hiring acme is hiring')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /^Funding\b/ }));
+
+      expect(screen.queryByText('Hiring acme is hiring')).not.toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Vendor d1' })).not.toBeInTheDocument();
+    });
+
+    it('leaves the feed intact when neither stream loads', () => {
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      expect(screen.queryByText(/is hiring/)).not.toBeInTheDocument();
+      expect(document.querySelector('[data-news-feed-list]')!.children.length).toBeGreaterThan(0);
+    });
+
+    it('reports role, view-all and deal clicks with their feed position', () => {
+      mockUseFeedHiring.mockReturnValue({ hiring: [hiringGroup('acme')] });
+      mockUseFeedDeals.mockReturnValue({ deals: [feedDeal('d1')] });
+      renderTeamNews(<TeamNews groups={wideGroups} pageSize={20} />);
+
+      fireEvent.click(screen.getByRole('link', { name: 'Role acme-r1' }));
+      expect(mockOnFeedHiringRoleClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ team: expect.objectContaining({ uid: 'acme' }) }),
+        expect.objectContaining({ uid: 'acme-r1' }),
+        0,
+        expect.any(Number),
+      );
+
+      fireEvent.click(screen.getByText('View all 5 open roles at Hiring acme'));
+      expect(mockOnFeedHiringViewAllClicked).toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('heading', { name: 'Vendor d1' }));
+      expect(mockOnFeedDealClicked).toHaveBeenCalledWith(expect.objectContaining({ uid: 'd1' }), expect.any(Number));
     });
   });
 

--- a/analytics/team-news.analytics.ts
+++ b/analytics/team-news.analytics.ts
@@ -287,6 +287,51 @@ export const useTeamNewsAnalytics = () => {
     });
   };
 
+  const onFeedHiringRoleClicked = (
+    group: { team: { uid: string; name: string }; totalRoles: number },
+    role: { uid: string; roleTitle: string },
+    rolePosition: number,
+    feedPosition: number,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_HIRING_ROLE_CLICKED, {
+      teamUid: group.team.uid,
+      teamName: group.team.name,
+      roleUid: role.uid,
+      roleTitle: role.roleTitle,
+      totalRoles: group.totalRoles,
+      rolePosition,
+      position: feedPosition,
+      source: 'home' satisfies TeamNewsAnalyticsSource,
+    });
+  };
+
+  const onFeedHiringViewAllClicked = (
+    group: { team: { uid: string; name: string }; totalRoles: number },
+    feedPosition: number,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_HIRING_VIEW_ALL_CLICKED, {
+      teamUid: group.team.uid,
+      teamName: group.team.name,
+      totalRoles: group.totalRoles,
+      position: feedPosition,
+      source: 'home' satisfies TeamNewsAnalyticsSource,
+    });
+  };
+
+  const onFeedDealClicked = (
+    deal: { uid: string; vendorName: string; category: string; audience: string },
+    feedPosition: number,
+  ) => {
+    captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_FEED_DEAL_CLICKED, {
+      dealUid: deal.uid,
+      vendorName: deal.vendorName,
+      category: deal.category,
+      audience: deal.audience,
+      position: feedPosition,
+      source: 'home' satisfies TeamNewsAnalyticsSource,
+    });
+  };
+
   const onPopularCardViewed = (itemCount: number) => {
     captureEvent(TEAM_NEWS_ANALYTICS_EVENTS.TEAM_NEWS_POPULAR_CARD_VIEWED, { itemCount });
   };
@@ -575,6 +620,9 @@ export const useTeamNewsAnalytics = () => {
     onPopularStoryFallbackOpened,
     onTopStoriesBlockViewed,
     onTopStoryClicked,
+    onFeedHiringRoleClicked,
+    onFeedHiringViewAllClicked,
+    onFeedDealClicked,
     onTeamsToFollowViewed,
     onTeamsToFollowHidden,
     onFeedForumPostCardClicked,

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -42,11 +42,14 @@ import { applyUpvoteOverlay } from './utils/applyUpvoteOverlay';
 import { resolveForumPostLike } from './utils/resolveForumPostLike';
 import { clusterByTeam } from './utils/clusterByTeam';
 import { selectTopStories, TOP_STORIES_MIN_CORPUS } from './utils/selectTopStories';
+import { injectFeedSignals } from './utils/injectFeedSignals';
 import { assertNever, feedEntryKey, mergeFeedEntries } from './utils/mergeFeedEntries';
 import { categoryIncludesForumPosts, filterFeedForumPosts } from './utils/matchesFeedForumPost';
 import { useStoryReveal } from './hooks/useStoryReveal';
 import { useNewsDeepLink } from './hooks/useNewsDeepLink';
 import { useFeedSocial } from './hooks/useFeedSocial';
+import { useFeedHiring } from './hooks/useFeedHiring';
+import { useFeedDeals } from './hooks/useFeedDeals';
 import { useForumPostDeepLink } from './hooks/useForumPostDeepLink';
 
 import { NewsDetailModal } from './components/NewsDetailModal';
@@ -54,6 +57,8 @@ import { ForumPostModal } from './components/ForumPostModal/ForumPostModal';
 
 import { NewsGroupCard } from './components/NewsGroupCard';
 import { TopStoriesBlock, type TopStorySlot } from './components/TopStories';
+import { HiringCard } from './components/HiringCard/HiringCard';
+import { DealCardCompact } from './components/DealCardCompact/DealCardCompact';
 import { ForumPostCard } from './components/ForumPostCard/ForumPostCard';
 import { NewsBase } from './components/NewsBase';
 import { NewsRail } from './components/NewsRail';
@@ -197,6 +202,12 @@ export const TeamNews = ({
 
   const [sort, setSort] = useState<TeamNewsSort>('popular');
 
+  // Both are client-side and non-blocking: the feed renders without them and
+  // the cards pop in, the same arrival forum posts already have. `undefined`
+  // (not loaded / no deals access / request failed) leaves the feed untouched.
+  const { hiring: feedHiring } = useFeedHiring();
+  const { deals: feedDeals } = useFeedDeals();
+
   const itemsForActiveTab = useMemo(() => {
     if (activeTab === ALL_TAB) return allItems;
     const group = groups.find((g) => g.focusArea.title === activeTab);
@@ -300,7 +311,7 @@ export const TeamNews = ({
   // byte-identical to the pre-feature feed) and ranks posts by their frozen
   // query-data likeCount — the live postLikeOverlay is applied at render only,
   // so likes never reorder anything.
-  const entries = useMemo(
+  const rankedEntries = useMemo(
     () =>
       mergeFeedEntries({
         sortedClusters,
@@ -310,6 +321,22 @@ export const TeamNews = ({
         upvoteCounts: initialUpvoteCounts,
       }),
     [sortedClusters, visibleForumPosts, sort, initialFollowedTeamUids, initialUpvoteCounts],
+  );
+
+  // Hiring roll-ups and deals are slotted in AFTER the ranked merge, never
+  // through it: they carry no popularity signal, so ranking them would mean
+  // inventing one — and under 'popular' (the default) an honest zero would sink
+  // them past pageSize forever. See injectFeedSignals for the full rationale.
+  //
+  // Both are unfiltered by tab/category/search on purpose: neither carries a
+  // focus area or an event type, so every narrowed view drops them. That falls
+  // out of `isNarrowedView` below rather than being re-derived per stream.
+  const entries = useMemo(
+    () =>
+      isNarrowedView
+        ? rankedEntries
+        : injectFeedSignals({ entries: rankedEntries, hiring: feedHiring, deals: feedDeals }),
+    [rankedEntries, isNarrowedView, feedHiring, feedDeals],
   );
 
   const visibleEntries = expanded ? entries : entries.slice(0, pageSize);
@@ -837,6 +864,27 @@ export const TeamNews = ({
                           position={index}
                           onOpenDetail={handleForumPostOpen}
                           onLikeToggle={handleForumPostLikeToggle}
+                        />
+                      );
+                    case 'hiring':
+                      return (
+                        <HiringCard
+                          key={key}
+                          group={entry.group}
+                          isFollowing={followedTeamUids.has(entry.group.team.uid)}
+                          onFollowToggle={handleFollowToggle}
+                          onRoleClick={(group, role, rolePosition) =>
+                            analytics.onFeedHiringRoleClicked(group, role, rolePosition, index)
+                          }
+                          onViewAllClick={(group) => analytics.onFeedHiringViewAllClicked(group, index)}
+                        />
+                      );
+                    case 'deal':
+                      return (
+                        <DealCardCompact
+                          key={key}
+                          deal={entry.deal}
+                          onClick={(deal) => analytics.onFeedDealClicked(deal, index)}
                         />
                       );
                     default:

--- a/components/page/home/TeamNews/components/DealCardCompact/DealCardCompact.module.scss
+++ b/components/page/home/TeamNews/components/DealCardCompact/DealCardCompact.module.scss
@@ -1,0 +1,83 @@
+@import '../../../../../../styles/media';
+
+// Shell is production NewsCard's `.card` so the deal sits in the column as a
+// peer of a news card; the anatomy inside is production DealCard's. Only the
+// three scale deltas and the feed-native footer live here.
+.card {
+  text-decoration: none;
+  color: inherit;
+
+  &:hover .title {
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}
+
+.content {
+  gap: 16px;
+  flex-wrap: nowrap;
+}
+
+// 48px, not the deals page's 64px — still larger than a news logo's 32px, so
+// the card reads as its own kind of object without dominating the column.
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+
+  @include mobile-only {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+// 18px, not the deals page's 24px: level with the feed's own headline scale.
+.title {
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.3px;
+  transition: color 0.12s ease;
+
+  @include mobile-only {
+    font-size: 17px;
+    line-height: 24px;
+  }
+}
+
+.kindBadge {
+  flex-shrink: 0;
+  background: rgba(27, 77, 255, 0.08);
+  color: var(--foreground-brand-primary, #1b4dff);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+// The deals page sets chips at 14px against a 24px title; against an 18px one
+// they compete with the subtitle.
+.tag {
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.foot {
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}

--- a/components/page/home/TeamNews/components/DealCardCompact/DealCardCompact.tsx
+++ b/components/page/home/TeamNews/components/DealCardCompact/DealCardCompact.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import clsx from 'clsx';
+
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { Badge } from '@/components/common/Badge';
+import { DEAL_AUDIENCE_LABELS, DEAL_CATEGORY_LABELS } from '@/services/deals/constants';
+import type { TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import type { IDeal } from '@/types/deals.types';
+
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+import dealStyles from '@/components/page/deals/DealCard/DealCard.module.scss';
+import s from './DealCardCompact.module.scss';
+
+interface DealCardCompactProps {
+  deal: IDeal;
+  onClick?: (deal: IDeal) => void;
+  analyticsSource?: TeamNewsAnalyticsSource;
+}
+
+/**
+ * A deal as an *announcement*, at feed scale.
+ *
+ * Anatomy is production `DealCard`'s — avatar / details / title / subtitle /
+ * tags, same classes — adapted to the feed on three axes only:
+ *   - the vendor name drops from 24px to the feed's 18px headline scale, so it
+ *     sits level with news rather than out-shouting it;
+ *   - the avatar drops from 64px to 48px, still larger than a news logo so the
+ *     card reads as its own kind of object;
+ *   - `teamsUsingCount` is not shown — adoption is a browsing signal on /deals,
+ *     and in a dated stream it says nothing about why this is here now.
+ *
+ * The whole card is a link, exactly as `DealCard` is.
+ *
+ * No eligibility gate line: access is all-or-nothing per member
+ * (`useDealsAccess`), and `useFeedDeals` doesn't fetch at all without it — so a
+ * card that reaches the feed is one this reader can act on. The prototype's
+ * per-deal "Restricted to <audience>" copy has no production data source.
+ */
+export function DealCardCompact({ deal, onClick, analyticsSource = 'home' }: DealCardCompactProps) {
+  return (
+    <a
+      href={`/deals/${deal.uid}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={clsx(newsCardStyles.card, s.card)}
+      data-analytics-source={analyticsSource}
+      onClick={() => onClick?.(deal)}
+    >
+      <div className={clsx(dealStyles.content, s.content)}>
+        <span className={clsx(dealStyles.avatar, s.avatar)}>
+          {deal.logoUrl ? (
+            <img className={dealStyles.avatarImg} src={deal.logoUrl} alt="" loading="lazy" />
+          ) : (
+            <span className={dealStyles.avatarPlaceholder}>{deal.vendorName.charAt(0)}</span>
+          )}
+        </span>
+
+        <div className={clsx(dealStyles.details, s.details)}>
+          <div className={dealStyles.description}>
+            <div className={s.titleRow}>
+              <h3 className={clsx(dealStyles.title, s.title)}>{deal.vendorName}</h3>
+              {/* The kind of object, at the top where the eye lands — a deal in
+                  a news column has to announce itself as one. */}
+              <Badge className={s.kindBadge} noBorder>
+                Deal
+              </Badge>
+            </div>
+            <p className={dealStyles.subtitle}>{deal.shortDescription}</p>
+          </div>
+
+          {/* Dev's two chips, same classes: category neutral, audience brand. */}
+          <div className={dealStyles.tags}>
+            {deal.category && (
+              <span className={clsx(dealStyles.tag, dealStyles.tagDefault, s.tag)}>
+                {DEAL_CATEGORY_LABELS[deal.category] || deal.category}
+              </span>
+            )}
+            {deal.audience && (
+              <span className={clsx(dealStyles.tag, dealStyles.tagBrand, s.tag)}>
+                {DEAL_AUDIENCE_LABELS[deal.audience] || deal.audience}
+              </span>
+            )}
+          </div>
+
+          {/* Why it is in a dated stream, and when — the only feed-native line. */}
+          <div className={s.foot}>Added {formatTimeAgo(deal.createdAt)}</div>
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/components/page/home/TeamNews/components/HiringCard/HiringCard.module.scss
+++ b/components/page/home/TeamNews/components/HiringCard/HiringCard.module.scss
@@ -1,0 +1,124 @@
+@import '../../../../../../styles/media';
+
+// The card shell is production NewsCard's `.card`, applied alongside this
+// class — a hiring signal sits in the column as a peer of a news card, not as
+// a foreign object. Only the deltas live here.
+.card {
+  // NewsCard's own cursor is `pointer` because the whole card is a click
+  // target. This one has no card-level click: the headline, the role rows and
+  // the expander each go somewhere different.
+  cursor: default;
+  gap: 12px;
+}
+
+// Brand-tinted rather than the default grey: it names the kind of object, and
+// at 12px next to a team name the default reads as a disabled chip.
+.kindBadge {
+  flex-shrink: 0;
+  background: rgba(27, 77, 255, 0.08);
+  color: var(--foreground-brand-primary, #1b4dff);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.headline {
+  margin: 0;
+}
+
+.headlineLink {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--foreground-brand-primary, #1b4dff);
+  }
+}
+
+.roleList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.roleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 8px;
+  margin: 0 -8px;
+  border-radius: 6px;
+
+  &:hover {
+    background: rgba(27, 56, 96, 0.04);
+  }
+}
+
+.roleTitle,
+.roleTitleLink {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-primary, #0a0c11);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roleTitleLink {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.roleRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.roleLocation {
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  white-space: nowrap;
+
+  @include mobile-only {
+    // The arrow is the affordance; on a narrow card the location is what gives.
+    display: none;
+  }
+}
+
+.roleArrow {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+// Production Job Board's expander treatment, left-aligned here: the board
+// centres it under a full-width group card, but in a feed column a centred
+// link reads as a section footer rather than as this card's own control.
+.expander {
+  align-self: flex-start;
+  color: var(--foreground-brand-primary, #1b4dff);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/components/page/home/TeamNews/components/HiringCard/HiringCard.tsx
+++ b/components/page/home/TeamNews/components/HiringCard/HiringCard.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import clsx from 'clsx';
+
+import { formatTimeAgo } from '@/utils/formatTimeAgo';
+import { useCurrentUserStore } from '@/services/auth/store';
+import { useRouter } from 'next/navigation';
+import { Badge } from '@/components/common/Badge';
+import { FollowButton } from '@/components/ui/FollowButton';
+import { JOB_QUERY_PARAMS } from '@/components/page/jobs/TeamGroupCard/component/ReferRoleRow/constants';
+import { ArrowIcon } from '@/components/page/jobs/TeamGroupCard/component/ReferRoleRow/components/Icons';
+import type { TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
+import type { IJobRole, IJobTeamGroup } from '@/types/jobs.types';
+
+import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
+import { hiringGroupDate } from '../../utils/injectFeedSignals';
+
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+import s from './HiringCard.module.scss';
+
+/** Roles named on the card; the rest roll into the expander. */
+const VISIBLE_ROLES = 3;
+
+interface HiringCardProps {
+  group: IJobTeamGroup;
+  isFollowing: boolean;
+  onFollowToggle: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
+  onRoleClick?: (group: IJobTeamGroup, role: IJobRole, position: number) => void;
+  onViewAllClick?: (group: IJobTeamGroup) => void;
+  analyticsSource?: TeamNewsAnalyticsSource;
+}
+
+/**
+ * Hiring as a *signal*, not a listing.
+ *
+ * Pasting job rows into a news feed mixes two reading modes — news is scanned,
+ * jobs are searched — and /jobs already does the second one well. What belongs
+ * in a feed is the derived fact: this team's hiring moved. One roll-up per team;
+ * the click-through hands off to /jobs rather than reproducing it.
+ *
+ * The prototype's trend line ("First open roles in 8 months") is deliberately
+ * absent: a 14-day window cannot see eight months of history, so there is
+ * nothing to derive it from. The footer states only what the window knows.
+ */
+export function HiringCard({
+  group,
+  isFollowing,
+  onFollowToggle,
+  onRoleClick,
+  onViewAllClick,
+  analyticsSource = 'home',
+}: HiringCardProps) {
+  const router = useRouter();
+  const { currentUser, isHydrated } = useCurrentUserStore();
+
+  const { team, totalRoles, roles } = group;
+  const visibleRoles = roles.slice(0, VISIBLE_ROLES);
+  const hiddenCount = totalRoles - visibleRoles.length;
+  const teamJobsUrl = `/jobs?team=${team.uid}`;
+
+  const handleFollowClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!currentUser) {
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
+      return;
+    }
+    onFollowToggle(team.uid, team.name, isFollowing);
+  };
+
+  return (
+    <div className={clsx(newsCardStyles.card, s.card)}>
+      <div className={newsCardStyles.head}>
+        {team.logoUrl ? (
+          <img className={newsCardStyles.logo} src={team.logoUrl} alt="" loading="lazy" />
+        ) : (
+          <div className={newsCardStyles.logoFallback}>{getTeamLogoFallback(team.name)}</div>
+        )}
+        <a href={`/teams/${team.uid}`} target="_blank" rel="noopener noreferrer" className={newsCardStyles.teamName}>
+          {team.name}
+        </a>
+        {/* The kind of object, at the top where the eye lands — not in the
+            footer, where news puts its event type and where the card has
+            already been read as news by the time you get there. */}
+        <Badge className={s.kindBadge} noBorder>
+          Hiring
+        </Badge>
+        {isHydrated && (
+          <FollowButton following={isFollowing} onClick={handleFollowClick} name={team.name} size="compact" />
+        )}
+      </div>
+
+      <h3 className={clsx(newsCardStyles.headline, s.headline)}>
+        <a href={teamJobsUrl} target="_blank" rel="noopener noreferrer" className={s.headlineLink}>
+          {team.name} is hiring
+        </a>
+      </h3>
+
+      {/* Each role links to its own posting — production's actionable unit too
+          (ReferRoleRow makes the title an anchor to applyUrl + JOB_QUERY_PARAMS).
+          Reusing the query params keeps a click from the feed attributed
+          exactly like a click from the board. */}
+      <ul className={s.roleList}>
+        {visibleRoles.map((role, index) => {
+          const location = role.location.filter(Boolean).join(', ');
+          return (
+            <li key={role.uid} className={s.roleRow}>
+              {/* A role can come back without an apply link. Plain text then —
+                  never an anchor with nowhere to go. */}
+              {role.applyUrl ? (
+                <a
+                  href={`${role.applyUrl}?${JOB_QUERY_PARAMS}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={s.roleTitleLink}
+                  onClick={() => onRoleClick?.(group, role, index)}
+                >
+                  {role.roleTitle}
+                </a>
+              ) : (
+                <span className={s.roleTitle}>{role.roleTitle}</span>
+              )}
+              <span className={s.roleRight}>
+                {location && <span className={s.roleLocation}>{location}</span>}
+                <span className={s.roleArrow} aria-hidden>
+                  <ArrowIcon />
+                </span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+
+      {hiddenCount > 0 && (
+        <a
+          href={teamJobsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={s.expander}
+          onClick={() => onViewAllClick?.(group)}
+        >
+          View all {totalRoles} open roles at {team.name}
+        </a>
+      )}
+
+      <div className={newsCardStyles.metaLine}>
+        <div className={newsCardStyles.meta}>
+          <span className={newsCardStyles.time}>
+            {totalRoles} open {totalRoles === 1 ? 'role' : 'roles'}
+          </span>
+          <span className={newsCardStyles.sep} aria-hidden="true" />
+          <span className={newsCardStyles.time}>{formatTimeAgo(hiringGroupDate(group))}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/page/home/TeamNews/hooks/useFeedDeals.ts
+++ b/components/page/home/TeamNews/hooks/useFeedDeals.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getRecentDeals } from '@/services/deals/deals.service';
+import { DealsQueryKeys } from '@/services/deals/constants';
+import { useDealsAccess } from '@/services/deals/hooks/useDealsAccess';
+import { TEAM_NEWS_DEFAULT_WINDOW_DAYS } from '@/services/team-news/constants';
+import type { IDeal } from '@/types/deals.types';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Exported for the test: the window is applied here, not trusted from the API. */
+export function isWithinWindow(createdAt: string, windowDays: number, now: number): boolean {
+  const created = Date.parse(createdAt);
+  // An unparseable date can't be shown to be recent, so it isn't.
+  if (Number.isNaN(created)) return false;
+  return now - created <= windowDays * MS_PER_DAY;
+}
+
+/**
+ * Deals added inside the news window, for the feed's deal cards.
+ *
+ * Gated on `useDealsAccess()` — which already combines the whitelist endpoint
+ * and the `deals.read` permission — so a member without access makes **no
+ * request at all** rather than fetching and hiding the result. Production
+ * already ships a `DealsNoAccessModal`; putting cards in a general feed that
+ * lead straight to it is the thing to avoid.
+ *
+ * The `createdAt` filter is deliberate belt-and-braces: `?windowDays=` may or
+ * may not be implemented yet, and the Directory API ignores params it doesn't
+ * know. Filtering here makes the window correct either way, and a no-op once
+ * the backend honours it.
+ *
+ * Client-side and non-blocking, like useFeedHiring — `undefined` means "not
+ * loaded / no access / failed", which injectFeedSignals leaves the feed alone for.
+ */
+export function useFeedDeals(): { deals: IDeal[] | undefined } {
+  const { hasAccess } = useDealsAccess();
+
+  const { data } = useQuery({
+    queryKey: [DealsQueryKeys.DEALS_LIST, 'home-feed', TEAM_NEWS_DEFAULT_WINDOW_DAYS],
+    queryFn: () => getRecentDeals(TEAM_NEWS_DEFAULT_WINDOW_DAYS),
+    enabled: hasAccess,
+    staleTime: 5 * 60 * 1000,
+    // Date.now() in `select` rather than at module scope: the latter would pin
+    // the window to whenever the bundle first evaluated.
+    select: (deals: IDeal[]) => {
+      const now = Date.now();
+      return deals.filter((deal) => isWithinWindow(deal.createdAt, TEAM_NEWS_DEFAULT_WINDOW_DAYS, now));
+    },
+  });
+
+  // Same contract guard as useFeedHiring: an unexpected response shape must
+  // degrade to "no deal cards", never throw inside the feed's merge.
+  return { deals: hasAccess && Array.isArray(data) ? data : undefined };
+}

--- a/components/page/home/TeamNews/hooks/useFeedHiring.ts
+++ b/components/page/home/TeamNews/hooks/useFeedHiring.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchJobsList } from '@/services/jobs/jobs.service';
+import { JobsQueryKey } from '@/services/jobs/constants';
+import { TEAM_NEWS_DEFAULT_WINDOW_DAYS } from '@/services/team-news/constants';
+import type { IJobTeamGroup } from '@/types/jobs.types';
+
+/** Groups requested. injectFeedSignals shows at most MAX_HIRING_ENTRIES of
+ *  them; the surplus is headroom for the recency sort to choose from. */
+const FEED_HIRING_LIMIT = 10;
+
+/**
+ * Teams hiring inside the news window, for the feed's hiring roll-ups.
+ *
+ * No grouping pass: `GET /v1/job-openings` already returns
+ * `IJobTeamGroup { team, totalRoles, roles[] }`, which is exactly the shape the
+ * card renders. `windowDays` reaches the backend untouched — the Next proxy at
+ * `/api/jobs/list` copies every param except `workplaceType`
+ * (utils/jobs-api-query.ts).
+ *
+ * Client-side and non-blocking: the feed renders without it and the cards pop
+ * in, the same accepted arrival forum posts already have. A failure resolves to
+ * `undefined`, which injectFeedSignals reads as "leave the feed alone".
+ */
+export function useFeedHiring(): { hiring: IJobTeamGroup[] | undefined } {
+  const { data } = useQuery({
+    queryKey: [JobsQueryKey.List, 'home-feed', TEAM_NEWS_DEFAULT_WINDOW_DAYS],
+    queryFn: () =>
+      fetchJobsList(
+        new URLSearchParams({
+          windowDays: String(TEAM_NEWS_DEFAULT_WINDOW_DAYS),
+          limit: String(FEED_HIRING_LIMIT),
+        }),
+      ),
+    staleTime: 5 * 60 * 1000,
+    select: (response) => response.groups,
+  });
+
+  // The declared return type is a promise this hook has to keep: `groups` is
+  // whatever the response carried, and a shape change upstream must degrade to
+  // "no hiring cards" rather than throw inside the feed's merge.
+  return { hiring: Array.isArray(data) ? data : undefined };
+}

--- a/components/page/home/TeamNews/utils/injectFeedSignals.ts
+++ b/components/page/home/TeamNews/utils/injectFeedSignals.ts
@@ -1,0 +1,110 @@
+import type { IDeal } from '@/types/deals.types';
+import type { IJobTeamGroup } from '@/types/jobs.types';
+
+import type { FeedEntry, RankedFeedEntry } from './mergeFeedEntries';
+
+/** Hiring roll-ups per render. Uncapped, a busy window puts more job cards on
+ *  the first page than news. */
+export const MAX_HIRING_ENTRIES = 2;
+export const MAX_DEAL_ENTRIES = 2;
+
+/** Ranked entries between one supporting card and the next. With the default
+ *  pageSize of 6 the first page reads: three stories, a signal, two stories. */
+export const SUPPORTING_CADENCE = 3;
+
+/** Most recent activity on a team's roles — `postedDate` when the board has it,
+ *  `lastUpdated` (always present) otherwise. */
+export function hiringGroupDate(group: IJobTeamGroup): string {
+  return group.roles.reduce((max, role) => {
+    const d = role.postedDate ?? role.lastUpdated;
+    return d > max ? d : max;
+  }, '');
+}
+
+/**
+ * Slots hiring roll-ups and deals into an already-merged feed.
+ *
+ * ## Why this is a separate pass, not part of mergeFeedEntries
+ *
+ * That function's contract is "news-vs-news order is byte-identical to the
+ * pre-feature feed under every sort mode", and it earns that by delegating to
+ * sortTeamNewsClusters rather than re-sorting. Folding a second concern into it
+ * would put that guarantee at risk on every future edit. Kept separate, this
+ * pass is independently testable, independently revertable, and structurally
+ * incapable of reordering news.
+ *
+ * ## Why slotted, not ranked
+ *
+ * Forum posts are ranked into the feed because they carry the currency of the
+ * mode they join — a likeCount under 'popular', a createdAt under 'latest'.
+ * Hiring roll-ups and deals carry neither. Ranking them would mean inventing a
+ * popularity signal they don't have, and 'popular' is the DEFAULT sort — under
+ * an honest zero they would sink past `pageSize` and never be seen at all.
+ *
+ * So they are placed at a fixed cadence instead: one supporting card after
+ * every `SUPPORTING_CADENCE` ranked entries, alternating hiring → deal so
+ * neither kind clusters at the top. The placement is identical under all three
+ * sorts, which also means changing the sort never shuffles them around.
+ *
+ * ## A story always leads
+ *
+ * Hiring and deals are the freshest things most weeks. The cadence starts
+ * counting from the top of the feed, so the first supporting card can never
+ * appear before `SUPPORTING_CADENCE` stories — an investor opening the page to
+ * a wall of job roll-ups and vendor perks reads it as a job board with ads.
+ * With no ranked entries at all this returns them unchanged: the feed's own
+ * empty state is the honest answer, not a page of nothing but jobs.
+ *
+ * `hiring`/`deals` undefined ⇒ the entries unchanged. That is the typed shape
+ * of "not loaded / no access / request failed", the same accepted pop-in
+ * `forumPosts` already has in mergeFeedEntries.
+ */
+export function injectFeedSignals({
+  entries,
+  hiring,
+  deals,
+}: {
+  entries: RankedFeedEntry[];
+  hiring: IJobTeamGroup[] | undefined;
+  deals: IDeal[] | undefined;
+}): FeedEntry[] {
+  // Nothing to lead with — see "A story always leads" above.
+  if (entries.length === 0) return entries;
+
+  const hiringEntries: FeedEntry[] = [...(hiring ?? [])]
+    .sort((a, b) => hiringGroupDate(b).localeCompare(hiringGroupDate(a)))
+    .slice(0, MAX_HIRING_ENTRIES)
+    .map((group) => ({ kind: 'hiring', group }));
+
+  const dealEntries: FeedEntry[] = [...(deals ?? [])]
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .slice(0, MAX_DEAL_ENTRIES)
+    .map((deal) => ({ kind: 'deal', deal }));
+
+  // Alternate rather than concatenate: two hiring cards back to back at the
+  // first two slots would read as a hiring section that news happens to follow.
+  const supporting: FeedEntry[] = [];
+  for (let i = 0; i < Math.max(hiringEntries.length, dealEntries.length); i++) {
+    if (hiringEntries[i]) supporting.push(hiringEntries[i]);
+    if (dealEntries[i]) supporting.push(dealEntries[i]);
+  }
+  if (supporting.length === 0) return entries;
+
+  const out: FeedEntry[] = [];
+  let next = 0;
+  let sinceLastSignal = 0;
+
+  for (const entry of entries) {
+    out.push(entry);
+    sinceLastSignal++;
+    if (sinceLastSignal >= SUPPORTING_CADENCE && next < supporting.length) {
+      out.push(supporting[next++]);
+      sinceLastSignal = 0;
+    }
+  }
+
+  // A feed shorter than the cadence still gets its signals, just at the end
+  // rather than dropped — they were fetched, and the reader can act on them.
+  out.push(...supporting.slice(next));
+  return out;
+}

--- a/components/page/home/TeamNews/utils/mergeFeedEntries.ts
+++ b/components/page/home/TeamNews/utils/mergeFeedEntries.ts
@@ -1,10 +1,30 @@
 import type { TeamCluster } from '@/types/team-news.types';
 import type { IFeedForumPost } from '@/types/feed.types';
+import type { IJobTeamGroup } from '@/types/jobs.types';
+import type { IDeal } from '@/types/deals.types';
 import type { TeamNewsSort } from './sortTeamNewsClusters';
 
 // Client-derived view shape (like TeamCluster, unlike the I-prefixed wire types
 // in types/feed.types.ts) — lives here with the merge that produces it.
-export type FeedEntry = { kind: 'news'; cluster: TeamCluster } | { kind: 'forum'; post: IFeedForumPost };
+//
+// 'news' and 'forum' are the RANKED kinds: they carry both a date and a like
+// count, so mergeFeedEntries below can order them against each other under
+// every sort mode. 'hiring' and 'deal' are supporting kinds with no popularity
+// signal at all — they are never ranked, only slotted, which is why they enter
+// through injectFeedSignals as a separate pass and not through this file's
+// merge. See that file's docblock for why that distinction matters.
+export type FeedEntry =
+  | { kind: 'news'; cluster: TeamCluster }
+  | { kind: 'forum'; post: IFeedForumPost }
+  | { kind: 'hiring'; group: IJobTeamGroup }
+  | { kind: 'deal'; deal: IDeal };
+
+/** The kinds this file ranks. Everything else is slotted in afterwards. */
+export type RankedFeedEntry = Extract<FeedEntry, { kind: 'news' } | { kind: 'forum' }>;
+
+export function isRankedEntry(entry: FeedEntry): entry is RankedFeedEntry {
+  return entry.kind === 'news' || entry.kind === 'forum';
+}
 
 export function assertNever(x: never): never {
   throw new Error(`Unexpected feed entry kind: ${JSON.stringify(x)}`);
@@ -18,6 +38,10 @@ export function feedEntryKey(entry: FeedEntry): string {
       return `news:${entry.cluster.teamUid}`;
     case 'forum':
       return `forum:${entry.post.uid}`;
+    case 'hiring':
+      return `hiring:${entry.group.team.uid}`;
+    case 'deal':
+      return `deal:${entry.deal.uid}`;
     default:
       return assertNever(entry);
   }
@@ -65,8 +89,8 @@ export function mergeFeedEntries({
   sort: TeamNewsSort;
   followedTeamUids: ReadonlySet<string>;
   upvoteCounts: ReadonlyMap<string, number>;
-}): FeedEntry[] {
-  const newsEntries: FeedEntry[] = sortedClusters.map((cluster) => ({ kind: 'news', cluster }));
+}): RankedFeedEntry[] {
+  const newsEntries: RankedFeedEntry[] = sortedClusters.map((cluster) => ({ kind: 'news', cluster }));
   if (!forumPosts || forumPosts.length === 0) return newsEntries;
 
   // A post outranks a cluster when the cluster ranks strictly below it — ties
@@ -81,7 +105,7 @@ export function mergeFeedEntries({
     sort === 'popular' ? b.likeCount - a.likeCount : b.createdAt.localeCompare(a.createdAt),
   );
 
-  const merged: FeedEntry[] = [];
+  const merged: RankedFeedEntry[] = [];
   let postIndex = 0;
   for (const cluster of sortedClusters) {
     const clusterIsFollowed = sort === 'following' && followedTeamUids.has(cluster.teamUid);

--- a/services/deals/deals.service.ts
+++ b/services/deals/deals.service.ts
@@ -23,6 +23,24 @@ export async function getAllDeals(): Promise<IDeal[]> {
   return response.json();
 }
 
+/**
+ * Deals added or changed in the last `windowDays` — the home feed's slice.
+ *
+ * The param is safe to send whether or not the backend implements it: the
+ * Directory API ignores query params it doesn't know (verified against dev),
+ * and `useFeedDeals` re-filters on `createdAt` client-side regardless. So this
+ * is correct while the backend catches up and a no-op afterwards.
+ */
+export async function getRecentDeals(windowDays: number): Promise<IDeal[]> {
+  const response = await customFetch(`${DEALS_API_URL}?windowDays=${windowDays}`, { method: 'GET' }, true);
+
+  if (!response || !response.ok) {
+    throw new Error('Failed to fetch recent deals');
+  }
+
+  return response.json();
+}
+
 export async function getDealById(uid: string): Promise<IDeal | null> {
   const response = await customFetch(`${DEALS_API_URL}/${uid}`, { method: 'GET' }, true);
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -613,6 +613,11 @@ export const TEAM_NEWS_ANALYTICS_EVENTS = {
   // without it a low click count can't be told apart from a block nobody saw.
   TEAM_NEWS_TOP_STORIES_BLOCK_VIEWED: 'team-news-top-stories-block-viewed',
   TEAM_NEWS_TOP_STORY_CLICKED: 'team-news-top-story-clicked',
+  // Supporting kinds in the feed. Both carry `position` so a card that only
+  // ever converts from the first slot can be told from one that converts anywhere.
+  TEAM_NEWS_FEED_HIRING_ROLE_CLICKED: 'team-news-feed-hiring-role-clicked',
+  TEAM_NEWS_FEED_HIRING_VIEW_ALL_CLICKED: 'team-news-feed-hiring-view-all-clicked',
+  TEAM_NEWS_FEED_DEAL_CLICKED: 'team-news-feed-deal-clicked',
   // Feed social layer (forum posts in the feed + feed-only comments).
   TEAM_NEWS_FEED_FORUM_POST_CARD_CLICKED: 'team-news-feed-forum-post-card-clicked',
   TEAM_NEWS_FEED_FORUM_POST_MODAL_OPENED: 'team-news-feed-forum-post-modal-opened',


### PR DESCRIPTION
> **Stacked on #2751.** Base is `feat/newsfeed-top-stories-block`, so this diff shows only Phase 2. Retarget to `develop` once #2751 merges.

## Summary

Phase 2 of the newsfeed redesign. Two new `FeedEntry` kinds join the news/forum stream: a per-team hiring roll-up and a compact deal card.

Prototype: `prototypes/entries/newsfeed/` (`HiringCard.tsx`, `PerkCard.tsx`).

## A separate pass, not an extension of the merge

Both kinds enter through `injectFeedSignals`, which runs **after** `mergeFeedEntries` rather than inside it.

That function's contract is *"news-vs-news order is byte-identical to the pre-feature feed under every sort mode"*, and it earns that by delegating to `sortTeamNewsClusters` instead of re-sorting. Folding a second concern into it would put that guarantee at risk on every future edit. Kept separate, this pass is structurally incapable of reordering news, and is independently testable and revertable.

`mergeFeedEntries` now returns `RankedFeedEntry[]` — the type system records which kinds it orders and which it doesn't.

## Slotted, not ranked — a change from the plan

The plan called for ordering hiring and deals **by date among** the ranked entries. That isn't coherent, and this is the one design decision that moved during implementation.

Forum posts are ranked in because they carry the currency of the mode they join — a `likeCount` under `popular`, a `createdAt` under `latest`. Hiring roll-ups and deals carry **neither**. Ordering them by date under `popular` would sort one part of the list by a key the rest isn't sorted by; ranking them by likes would mean inventing a signal they don't have. And since `popular` is the **default** sort, an honest zero would sink them past `pageSize` and they'd never be seen at all.

So they're placed at a fixed cadence instead: one supporting card after every three ranked entries, alternating hiring → deal so neither kind clusters. Placement is identical under all three sorts, so changing the sort never shuffles them. Date ordering still decides *which* cards survive the per-kind cap (2 each) — just not where they land.

**A story always leads.** The cadence counts from the top, so no signal can appear before three stories — an investor opening to a wall of job roll-ups and vendor perks reads the page as a job board with ads. With no ranked entries at all, the signals are dropped entirely: the feed's own empty state is the honest answer, not a page of nothing but jobs.

Both kinds are also dropped on any narrowed view, falling out of the same `isNarrowedView` flag the top-stories band uses — neither carries a focus area or an event type, so every filter would drop them anyway.

## Backend

`windowDays` verified live on dev through the app's own proxy: **28 groups** unfiltered → **7** at `windowDays=14` → **2** at `windowDays=1`.

No client-side grouping for hiring — `GET /v1/job-openings` already returns `IJobTeamGroup { team, totalRoles, roles[] }`, exactly what the card renders. The param reaches the backend untouched through the existing Next proxy (`utils/jobs-api-query.ts` copies everything except `workplaceType`).

For deals, `getRecentDeals` sends `?windowDays=` **and** `useFeedDeals` re-filters on `createdAt`. That makes the window correct whether or not the backend implements the param — I confirmed the API ignores query params it doesn't know, so sending it is safe either way, and the filter becomes a no-op once the backend honours it.

## Deals gating

`useFeedDeals` is `enabled: hasAccess` off `useDealsAccess()`, which already combines the whitelist endpoint and the `deals.read` permission. A member without access makes **no request at all** rather than fetching and hiding the result — production ships a `DealsNoAccessModal`, and putting cards in a general feed that lead straight to it is the thing to avoid.

Verified in the browser: `performance.getEntriesByType('resource')` shows zero deals requests for a no-access viewer.

## Dropped from the prototype

- **The hiring trend line** ("First open roles in 8 months") — a 14-day window cannot see eight months of history, so there is nothing to derive it from. The footer states only what the window knows: `N open roles · <time ago>`.
- **`PerkCard`'s per-deal eligibility gate** ("Restricted to All Founders") — access is all-or-nothing per member, so a card that reaches the feed is one the reader can act on. There's no per-deal audience eligibility to render.
- **`PerkCard`'s `offFeed` verdict copy** — prototype-only exhibit for the Deals pill.

## Notable details

- Both hooks guard their own return contract with `Array.isArray`. They declare `T[] | undefined` but were handing back whatever the response carried; the guard makes the declared type true, so an upstream shape change degrades to "no cards" instead of throwing inside the feed's merge.
- A role with `applyUrl: null` renders as plain text, never an anchor with nowhere to go. `location: []` renders nothing rather than an empty string.
- Role links carry `JOB_QUERY_PARAMS`, so a click from the feed is attributed exactly like a click from the board.
- Card shells reuse production `NewsCard.module.scss`; the deal card's anatomy is production `DealCard`'s classes, adapted on three axes only (title 24px → 18px, avatar 64px → 48px, `teamsUsingCount` hidden — adoption is a browsing signal on /deals and says nothing about why a card is here *now*).
- New analytics: `team-news-feed-hiring-role-clicked`, `team-news-feed-hiring-view-all-clicked`, `team-news-feed-deal-clicked`, each carrying feed `position`.

## Testing

- 14 new unit tests for `injectFeedSignals`: caps, alternation, story-leads rule, order preservation, most-recent selection over the cap, leftovers when the feed is shorter than the cadence, one stream loading without the other, no input mutation.
- 8 new `TeamNews` integration tests: both cards render, no signal leads, attribution params, null `applyUrl`, empty `location`, both kinds dropped under a category pill, feed intact when neither stream loads, click analytics.
- Existing `mergeFeedEntries` tests pass untouched — the guarantee held.
- Full suite: 1399 pass. The one failure (`getCurrentRoundNumber` month boundary) is date-dependent and reproduces on a clean tree.
- `npm run build` compiles; lint clean across every touched file.

Verified live against the dev API: the hiring card lands at feed index 3 — exactly the cadence, three stories leading — rendering QuickNode with the HIRING badge, a role row with locations, and `1 open role · 6h ago` (correct singular, correct relative time).

## Not verified

**The deal card has not been seen rendered against real data.** Anonymous browsing has no deals access, so it is covered by tests only. Worth a look on a deals-enabled account before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
