### PR TITLE
feat(newsfeed): lift rail modules into horizontal rows below desktop

### DIFF
--- a/__tests__/page/home/news-rail.test.tsx
+++ b/__tests__/page/home/news-rail.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { NewsRail } from '@/components/page/home/TeamNews/components/NewsRail/NewsRail';
 
@@ -144,49 +144,45 @@ describe('NewsRail', () => {
     expect(screen.getByRole('button', { name: 'Subscribe' })).toBeInTheDocument();
   });
 
-  it('keeps a followed suggestion visible with Following for 2s, then removes it', () => {
-    jest.useFakeTimers();
+  // The delayed-hide-after-follow behaviour moved into
+  // useDelayedHideFollowedSuggestions when the module gained a second surface;
+  // it has its own test file now. NewsRail just renders the list it is handed.
+  it('renders the suggestions it is given, and drops the modules when renderModules is false', async () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'user-1' }, isHydrated: true });
-    const onFollowToggle = jest.fn();
-    const suggestions = [
+    const visibleSuggestions = [
       { uid: 't1', name: 'Banyan Storage', logo: null, reason: 'Storage · 1.2k followers' },
       { uid: 't2', name: 'Helia Labs', logo: null, reason: 'Infrastructure · 890 followers' },
     ];
 
     const { rerender } = render(
       <NewsRail
-        suggestedTeams={suggestions}
+        visibleSuggestions={visibleSuggestions}
         followedTeamUids={new Set()}
-        onFollowToggle={onFollowToggle}
+        onFollowToggle={jest.fn()}
         onPopularItemClick={mockOnPopularItemClick}
       />,
     );
 
     expect(screen.getByText('Banyan Storage')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /follow banyan storage/i }));
-    expect(onFollowToggle).toHaveBeenCalledWith('t1', 'Banyan Storage', false, 'news-rail', {
-      position: 0,
-      reason: 'Storage',
-    });
+    expect(screen.getByText('Helia Labs')).toBeInTheDocument();
 
+    // Below 1200px TeamNews renders these as scrollers instead — the rail must
+    // not also render them, or both would be on screen at once.
     rerender(
       <NewsRail
-        suggestedTeams={suggestions}
-        followedTeamUids={new Set(['t1'])}
-        onFollowToggle={onFollowToggle}
+        visibleSuggestions={visibleSuggestions}
+        followedTeamUids={new Set()}
+        onFollowToggle={jest.fn()}
         onPopularItemClick={mockOnPopularItemClick}
+        renderModules={false}
       />,
     );
 
