### PR TITLE
fix(warm-intros-v2): drop PL+1A proximity code from table rows

### DIFF
--- a/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.tsx
+++ b/components/page/investors/WarmIntrosV2Workspace/WarmIntrosV2Table.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode, Ref } from 'react';
 import clsx from 'clsx';
-import { ProximityCodeBadge } from '@/components/page/investors/ProximityCodeBadge/ProximityCodeBadge';
 import { CoInvestmentCountBadge, PlBackingMark } from '@/components/page/investors/PlBackingMark/PlBackingMark';
 import { getDefaultAvatar } from '@/hooks/useDefaultAvatar';
 import type { WarmIntrosV2InvestorSummary, WarmIntrosV2PathListItem } from '@/services/investors/warm-intros-v2.types';
@@ -82,12 +81,7 @@ export function WarmIntrosV2Table({
 
             const leadBadge = (
               <span className={clsx(s.proximityCell, s.joinGroup, s.proximityLead)}>
-                {row.proximityCode ? <ProximityCodeBadge code={row.proximityCode} className={s.joinLeft} /> : null}
-                <ScorePercentPill
-                  scorePercent={row.scorePercent}
-                  scoreBand={row.scoreBand}
-                  className={row.proximityCode ? s.joinRight : undefined}
-                />
+                <ScorePercentPill scorePercent={row.scorePercent} scoreBand={row.scoreBand} />
               </span>
             );
 


### PR DESCRIPTION
## Summary
- Remove the `PL+1A`-style proximity code badge from Warm Intros v2 table rows — the Path column now shows only the score percent pill.

## Test plan
- [ ] Load Warm Intros v2 workspace and confirm the Path column shows only the score percentage (no `PL+1A` pill)
- [ ] Confirm proximity codes still render elsewhere (investor drawer, feedback modal/queue, glossary)
- [ ] `npx eslint` passes on the changed file