### PR TITLE
fix(newsfeed): mobile prototype-alignment fixes (quick actions, category filter, follow reason)

### DIFF
--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -24,6 +24,16 @@ function renderTeamNews(ui: ReactElement) {
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
+// The mobile "Type:" dropdown's trigger shows the active category's label,
+// which for the default (All categories) is byte-identical to the desktop
+// pill's own text — jsdom doesn't evaluate the media query that hides one of
+// them, so both are in the DOM at once and a bare name-based query is
+// ambiguous. Scope to the pill row (`.catRow`) for anything that queries by
+// category label; the dropdown has its own dedicated tests.
+function catRow(): HTMLElement {
+  return document.querySelector('.catRow') as HTMLElement;
+}
+
 /** Default sort is Most popular — switch to Following when a test needs followed-first order. */
 function selectFollowingSort() {
   fireEvent.click(screen.getByRole('button', { name: 'Most popular' }));
@@ -230,7 +240,7 @@ describe('TeamNews', () => {
     expect(screen.getByRole('tab', { name: /All/ })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('tab', { name: /AI & Robotics/ })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Digital Human Rights/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /All categories/ })).toHaveClass(/catActive/);
+    expect(within(catRow()).getByRole('button', { name: /All categories/ })).toHaveClass(/catActive/);
   });
 
   it('switches to a focus-area tab and reports analytics', () => {
@@ -257,7 +267,7 @@ describe('TeamNews', () => {
     expect(screen.getByRole('button', { name: /^Funding$/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /^Launch$/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Milestone/ })).not.toBeDisabled();
-    expect(screen.getByRole('button', { name: /All categories/ })).not.toBeDisabled();
+    expect(within(catRow()).getByRole('button', { name: /All categories/ })).not.toBeDisabled();
   });
 
   it('renders an Other category chip, disabled when no OTHER items exist', () => {
@@ -278,6 +288,53 @@ describe('TeamNews', () => {
     expect(mockOnCategoryClicked).toHaveBeenCalledWith('OTHER', 1, 'All');
     expect(screen.getByText(/Headline ai-other/)).toBeInTheDocument();
     expect(screen.queryByText(/Headline ai-1/)).not.toBeInTheDocument();
+  });
+
+  describe('mobile "Type:" category dropdown', () => {
+    // jsdom doesn't evaluate the media query that hides this dropdown at
+    // desktop widths and the pill row below mobile, so both are always in the
+    // DOM in tests — scope to `.typeMobile` the same way category-pill tests
+    // scope to `.catRow`.
+    const typeDropdown = (): HTMLElement => document.querySelector('.typeMobile') as HTMLElement;
+
+    it('defaults to the plain "All categories" label, with no count', () => {
+      renderTeamNews(<TeamNews groups={groups} />);
+      expect(within(typeDropdown()).getByRole('button', { name: 'All categories' })).toBeInTheDocument();
+    });
+
+    it('omits zero-count categories and folds counts into the label for the rest', () => {
+      renderTeamNews(<TeamNews groups={groups} />);
+      fireEvent.click(within(typeDropdown()).getByRole('button', { name: 'All categories' }));
+
+      // aiItems: FUNDING, LAUNCH, PARTNERSHIP (1 each); dhrItems: MILESTONE, ANNOUNCEMENT (1 each).
+      expect(screen.getByRole('menuitem', { name: 'Funding (1)' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Milestone (1)' })).toBeInTheDocument();
+      // OTHER has zero items in this fixture — dropped, not shown disabled
+      // (SortDropdown has no disabled state; see the memo's own comment).
+      expect(screen.queryByRole('menuitem', { name: /Other/ })).not.toBeInTheDocument();
+    });
+
+    it('filters the feed and reports the same analytics event a pill click would', () => {
+      renderTeamNews(<TeamNews groups={groups} />);
+      fireEvent.click(within(typeDropdown()).getByRole('button', { name: 'All categories' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Funding (1)' }));
+
+      expect(mockOnCategoryClicked).toHaveBeenCalledWith('FUNDING', 1, 'All');
+      expect(screen.getByText(/Headline ai-1/)).toBeInTheDocument();
+      expect(screen.queryByText(/Headline ai-2/)).not.toBeInTheDocument();
+      // The trigger now reflects the selection, count folded in — same label
+      // format the menu offered it under.
+      expect(within(typeDropdown()).getByRole('button', { name: 'Funding (1)' })).toBeInTheDocument();
+    });
+
+    it('stays in sync with the desktop pill row — selecting a pill updates the dropdown label too', () => {
+      renderTeamNews(<TeamNews groups={groups} />);
+      // The pill's accessible name is "Launch" + its count span concatenated
+      // with no separator (e.g. "Launch1") — matching other tests in this file.
+      fireEvent.click(within(catRow()).getByRole('button', { name: /^Launch/ }));
+
+      expect(within(typeDropdown()).getByRole('button', { name: 'Launch (1)' })).toBeInTheDocument();
+    });
   });
 
   it('shows all items on Show All click and collapses back on Show Less, reports analytics', () => {
@@ -373,9 +430,9 @@ describe('TeamNews', () => {
 
     it('shows Discussions after All categories when at least one item has a thread', () => {
       renderTeamNews(<TeamNews groups={groupsWithDiscussion} />);
-      const chips = screen.getAllByRole('button', { name: /categories|Discussions|Funding|Launch/i });
-      const allCat = screen.getByRole('button', { name: /All categories/ });
-      const discussions = screen.getByRole('button', { name: /Discussions/ });
+      const chips = within(catRow()).getAllByRole('button', { name: /categories|Discussions|Funding|Launch/i });
+      const allCat = within(catRow()).getByRole('button', { name: /All categories/ });
+      const discussions = within(catRow()).getByRole('button', { name: /Discussions/ });
       expect(chips.indexOf(discussions)).toBeGreaterThan(chips.indexOf(allCat));
       expect(within(discussions).getByText('1')).toBeInTheDocument();
     });

--- a/components/page/home/QuickActions/QuickActions.module.scss
+++ b/components/page/home/QuickActions/QuickActions.module.scss
@@ -8,7 +8,7 @@
 }
 
 .title {
-  letter-spacing: -.2px;
+  letter-spacing: -0.2px;
   color: var(--foreground-neutral-secondary, #455468);
   margin-bottom: 12px;
   font-size: 16px;
@@ -41,6 +41,7 @@
   @include mobile-only {
     display: flex;
     grid-template-columns: none;
+    gap: 10px;
     overflow-x: scroll;
     scroll-snap-type: x mandatory;
     margin-inline: -14px;
@@ -60,13 +61,15 @@
     );
     @include mixins.hide-scrollbar;
 
-    // Fixed width (not a %) sized to comfortably fit the longest title ("Book
-    // Office Hours", ~152px at this weight/tracking in Inter) plus the card's
-    // 16px side padding, so it never ellipsizes. min-width: 0 overrides the
-    // flex-item default of min-width: auto, which would otherwise let a card
-    // grow past this to fit its unbreakable (white-space: nowrap) text anyway.
+    // 150px, matching the prototype's MobileQuickActions card — narrower than
+    // the desktop grid's cards so more of the row peeks into view at once.
+    // Titles now clamp to two lines (ActionCard.module.scss) instead of
+    // ellipsizing, so this width doesn't need to fit "Book Office Hours" on one
+    // line the way the old 200px card did. min-width: 0 overrides the flex-item
+    // default of min-width: auto, which would otherwise let a card grow past
+    // this to fit unbreakable text anyway.
     > * {
-      flex: 0 0 200px;
+      flex: 0 0 150px;
       min-width: 0;
       scroll-snap-align: start;
     }

--- a/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
+++ b/components/page/home/QuickActions/components/ActionCard/ActionCard.module.scss
@@ -32,8 +32,8 @@
   @include mobile-only {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
-    padding: 16px;
+    gap: 10px;
+    padding: 14px;
   }
 }
 
@@ -48,6 +48,21 @@
   border-radius: 50%;
   color: #1b4dff;
   box-shadow: inset 0px -1px 4px 0px rgba(27, 77, 255, 0.08);
+
+  // Prototype's mobile icon is smaller, and shrinks its glyph to match —
+  // otherwise a 20-24px svg (each icon's own native size) would overflow a
+  // 32px circle. The svg selector overrides the icons' own width/height
+  // attributes: CSS beats a presentational HTML attribute regardless of
+  // specificity, so no !important is needed.
+  @include mobile-only {
+    width: 32px;
+    height: 32px;
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+  }
 }
 
 .text {
@@ -73,6 +88,21 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  // Prototype's mobile card clamps to two lines rather than ellipsizing a
+  // single one — sized for a narrower (150px) card at a smaller font, where a
+  // longer title like "Book Office Hours" no longer reliably fits on one line.
+  // `white-space: nowrap` has to go too: it wins over `-webkit-line-clamp`,
+  // which needs to wrap to produce more than one line.
+  @include mobile-only {
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: -0.2px;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
 }
 
 .description {
@@ -85,6 +115,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  @include mobile-only {
+    font-size: 12px;
+    line-height: 16px;
+  }
 }
 
 .arrow {

--- a/components/page/home/TeamNews/TeamNews.module.scss
+++ b/components/page/home/TeamNews/TeamNews.module.scss
@@ -47,6 +47,7 @@
 .filterActions {
   display: inline-flex;
   align-items: center;
+  gap: 8px;
   flex-shrink: 0;
 
   @include mobile-only {
@@ -54,10 +55,29 @@
   }
 }
 
+// "Type:" dropdown, mobile only — `.catRow`'s pill row replaces it at every
+// wider breakpoint. Hidden here rather than unmounted, so there's no layout
+// jump crossing the breakpoint mid-resize.
+.typeMobile {
+  display: none;
+
+  @include mobile-only {
+    display: inline-flex;
+  }
+}
+
 .catRow {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+
+  // Replaced by the "Type:" dropdown (`.typeMobile`) below tablet-portrait —
+  // a wrapping pill row costs two lines of vertical space the mobile layout
+  // doesn't have to spare, and the prototype's own mobile treatment collapses
+  // it into the same dropdown family as "Sort by:".
+  @include mobile-only {
+    display: none;
+  }
 }
 
 .cat {

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -261,6 +261,25 @@ export const TeamNews = ({
     return withDiscussions;
   }, [countForCategory]);
 
+  /**
+   * The same list the pills render, shaped for the mobile "Type:" dropdown.
+   *
+   * Counts fold into the label because `SortDropdown` options are plain text —
+   * there's no separate count slot the way the pill has its own `<span>`.
+   * Empty categories are DROPPED rather than shown disabled: `SortDropdown`
+   * has no disabled state today, and a menu listing choices you can't pick is
+   * worse than a pill row where they're visibly greyed. A category with
+   * nothing in the current window just doesn't appear, matching the pill
+   * row's `isDisabled` rule in spirit (nothing to filter to ⇒ not offered).
+   */
+  const categoryOptions = useMemo(
+    () =>
+      categoriesWithCounts
+        .filter((c) => c.id === ALL_CAT || c.count > 0)
+        .map((c) => ({ value: c.id, label: c.id === ALL_CAT ? c.label : `${c.label} (${c.count})` })),
+    [categoriesWithCounts],
+  );
+
   const filteredItems = useMemo(() => {
     if (activeCategory === ALL_CAT) return itemsForActiveTab;
     return itemsForActiveTab.filter((i) => matchesTeamNewsCategory(i, activeCategory));
@@ -822,6 +841,18 @@ export const TeamNews = ({
           })}
         </div>
         <div className={s.filterActions}>
+          {/* Mobile only — `.catRow`'s pill row holds the category filter at
+              every wider breakpoint (see TeamNews.module.scss `.catRow` /
+              `.typeMobile`). Same SortDropdown "Sort by:" already uses, so the
+              two read as one control family on a narrow screen. */}
+          <span className={s.typeMobile}>
+            <SortDropdown
+              sortByLabel="Type:"
+              options={categoryOptions}
+              currentSort={activeCategory}
+              onSortChange={(value) => handleCategory(value as TeamNewsCategoryId)}
+            />
+          </span>
           <SortDropdown sortByLabel="Sort by:" options={SORT_OPTIONS} currentSort={sort} onSortChange={handleSort} />
         </div>
       </div>

--- a/types/team-news.types.ts
+++ b/types/team-news.types.ts
@@ -53,8 +53,10 @@ export interface ISuggestedTeam {
   name: string;
   logo: string | null;
   reason: string;
-  /** One-line team blurb (same field the teams grid shows). Optional until the
-      follow-suggestions endpoint ships it; the UI falls back to `reason`. */
+  /** One-line team blurb (same field the teams grid shows). `reason` takes
+      precedence in the UI — it says why this team is suggested to *you*,
+      which a tagline can't — so this is only the fallback when `reason` is
+      missing or blank. */
   shortDescription?: string | null;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2751/#2752/#2753 (all merged): three prototype-alignment fixes found by comparing the shipped newsfeed redesign against `prototypes/entries/newsfeed/` on mobile.

## 1. Quick Actions — mobile card size

Production reused the desktop `ActionCard` at a reduced width for mobile; the prototype's dedicated `MobileQuickActions` treatment is meaningfully smaller. Brought the mobile-only breakpoint in line, value for value:

| | Before | After |
|---|---|---|
| Card width | 200px | **150px** |
| Card padding | 16px | **14px** |
| Icon | 40px, native SVG size | **32px, SVG forced to 18px** |
| Title | 18px, single-line ellipsis | **14px, 2-line clamp** |
| Description | 14px | **12px** |
| Row gap | 12px | **10px** |

The title's line-clamp isn't cosmetic: a narrower, smaller-font card no longer reliably fits "Book Office Hours" on one line the way the old 200px/18px card did.

`QuickActions` is gated behind `isLoggedIn` on `/home`, which anonymous browsing can't reach — verified via a disposable, never-committed debug route instead. Measured 150px/14px/32px/18px/14px-2-line/12px against the running dev build; all matched the prototype exactly.

## 2. Team News — mobile category filter becomes a "Type:" dropdown

The event-type filter rendered as a wrapping pill row at every width, costing two lines of vertical space on mobile that the prototype's own mobile treatment doesn't spend — it collapses the same filter into a "Type:" dropdown beside "Sort by:", both driven by the same control.

Reuses the existing `SortDropdown` component (already used for "Sort by:" at every width) rather than introducing a new one. This mirrors the prototype's own `NewsfeedPrototype.tsx` exactly — it builds its "Type:" dropdown the same way, off the same `categoriesWithCounts` list, with the same reasoning documented in its own comment:

- Counts fold into the option label (`"Funding (12)"`) since `SortDropdown` options are plain text with no separate count slot.
- Zero-count categories are **dropped** from the list rather than shown disabled — `SortDropdown` has no disabled state today, and a menu offering choices you can't act on is worse than the pill row's visibly-greyed treatment.

The desktop pill row (`.catRow`) is unchanged and hidden only below the mobile breakpoint; the new dropdown is the reverse — both exist in the DOM at every width, only CSS toggles which renders.

**Test fallout:** jsdom doesn't evaluate the hiding media query, so three existing tests started matching "All categories" in two places at once (the pill row and the new dropdown's default label are identical text) and needed scoping to `.catRow`. Four new tests cover the dropdown itself (option list, count-folding, zero-count dropping, click → filter + analytics parity with a pill click, sync with the pill row).

Verified live: Playwright confirms the pill row and the dropdown swap visibility (computed style + `offsetParent`) at 390px vs 1280px, and the rendered mobile page matches the requested design exactly: `Type: All categories ▾  Sort by: Most popular ▾`.

## 3. Teams-to-follow reason — verified, no code change needed

Checked whether the rail card and mobile scroller both show the per-team suggestion reason (not just the tagline) per the original ticket. They already do — shipped in #2751 (rail) and #2753 (scroller): `stripFollowerCountFromReason(team.reason) || team.shortDescription`.

Couldn't verify against real data (the suggestions endpoint requires auth; anonymous browsing returns none), so rendered both components directly with mock data matching the real backend's documented reason format (`"Storage · 1.2k followers"`) through a disposable debug route. Confirmed all three cases: follower-count stripped, a reason with no count shown verbatim, and a blank reason falling back to the tagline — on both surfaces.

Found and fixed one thing while in there: `ISuggestedTeam.shortDescription`'s doc comment still said the UI falls back to `reason` — backwards since the Phase 1 flip. Doc-only, no behavior change.

## Testing

- Full suite: 1414 pass. The one failure (`getCurrentRoundNumber` month boundary) is date-dependent and reproduces on a clean `develop` — unrelated.
- `npm run build` compiles; lint clean across every touched file.
- All three items verified live via Playwright against the running dev server, using disposable debug routes where the real route is gated behind auth or fetched data I don't have. No debug route left in the tree — each was created, screenshotted/measured, and deleted within the same turn, never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