-    expect(screen.getByRole('button', { name: /following banyan storage/i })).toBeInTheDocument();
-    expect(screen.getByText('Helia Labs')).toBeInTheDocument();
-
-    act(() => {
-      jest.advanceTimersByTime(2000);
-    });
-
-    expect(screen.queryByText('Banyan Storage')).not.toBeInTheDocument();
-    expect(screen.getByText('Helia Labs')).toBeInTheDocument();
-    jest.useRealTimers();
+    // waitFor, not a bare assertion: AnimatePresence plays the card's exit
+    // animation, so it stays mounted for the duration. That is also the one
+    // window in which both surfaces exist — a resize across 1200px, ~280ms.
+    await waitFor(() => expect(screen.queryByText('Banyan Storage')).not.toBeInTheDocument());
+    // The digest card has no scroller counterpart, so it stays at every width.
+    expect(screen.getByText(/Get network news Digest/i)).toBeInTheDocument();
   });
 });

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -109,6 +109,10 @@ const mockUseFeedHiring = jest.fn((): { hiring: IJobTeamGroup[] | undefined } =>
 jest.mock('@/components/page/home/TeamNews/hooks/useFeedHiring', () => ({
   useFeedHiring: () => mockUseFeedHiring(),
 }));
+const mockUseIsBelowDesktop = jest.fn(() => false);
+jest.mock('@/hooks/useIsBelowDesktop', () => ({
+  useIsBelowDesktop: () => mockUseIsBelowDesktop(),
+}));
 const mockUseFeedDeals = jest.fn((): { deals: IDeal[] | undefined } => ({ deals: undefined }));
 jest.mock('@/components/page/home/TeamNews/hooks/useFeedDeals', () => ({
   useFeedDeals: () => mockUseFeedDeals(),
@@ -206,6 +210,7 @@ describe('TeamNews', () => {
     mockUseFeedSocial.mockReturnValue(feedSocial(undefined, false));
     mockUseFeedHiring.mockReturnValue({ hiring: undefined });
     mockUseFeedDeals.mockReturnValue({ deals: undefined });
+    mockUseIsBelowDesktop.mockReturnValue(false);
     // useNewsDeepLink reads the real jsdom URL on mount — reset it so a
     // ?news= param written by one test can't open the modal in the next.
     window.history.replaceState(null, '', '/home');
@@ -1577,6 +1582,113 @@ describe('TeamNews', () => {
 
       fireEvent.click(screen.getByRole('heading', { name: 'Vendor d1' }));
       expect(mockOnFeedDealClicked).toHaveBeenCalledWith(expect.objectContaining({ uid: 'd1' }), expect.any(Number));
+    });
+  });
+
+  describe('sub-desktop rails', () => {
+    const suggestions = [
+      { uid: 's1', name: 'Banyan Storage', logo: null, reason: 'Storage · 1.2k followers' },
+      { uid: 's2', name: 'Helia Labs', logo: null, reason: 'Infrastructure · 890 followers' },
+    ];
+    const popular = [
+      {
+        uid: 'ai-1',
+        teamUid: 'team-ai-1',
+        teamName: 'Team ai-1',
+        title: 'Headline ai-1',
+        sourceUrl: 'https://example.com/ai-1',
+        upvoteCount: 5,
+      },
+    ];
+
+    const railAside = () => screen.queryByRole('complementary', { name: /sidebar/i });
+    // The rail's own cards are labelled sections too, so a bare role query would
+    // match either surface — scope to the feed column, which is where the
+    // scrollers live.
+    const scroller = (name: string) =>
+      within(document.querySelector('[data-news-feed-root]') as HTMLElement).queryByRole('region', { name });
+
+    beforeEach(() => {
+      mockUseSuggestedTeamsToFollow.mockReturnValue({ suggestions, isLoading: false });
+    });
+
+    it('keeps both modules in the rail at desktop width, with no scrollers', () => {
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+      expect(within(railAside()!).getByText('Banyan Storage')).toBeInTheDocument();
+      expect(within(railAside()!).getByText('Popular this week')).toBeInTheDocument();
+      expect(scroller('Teams to follow')).not.toBeInTheDocument();
+      expect(scroller('Popular this week')).not.toBeInTheDocument();
+    });
+
+    it('lifts both modules into horizontal rows below desktop', () => {
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+      expect(scroller('Teams to follow')).toBeInTheDocument();
+      expect(scroller('Popular this week')).toBeInTheDocument();
+      // The rail is still in the tree for the digest card — it just no longer
+      // carries these two.
+      expect(within(railAside()!).queryByText('Banyan Storage')).not.toBeInTheDocument();
+    });
+
+    it('keeps the digest card in the rail at both widths', () => {
+      const { unmount } = renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+      expect(within(railAside()!).getByText(/Get network news Digest/i)).toBeInTheDocument();
+      unmount();
+
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+      expect(within(railAside()!).getByText(/Get network news Digest/i)).toBeInTheDocument();
+    });
+
+    it('mounts exactly one instance of each module at either width', () => {
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+      expect(screen.getAllByText('Banyan Storage')).toHaveLength(1);
+      expect(screen.getAllByText('Popular this week')).toHaveLength(1);
+    });
+
+    // The events live in TeamNews now precisely so the count doesn't depend on
+    // which surface rendered.
+    it('fires each view event exactly once, on either surface', () => {
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+      expect(mockOnTeamsToFollowViewed).toHaveBeenCalledTimes(1);
+      expect(mockOnPopularCardViewed).toHaveBeenCalledTimes(1);
+
+      jest.clearAllMocks();
+      mockUseSuggestedTeamsToFollow.mockReturnValue({ suggestions, isLoading: false });
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+      expect(mockOnTeamsToFollowViewed).toHaveBeenCalledTimes(1);
+      expect(mockOnPopularCardViewed).toHaveBeenCalledTimes(1);
+    });
+
+    it('follows a team from the scroller with the same payload as the rail row', () => {
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      useCurrentUserStore.setState({ currentUser: { uid: 'user-1' }, isHydrated: true });
+      try {
+        renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+        const row = scroller('Teams to follow')!;
+        fireEvent.click(within(row).getByRole('button', { name: /follow banyan storage/i }));
+
+        expect(mockFollowMutate).toHaveBeenCalled();
+      } finally {
+        useCurrentUserStore.setState({ currentUser: null, isHydrated: false });
+      }
+    });
+
+    it('reveals the story in the feed when a scroller card is tapped', () => {
+      mockUseIsBelowDesktop.mockReturnValue(true);
+      renderTeamNews(<TeamNews groups={groups} popularItems={popular} />);
+
+      const row = scroller('Popular this week')!;
+      fireEvent.click(within(row).getByRole('button', { name: /Headline ai-1/ }));
+
+      expect(mockOnPopularStoryClicked).toHaveBeenCalled();
     });
   });
 

--- a/__tests__/page/home/use-delayed-hide-followed-suggestions.test.tsx
+++ b/__tests__/page/home/use-delayed-hide-followed-suggestions.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDelayedHideFollowedSuggestions } from '@/components/page/home/TeamNews/components/NewsRail/useSuggestionsModule';
+import type { ISuggestedTeam } from '@/types/team-news.types';
+
+const team = (uid: string, name: string): ISuggestedTeam => ({
+  uid,
+  name,
+  logo: null,
+  reason: 'Storage · 1.2k followers',
+});
+
+const names = (result: { current: ISuggestedTeam[] }) => result.current.map((t) => t.name);
+
+// This behaviour used to be verified through NewsRail. It moved into its own
+// hook when the follow module gained a second surface (the sub-desktop
+// scroller) — TeamNews owns the list now so both surfaces share one confirm
+// timer, and testing it here is more direct than through either renderer.
+describe('useDelayedHideFollowedSuggestions', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  const suggestions = [team('t1', 'Banyan Storage'), team('t2', 'Helia Labs')];
+
+  it('keeps a newly followed suggestion visible for the confirm window, then removes it', () => {
+    const { result, rerender } = renderHook(
+      ({ followed }) => useDelayedHideFollowedSuggestions(suggestions, followed),
+      { initialProps: { followed: new Set<string>() } },
+    );
+
+    expect(names(result)).toEqual(['Banyan Storage', 'Helia Labs']);
+
+    rerender({ followed: new Set(['t1']) });
+    expect(names(result)).toEqual(['Banyan Storage', 'Helia Labs']);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(names(result)).toEqual(['Helia Labs']);
+  });
+
+  it('hides a team already followed on first sight, with no confirm flash', () => {
+    const { result } = renderHook(() => useDelayedHideFollowedSuggestions(suggestions, new Set(['t1'])));
+
+    expect(names(result)).toEqual(['Helia Labs']);
+  });
+
+  // Unfollowing inside the confirm window cancels the pending removal — the row
+  // was never meant to disappear, so it must not disappear two seconds later.
+  it('restores a row when the follow is undone before the timer fires', () => {
+    const { result, rerender } = renderHook(
+      ({ followed }) => useDelayedHideFollowedSuggestions(suggestions, followed),
+      { initialProps: { followed: new Set<string>() } },
+    );
+
+    rerender({ followed: new Set(['t1']) });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    rerender({ followed: new Set<string>() });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(names(result)).toEqual(['Banyan Storage', 'Helia Labs']);
+  });
+
+  it('leaves an empty suggestion list empty', () => {
+    const { result } = renderHook(() => useDelayedHideFollowedSuggestions([], new Set()));
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/components/page/home/TeamNews/TeamNews.module.scss
+++ b/components/page/home/TeamNews/TeamNews.module.scss
@@ -119,6 +119,15 @@
   margin-bottom: 16px;
 }
 
+// The lifted rail modules, sub-desktop only. Same 16px separation from the
+// stream that `.topStories` uses, so band → rails → feed reads as one rhythm.
+.feedScrollers {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
 .feed {
   display: flex;
   flex-direction: column;

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -48,6 +48,7 @@ import { categoryIncludesForumPosts, filterFeedForumPosts } from './utils/matche
 import { useStoryReveal } from './hooks/useStoryReveal';
 import { useNewsDeepLink } from './hooks/useNewsDeepLink';
 import { useFeedSocial } from './hooks/useFeedSocial';
+import { useIsBelowDesktop } from '@/hooks/useIsBelowDesktop';
 import { useFeedHiring } from './hooks/useFeedHiring';
 import { useFeedDeals } from './hooks/useFeedDeals';
 import { useForumPostDeepLink } from './hooks/useForumPostDeepLink';
@@ -62,6 +63,12 @@ import { DealCardCompact } from './components/DealCardCompact/DealCardCompact';
 import { ForumPostCard } from './components/ForumPostCard/ForumPostCard';
 import { NewsBase } from './components/NewsBase';
 import { NewsRail } from './components/NewsRail';
+import {
+  useDelayedHideFollowedSuggestions,
+  useFeedModulesViewAnalytics,
+} from './components/NewsRail/useSuggestionsModule';
+import { FollowTeamsScroller } from './components/FeedScrollers/FollowTeamsScroller';
+import { PopularScroller } from './components/FeedScrollers/PopularScroller';
 import { NewsSearch } from './components/NewsSearch';
 import { TeamNewsTabs } from './components/TeamNewsTabs';
 
@@ -424,6 +431,29 @@ export const TeamNews = ({
   const { currentUser } = useCurrentUserStore();
   const { suggestions: suggestedTeams, isLoading: isLoadingSuggestedTeams } = useSuggestedTeamsToFollow({
     currentUserUid: currentUser?.uid ?? null,
+  });
+
+  // Below 1200px the grid drops the rail's column and the sidebar stacks under
+  // the whole feed, which buries Teams-to-follow and Popular about three screens
+  // down. They lift into horizontal rows just under the top-stories band
+  // instead. A JS switch rather than CSS show/hide: NewsRail animates its cards
+  // through AnimatePresence, so a hidden second copy would still mount a motion
+  // tree — and would double-count the view events below.
+  const isBelowDesktop = useIsBelowDesktop();
+
+  // Owned here, not in NewsRail, because both surfaces need the same list AND
+  // the same delayed-hide-after-follow confirm — computing it twice would let
+  // the two drift.
+  const visibleSuggestions = useDelayedHideFollowedSuggestions(suggestedTeams, followedTeamUids);
+
+  const showSuggestionsModule = isLoadingSuggestedTeams || visibleSuggestions.length > 0;
+
+  // Fired from the parent, which mounts exactly one surface, so the count is one
+  // per session at either width.
+  useFeedModulesViewAnalytics({
+    suggestionsShown: showSuggestionsModule && !isLoadingSuggestedTeams ? visibleSuggestions.length : 0,
+    isLoadingSuggestedTeams,
+    popularCount: railPopularItems.length,
   });
 
   const handleTab = (id: string) => {
@@ -814,6 +844,25 @@ export const TeamNews = ({
               />
             </div>
           )}
+
+          {/* The rail's two modules, lifted to just under the band at widths
+              where the rail itself stacks below the whole feed. Rendered only
+              here — NewsRail drops them at the same breakpoint, so exactly one
+              instance of each is ever on screen. Kept in the rail's own order
+              so the modules don't swap places between widths. */}
+          {isBelowDesktop && (
+            <div className={s.feedScrollers}>
+              {showSuggestionsModule && (
+                <FollowTeamsScroller
+                  suggestions={visibleSuggestions}
+                  followedTeamUids={followedTeamUids}
+                  onFollowToggle={handleFollowToggle}
+                />
+              )}
+              <PopularScroller items={railPopularItems} onPopularItemClick={handlePopularItemClick} />
+            </div>
+          )}
+
           {/* Suppressed when the band is showing: a window whose every story is
               in the band leaves the stream empty, and "No network news in this
               filter" directly under three stories reads as a bug. */}
@@ -905,8 +954,9 @@ export const TeamNews = ({
         <NewsRail
           initialDigestSettings={initialDigestSettings}
           popularItems={railPopularItems}
-          suggestedTeams={suggestedTeams}
           isLoadingSuggestedTeams={isLoadingSuggestedTeams}
+          visibleSuggestions={visibleSuggestions}
+          renderModules={!isBelowDesktop}
           followedTeamUids={followedTeamUids}
           onFollowToggle={handleFollowToggle}
           onPopularItemClick={handlePopularItemClick}

--- a/components/page/home/TeamNews/components/FeedScrollers/FeedScrollers.module.scss
+++ b/components/page/home/TeamNews/components/FeedScrollers/FeedScrollers.module.scss
@@ -1,0 +1,143 @@
+@import '../../../../../../styles/media';
+
+.scroller {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #0a0c11;
+}
+
+// CSS-only scroll mechanics: the right-edge mask makes the next card peek, so
+// unlike production's QuickActions row there is no JS scroll listener to port.
+.row {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  // Right padding = the mask width, so the last card can still scroll clear of
+  // the fade. Bottom padding leaves room for the cards' shadow.
+  padding: 2px 28px 8px 0;
+  scroll-snap-type: x proximity;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+  mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  // The row is focusable so it can be scrolled by keyboard — it needs a visible
+  // focus ring like any other focusable region.
+  &:focus-visible {
+    outline: 2px solid var(--foreground-brand-primary, #1b4dff);
+    outline-offset: 2px;
+    border-radius: 8px;
+  }
+}
+
+// 240px, not chip-sized: the reason line is what earns a follow, and a narrower
+// card would have to drop it and leave a row of logos.
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 0 0 240px;
+  width: 240px;
+  padding: 14px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow:
+    0px 0px 1px 0px rgba(15, 23, 42, 0.12),
+    0px 4px 4px 0px rgba(15, 23, 42, 0.04);
+  scroll-snap-align: start;
+  text-align: left;
+  border: none;
+}
+
+.cardHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+}
+
+.logo,
+.logoFallback {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border: 1px solid rgba(27, 56, 96, 0.24);
+}
+
+.logoFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1b4dff;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+}
+
+.cardName {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #0a0c11;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+
+  &:hover {
+    color: #1b4dff;
+    text-decoration: underline;
+  }
+}
+
+.cardReason {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+  letter-spacing: -0.2px;
+  color: #455468;
+  // Two lines, so a long reason can't make one card taller than its neighbours.
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.storyCard {
+  cursor: pointer;
+  gap: 4px;
+}
+
+.storyTitle {
+  display: -webkit-box;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: #0a0c11;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/components/page/home/TeamNews/components/FeedScrollers/FollowTeamsScroller.tsx
+++ b/components/page/home/TeamNews/components/FeedScrollers/FollowTeamsScroller.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useCurrentUserStore } from '@/services/auth/store';
+import { FollowButton } from '@/components/ui/FollowButton';
+import type { FollowAnalyticsSource } from '@/analytics/follow.analytics';
+import type { ISuggestedTeam } from '@/types/team-news.types';
+
+import { getTeamLogoFallback } from '../../utils/getTeamLogoFallback';
+import { stripFollowerCountFromReason } from '../NewsRail/components/TeamsToFollowCard/TeamsToFollowCard';
+
+import { MobileScrollRow } from './MobileScrollRow';
+import s from './FeedScrollers.module.scss';
+
+interface FollowTeamsScrollerProps {
+  suggestions: ISuggestedTeam[];
+  followedTeamUids: Set<string>;
+  onFollowToggle: (
+    teamUid: string,
+    teamName: string,
+    isCurrentlyFollowing: boolean,
+    source?: FollowAnalyticsSource,
+    meta?: { position?: number; reason?: string },
+  ) => void;
+}
+
+/**
+ * "Teams to follow" for sub-desktop widths.
+ *
+ * Cards are 240px rather than chip-sized on purpose: the *reason* line is the
+ * only thing that earns a follow ("Storage", "works with 2 teams you follow"),
+ * and a narrow chip would have to drop it, leaving a row of logos.
+ *
+ * Reads the same `visibleSuggestions` the rail card does — TeamNews computes it
+ * once, so the delayed-hide-after-follow confirm behaves identically at either
+ * width, and the same reason-first subtitle rule applies.
+ */
+export function FollowTeamsScroller({ suggestions, followedTeamUids, onFollowToggle }: FollowTeamsScrollerProps) {
+  const router = useRouter();
+  const { currentUser } = useCurrentUserStore();
+
+  if (suggestions.length === 0) return null;
+
+  const handleFollowClick = (team: ISuggestedTeam, position: number) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!currentUser) {
+      router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
+      return;
+    }
+    if (followedTeamUids.has(team.uid)) return;
+    onFollowToggle(team.uid, team.name, false, 'news-rail', {
+      position,
+      reason: stripFollowerCountFromReason(team.reason || ''),
+    });
+  };
+
+  return (
+    <MobileScrollRow title="Teams to follow">
+      {suggestions.map((team, position) => {
+        const isFollowing = followedTeamUids.has(team.uid);
+        // Same precedence as the rail card: the reason says why this team is in
+        // front of *you*; the tagline only says what it is.
+        const subtitle = stripFollowerCountFromReason(team.reason || '') || team.shortDescription?.trim() || '';
+        return (
+          <div key={team.uid} className={s.card}>
+            <div className={s.cardHead}>
+              {team.logo ? (
+                <img className={s.logo} src={team.logo} alt="" loading="lazy" />
+              ) : (
+                <div className={s.logoFallback}>{getTeamLogoFallback(team.name)}</div>
+              )}
+              <a href={`/teams/${team.uid}`} target="_blank" rel="noopener noreferrer" className={s.cardName}>
+                {team.name}
+              </a>
+            </div>
+            {subtitle && <p className={s.cardReason}>{subtitle}</p>}
+            <FollowButton
+              following={isFollowing}
+              onClick={handleFollowClick(team, position)}
+              name={team.name}
+              size="compact"
+              disabled={isFollowing}
+            />
+          </div>
+        );
+      })}
+    </MobileScrollRow>
+  );
+}

--- a/components/page/home/TeamNews/components/FeedScrollers/MobileScrollRow.tsx
+++ b/components/page/home/TeamNews/components/FeedScrollers/MobileScrollRow.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import s from './FeedScrollers.module.scss';
+
+interface MobileScrollRowProps {
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * The shell both sub-desktop rail rows share.
+ *
+ * Below 1200px the grid drops the rail's column and the sidebar stacks under
+ * the *whole* feed — which puts Teams-to-follow roughly three screens down,
+ * i.e. nowhere. Lifting them means a horizontal row, and the scroll mechanics
+ * (snap, hidden scrollbar, the right-edge mask that makes the next card peek)
+ * live here rather than in each row, so there is one copy of them.
+ *
+ * `tabIndex={0}` on the scroll container: an overflow region that isn't
+ * keyboard-focusable can't be scrolled by keyboard at all, and the cards inside
+ * are focusable but the row itself needs to be reachable for arrow-key
+ * scrolling. Paired with the group role + label so it's announced as one unit.
+ */
+export function MobileScrollRow({ title, children }: MobileScrollRowProps) {
+  return (
+    <section className={s.scroller} aria-label={title}>
+      <h3 className={s.title}>{title}</h3>
+      <div className={s.row} role="group" aria-label={`${title}, scrollable`} tabIndex={0}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/components/page/home/TeamNews/components/FeedScrollers/PopularScroller.tsx
+++ b/components/page/home/TeamNews/components/FeedScrollers/PopularScroller.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { ITeamNewsPopularItem } from '@/types/team-news.types';
+
+import { MobileScrollRow } from './MobileScrollRow';
+import s from './FeedScrollers.module.scss';
+
+interface PopularScrollerProps {
+  items: ITeamNewsPopularItem[];
+  onPopularItemClick: (item: ITeamNewsPopularItem, position: number) => void;
+}
+
+/**
+ * "Popular this week" for sub-desktop widths.
+ *
+ * Same problem the follow module had: below 1200px the rail stacks under the
+ * whole feed, so this landed after six cards and the Show All button. Same fix,
+ * same scroller shell — and the same click handler as the rail card, so a tap
+ * still reveals the story in the feed rather than opening its source link.
+ */
+export function PopularScroller({ items, onPopularItemClick }: PopularScrollerProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <MobileScrollRow title="Popular this week">
+      {items.map((item, position) => (
+        <button
+          key={item.uid}
+          type="button"
+          className={`${s.card} ${s.storyCard}`}
+          onClick={() => onPopularItemClick(item, position)}
+        >
+          <span className={s.storyTitle}>{item.title}</span>
+          <span className={s.cardReason}>
+            ↑ {item.upvoteCount ?? 0} · {item.teamName}
+          </span>
+        </button>
+      ))}
+    </MobileScrollRow>
+  );
+}

--- a/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
+++ b/components/page/home/TeamNews/components/NewsRail/NewsRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -9,7 +9,6 @@ import { useCurrentUserStore } from '@/services/auth/store';
 import { useGetForumDigestSettings, type ForumDigestSettings } from '@/services/forum/hooks/useGetForumDigestSettings';
 import { useUpdateForumDigestSettings } from '@/services/forum/hooks/useUpdateForumDigestSettings';
 import { useSettingsAnalytics } from '@/analytics/settings.analytics';
-import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
 import type { FollowAnalyticsSource } from '@/analytics/follow.analytics';
 import type { ISuggestedTeam, ITeamNewsPopularItem } from '@/types/team-news.types';
 
@@ -17,8 +16,6 @@ import { TeamsToFollowCard } from './components/TeamsToFollowCard';
 import { PopularThisWeekCard } from './components/PopularThisWeekCard';
 
 import s from './NewsRail.module.scss';
-
-const FOLLOW_CONFIRM_MS = 2000;
 
 const ArrowRight = () => (
   <svg width="11" height="10" viewBox="0 0 11 10" fill="none" aria-hidden="true">
@@ -57,7 +54,6 @@ interface NewsRailProps {
   /** Server-ranked "Popular this week" (GET /v1/team-news/popular), fetched SSR in
    * app/home/page.tsx and threaded through TeamNews.tsx. */
   popularItems?: ITeamNewsPopularItem[];
-  suggestedTeams?: ISuggestedTeam[];
   isLoadingSuggestedTeams?: boolean;
   followedTeamUids?: Set<string>;
   /** Same followedTeamUids/handleFollowToggle TeamNews.tsx already threads to
@@ -73,110 +69,33 @@ interface NewsRailProps {
   /** Threaded straight through to PopularThisWeekCard, unchanged — TeamNews.tsx
    * is the single caller and always provides it, so there's no fallback here. */
   onPopularItemClick: (item: ITeamNewsPopularItem, position: number) => void;
+  /** False below 1200px, where TeamNews renders Teams-to-follow and Popular as
+   *  horizontal scrollers in the feed column instead. Keeps exactly one instance
+   *  of each module on screen; the digest card is unaffected either way. */
+  renderModules?: boolean;
+  /** Computed by TeamNews (one owner, since the scrollers need the same list and
+   *  the same delayed-hide-after-follow behaviour). */
+  visibleSuggestions?: ISuggestedTeam[];
 }
 
 const EMPTY_FOLLOWED_UIDS = new Set<string>();
-
-/** After follow, keep the row visible with a Following checkmark for
- * FOLLOW_CONFIRM_MS, then drop it so AnimatePresence can play the card exit.
- * Teams already followed when they first appear are hidden immediately. */
-function useDelayedHideFollowedSuggestions(suggestions: ISuggestedTeam[], followedTeamUids: Set<string>) {
-  const [hiddenUids, setHiddenUids] = useState<Set<string>>(() => new Set());
-  const pendingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-  const scheduledUidsRef = useRef<Set<string>>(new Set());
-  const seenUnfollowedRef = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    return () => {
-      pendingTimersRef.current.forEach((timer) => clearTimeout(timer));
-      pendingTimersRef.current.clear();
-      scheduledUidsRef.current.clear();
-    };
-  }, []);
-
-  useEffect(() => {
-    for (const team of suggestions) {
-      const isFollowed = followedTeamUids.has(team.uid);
-
-      if (!isFollowed) {
-        seenUnfollowedRef.current.add(team.uid);
-        const timer = pendingTimersRef.current.get(team.uid);
-        if (timer) {
-          clearTimeout(timer);
-          pendingTimersRef.current.delete(team.uid);
-        }
-        scheduledUidsRef.current.delete(team.uid);
-        if (hiddenUids.has(team.uid)) {
-          setHiddenUids((prev) => {
-            if (!prev.has(team.uid)) return prev;
-            const next = new Set(prev);
-            next.delete(team.uid);
-            return next;
-          });
-        }
-        continue;
-      }
-
-      if (hiddenUids.has(team.uid) || scheduledUidsRef.current.has(team.uid)) continue;
-
-      // Already followed when first seen — hide without the confirm delay.
-      if (!seenUnfollowedRef.current.has(team.uid)) {
-        setHiddenUids((prev) => {
-          const next = new Set(prev);
-          next.add(team.uid);
-          return next;
-        });
-        continue;
-      }
-
-      scheduledUidsRef.current.add(team.uid);
-      pendingTimersRef.current.set(
-        team.uid,
-        setTimeout(() => {
-          pendingTimersRef.current.delete(team.uid);
-          setHiddenUids((prev) => {
-            const next = new Set(prev);
-            next.add(team.uid);
-            return next;
-          });
-        }, FOLLOW_CONFIRM_MS),
-      );
-    }
-  }, [suggestions, followedTeamUids, hiddenUids]);
-
-  return useMemo(() => {
-    return suggestions.filter((team) => {
-      if (hiddenUids.has(team.uid)) return false;
-      // Already followed on first sight — hide immediately (no confirm flash).
-      if (
-        followedTeamUids.has(team.uid) &&
-        !seenUnfollowedRef.current.has(team.uid) &&
-        !scheduledUidsRef.current.has(team.uid)
-      ) {
-        return false;
-      }
-      return true;
-    });
-  }, [suggestions, hiddenUids, followedTeamUids]);
-}
 
 /** Teams-to-follow + Popular-this-week (v1) alongside the digest subscribe CTA
  * (reuses the same forum-digest mutation as Settings > Email, weekly frequency). */
 export function NewsRail({
   initialDigestSettings = null,
   popularItems = [],
-  suggestedTeams = [],
   isLoadingSuggestedTeams = false,
   followedTeamUids = EMPTY_FOLLOWED_UIDS,
   onFollowToggle,
   onPopularItemClick,
+  renderModules = true,
+  visibleSuggestions = [],
 }: NewsRailProps) {
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
   const analytics = useSettingsAnalytics();
-  const teamNewsAnalytics = useTeamNewsAnalytics();
   const { mutate } = useUpdateForumDigestSettings();
-  const visibleSuggestions = useDelayedHideFollowedSuggestions(suggestedTeams, followedTeamUids);
 
   const defaultSettings = useMemo(
     () => initialDigestSettings ?? buildDefaultDigestSettings(currentUser?.uid ?? ''),
@@ -213,32 +132,18 @@ export function NewsRail({
   // card's own exit animation instead of it just vanishing — e.g. when the loader
   // resolves to zero suggestions. `layout` on every card below lets the rest of
   // the rail smoothly reflow into the space that frees up, rather than jumping.
-  const showTeamsToFollow = Boolean(onFollowToggle) && (isLoadingSuggestedTeams || visibleSuggestions.length > 0);
-  const showPopular = popularItems.length > 0;
+  //
+  // `renderModules` is the sub-desktop switch: below 1200px the grid drops this
+  // rail's column and TeamNews renders these two as horizontal scrollers inside
+  // the feed column instead. Exactly one surface is ever mounted, so the digest
+  // card below — which has no scroller counterpart — is unaffected.
+  const showTeamsToFollow =
+    renderModules && Boolean(onFollowToggle) && (isLoadingSuggestedTeams || visibleSuggestions.length > 0);
+  const showPopular = renderModules && popularItems.length > 0;
 
-  // Two constants for this card were declared and never fired. Wired off the
-  // mount decision above, which is the only place that knows both outcomes:
-  // the card appearing with real suggestions, and it leaving — which happens
-  // when the member has followed every one, the completion of this funnel.
-  const suggestionsShown = showTeamsToFollow && !isLoadingSuggestedTeams ? visibleSuggestions.length : 0;
-  const wasShownRef = useRef(false);
-  useEffect(() => {
-    if (suggestionsShown > 0 && !wasShownRef.current) {
-      wasShownRef.current = true;
-      teamNewsAnalytics.onTeamsToFollowViewed(suggestionsShown);
-    } else if (suggestionsShown === 0 && wasShownRef.current && !isLoadingSuggestedTeams) {
-      wasShownRef.current = false;
-      teamNewsAnalytics.onTeamsToFollowHidden();
-    }
-  }, [suggestionsShown, isLoadingSuggestedTeams, teamNewsAnalytics]);
-
-  // Popular-this-week's click-through had a numerator and no denominator.
-  const popularShownRef = useRef(false);
-  useEffect(() => {
-    if (!showPopular || popularShownRef.current) return;
-    popularShownRef.current = true;
-    teamNewsAnalytics.onPopularCardViewed(popularItems.length);
-  }, [showPopular, popularItems.length, teamNewsAnalytics]);
+  // The view-once analytics used to live here. They moved up to TeamNews (see
+  // useFeedModulesViewAnalytics): with two possible surfaces, an effect next to
+  // the cards would either double-fire or only ever report desktop.
 
   return (
     <aside className={s.rail} aria-label="News feed sidebar">

--- a/components/page/home/TeamNews/components/NewsRail/useSuggestionsModule.ts
+++ b/components/page/home/TeamNews/components/NewsRail/useSuggestionsModule.ts
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useTeamNewsAnalytics } from '@/analytics/team-news.analytics';
+import type { ISuggestedTeam } from '@/types/team-news.types';
+
+const FOLLOW_CONFIRM_MS = 2000;
+
+/** After follow, keep the row visible with a Following checkmark for
+ * FOLLOW_CONFIRM_MS, then drop it so AnimatePresence can play the card exit.
+ * Teams already followed when they first appear are hidden immediately. */
+export function useDelayedHideFollowedSuggestions(suggestions: ISuggestedTeam[], followedTeamUids: Set<string>) {
+  const [hiddenUids, setHiddenUids] = useState<Set<string>>(() => new Set());
+  const pendingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const scheduledUidsRef = useRef<Set<string>>(new Set());
+  const seenUnfollowedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    return () => {
+      pendingTimersRef.current.forEach((timer) => clearTimeout(timer));
+      pendingTimersRef.current.clear();
+      scheduledUidsRef.current.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    for (const team of suggestions) {
+      const isFollowed = followedTeamUids.has(team.uid);
+
+      if (!isFollowed) {
+        seenUnfollowedRef.current.add(team.uid);
+        const timer = pendingTimersRef.current.get(team.uid);
+        if (timer) {
+          clearTimeout(timer);
+          pendingTimersRef.current.delete(team.uid);
+        }
+        scheduledUidsRef.current.delete(team.uid);
+        if (hiddenUids.has(team.uid)) {
+          setHiddenUids((prev) => {
+            if (!prev.has(team.uid)) return prev;
+            const next = new Set(prev);
+            next.delete(team.uid);
+            return next;
+          });
+        }
+        continue;
+      }
+
+      if (hiddenUids.has(team.uid) || scheduledUidsRef.current.has(team.uid)) continue;
+
+      // Already followed when first seen — hide without the confirm delay.
+      if (!seenUnfollowedRef.current.has(team.uid)) {
+        setHiddenUids((prev) => {
+          const next = new Set(prev);
+          next.add(team.uid);
+          return next;
+        });
+        continue;
+      }
+
+      scheduledUidsRef.current.add(team.uid);
+      pendingTimersRef.current.set(
+        team.uid,
+        setTimeout(() => {
+          pendingTimersRef.current.delete(team.uid);
+          setHiddenUids((prev) => {
+            const next = new Set(prev);
+            next.add(team.uid);
+            return next;
+          });
+        }, FOLLOW_CONFIRM_MS),
+      );
+    }
+  }, [suggestions, followedTeamUids, hiddenUids]);
+
+  return useMemo(() => {
+    return suggestions.filter((team) => {
+      if (hiddenUids.has(team.uid)) return false;
+      // Already followed on first sight — hide immediately (no confirm flash).
+      if (
+        followedTeamUids.has(team.uid) &&
+        !seenUnfollowedRef.current.has(team.uid) &&
+        !scheduledUidsRef.current.has(team.uid)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [suggestions, hiddenUids, followedTeamUids]);
+}
+/**
+ * Fire-once view events for the two modules that now render on two surfaces —
+ * the rail card above 1200px, the horizontal scroller below it.
+ *
+ * Lifted out of NewsRail deliberately. These effects used to sit next to the
+ * cards, which was fine while the rail was the only place they could appear;
+ * with a second surface that would either double-fire (if both mounted) or fire
+ * only on desktop (if only the rail kept them). Living in the parent, which
+ * mounts exactly one surface, the count stays one per session either way.
+ *
+ * `onTeamsToFollowHidden` is the completion of the follow funnel — the member
+ * followed every suggestion — so it fires on the transition to zero, not on the
+ * loading state that precedes the first render.
+ */
+export function useFeedModulesViewAnalytics({
+  suggestionsShown,
+  isLoadingSuggestedTeams,
+  popularCount,
+}: {
+  suggestionsShown: number;
+  isLoadingSuggestedTeams: boolean;
+  popularCount: number;
+}) {
+  const teamNewsAnalytics = useTeamNewsAnalytics();
+
+  const wasShownRef = useRef(false);
+  useEffect(() => {
+    if (suggestionsShown > 0 && !wasShownRef.current) {
+      wasShownRef.current = true;
+      teamNewsAnalytics.onTeamsToFollowViewed(suggestionsShown);
+    } else if (suggestionsShown === 0 && wasShownRef.current && !isLoadingSuggestedTeams) {
+      wasShownRef.current = false;
+      teamNewsAnalytics.onTeamsToFollowHidden();
+    }
+  }, [suggestionsShown, isLoadingSuggestedTeams, teamNewsAnalytics]);
+
+  // Popular's click-through had a numerator and no denominator.
+  const popularShownRef = useRef(false);
+  useEffect(() => {
+    if (popularCount === 0 || popularShownRef.current) return;
+    popularShownRef.current = true;
+    teamNewsAnalytics.onPopularCardViewed(popularCount);
+  }, [popularCount, teamNewsAnalytics]);
+}

--- a/hooks/useIsBelowDesktop.ts
+++ b/hooks/useIsBelowDesktop.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+// $breakpoint-lg / @include desktop in styles/media.scss — the width at which
+// TeamNews.module.scss `.layout` drops its 300px rail column and the sidebar
+// falls below the whole feed.
+//
+// A third breakpoint hook rather than reusing one of the two that exist:
+// useIsNarrow is 1024 and useIsMobile is 768, and neither is where this layout
+// actually changes. Matching the SCSS is the point — a hook that switches at a
+// width the grid doesn't would put two copies of a module on screen at once.
+const DESKTOP_BREAKPOINT = 1200;
+
+/**
+ * True below the desktop grid breakpoint.
+ *
+ * `undefined` until the effect runs, coerced to `false`, so SSR and the first
+ * client render agree on the desktop layout and hydration is clean; the flip
+ * happens on mount if the viewport is actually narrow. Same shape as
+ * useIsNarrow / useIsMobile.
+ */
+export function useIsBelowDesktop() {
+  const [isBelowDesktop, setIsBelowDesktop] = React.useState<boolean | undefined>(undefined);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${DESKTOP_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsBelowDesktop(window.innerWidth < DESKTOP_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsBelowDesktop(window.innerWidth < DESKTOP_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return !!isBelowDesktop;
+}


### PR DESCRIPTION
> **Stacked on #2752.** Base is `feat/newsfeed-jobs-deals-in-feed`, so this diff shows only Phase 3. Retarget to `develop` once #2751 and #2752 merge.

## Summary

Phase 3 of the newsfeed redesign. Below 1200px the grid drops the rail's column and the sidebar stacks under the whole feed — which put Teams to follow and Popular this week roughly three screens down, past six cards and the Show All button. Both now render as horizontal scroll rows directly under the top-stories band instead.

Prototype: `prototypes/entries/newsfeed/` (`MobileScrollRow.tsx`, `FollowTeamsScroller.tsx`, `PopularScroller.tsx`).

## The breakpoint is 1200px, not the prototype's 960px

```scss
/* TeamNews.module.scss */
.layout {
  grid-template-columns: minmax(0, 1fr);
  @include desktop {                    /* $breakpoint-lg: 1200 */
    grid-template-columns: minmax(0, 1fr) 300px;
  }
}
```

That's the width at which the rail actually falls below the feed. Neither existing hook matches — `useIsNarrow` is 1024, `useIsMobile` is 768 — so this adds `useIsBelowDesktop`. Matching the SCSS is the point: a hook that switches at a width the grid doesn't would put two copies of a module on screen.

## A JS switch, not the prototype's CSS show/hide

The prototype renders both surfaces and hides one with a media query. Production's `NewsRail` animates its cards through `AnimatePresence` and fires `onTeamsToFollowViewed` / `onPopularCardViewed` on mount — rendering both would mount two motion trees and double-count both events. `useIsBelowDesktop` picks exactly one surface instead.

## One thing moved that wasn't in the plan

The plan called for extracting the two view-analytics effects into a shared hook. Doing that surfaced a second piece that had to move with them: `useDelayedHideFollowedSuggestions` — the 2s Following-confirm before a followed row disappears — lived inside `NewsRail`. The scroller needs identical behaviour, and computing it twice would let the two surfaces drift (a row vanishing on one while lingering on the other). So it moved to `components/NewsRail/useSuggestionsModule.ts` alongside the view events, and `TeamNews` now computes the list once and hands it to whichever surface renders.

`NewsRail` becomes a presenter for these two cards: it takes `visibleSuggestions` and a `renderModules` flag instead of owning either. The digest card has no scroller counterpart and stays in the rail at every width.

The moved code carries its two pre-existing `exhaustive-deps` warnings and a `refs-during-render` lint error unchanged — I diffed against the parent commit to confirm they were already there, not introduced by the move.

## Testing

- 4 new tests for the extracted `useDelayedHideFollowedSuggestions` hook (moved from `news-rail.test.tsx`, more direct via `renderHook`), including a case the old test didn't cover: unfollowing inside the confirm window must cancel the pending removal rather than let it fire two seconds later.
- 7 new `TeamNews` integration tests: desktop keeps both in the rail with no scrollers, sub-desktop lifts both with neither in the rail, digest stays in the rail at both widths, exactly one instance mounted, each view event fires once regardless of surface, follow-from-scroller sends the same payload as the rail row, tapping a scroller story reveals it in the feed.
- `news-rail.test.tsx` updated to test `NewsRail` as a presenter (renders what it's given, drops the modules when `renderModules={false}`) rather than owning the confirm timer.
- Full suite: 1410 pass. The one failure (`getCurrentRoundNumber` month boundary) is date-dependent and reproduces on a clean tree.
- `npm run build` compiles; lint clean — confirmed the one pre-existing warning/error pair in the moved code already existed before this branch.

Verified live at three widths (desktop 1440 / tablet 1100 / mobile 390) via Playwright against the dev API:
- 1440: Popular in the rail, no scroller in the feed.
- 1100 and 390: Popular renders as a scroller in the feed, absent from the rail.
- Exactly one instance of each module at every width; digest card present in the rail throughout; no horizontal page overflow at either narrow width.
- The mobile scroller sits directly under the band — 240px cards, next card peeking through the fade mask, genuinely scrollable (1018px of content in a 356px viewport).

## Known caveats

- **"Exactly one instance" has a ~280ms exception.** On a resize *across* 1200px, `AnimatePresence` keeps the outgoing rail card mounted for its exit animation while the scroller is already in. The analytics are unaffected (they live in the parent now, not next to either card). I didn't defeat the exit animation for this — a viewport crossing 1200px mid-session is a desktop window being resized, not a device.
- **`FollowTeamsScroller` has not been seen rendered against real data.** Follow suggestions require a signed-in user; anonymous browsing on dev returns none, so this is covered by tests only. Same situation as the deal card in #2752 — worth a look together on a signed-in, deals-enabled account before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
