### PR TITLE
feat: Team News view counts on feed cards

### DIFF
--- a/__tests__/page/home/news-group-card.test.tsx
+++ b/__tests__/page/home/news-group-card.test.tsx
@@ -67,6 +67,9 @@ const makeItem = (uid: string, eventDate: string, overrides: Partial<ITeamNewsIt
 // Required prop: every row click routes through it (the old open-the-source
 // behavior moved into the detail modal). Cleared by clearAllMocks in setup.
 const noopStoryOpen = jest.fn();
+// Required prop: view-impression recording. Not under test here (that's
+// use-team-news-impressions.test.ts) — this file is about the card's wiring.
+const noopStoryVisible = jest.fn();
 
 const clusterWith = (items: ITeamNewsItem[]): TeamCluster => ({
   teamUid: 'team-1',
@@ -76,6 +79,17 @@ const clusterWith = (items: ITeamNewsItem[]): TeamCluster => ({
 });
 
 describe('NewsGroupCard', () => {
+  beforeAll(() => {
+    // No global mock exists in jest.setup.js (see team-news-modal.test.tsx's
+    // own inline mock) — story rows now call useCardVisibilityTracking.
+    class IO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IO;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseCurrentUserStore.mockReturnValue({ currentUser: null, isHydrated: false });
@@ -83,7 +97,7 @@ describe('NewsGroupCard', () => {
 
   it('renders the team header', () => {
     render(
-      <NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} />,
+      <NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} />,
     );
     expect(screen.getByRole('link', { name: 'Acme' })).toHaveAttribute('href', '/teams/team-1');
   });
@@ -91,7 +105,7 @@ describe('NewsGroupCard', () => {
   it('renders no follow button when onFollowToggle is not provided, even once hydrated', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: { uid: 'm-1' }, isHydrated: true });
     render(
-      <NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} />,
+      <NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} />,
     );
     expect(screen.queryByRole('button', { name: /follow/i })).not.toBeInTheDocument();
   });
@@ -99,7 +113,7 @@ describe('NewsGroupCard', () => {
   it('does not render the follow button before the auth store hydrates, even with onFollowToggle provided', () => {
     render(
       <NewsGroupCard
-        onStoryOpen={noopStoryOpen}
+        onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible}
         cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])}
         onFollowToggle={jest.fn()}
       />,
@@ -112,7 +126,7 @@ describe('NewsGroupCard', () => {
     const onFollowToggle = jest.fn();
     render(
       <NewsGroupCard
-        onStoryOpen={noopStoryOpen}
+        onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible}
         cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])}
         onFollowToggle={onFollowToggle}
       />,
@@ -128,7 +142,7 @@ describe('NewsGroupCard', () => {
     const onFollowToggle = jest.fn();
     render(
       <NewsGroupCard
-        onStoryOpen={noopStoryOpen}
+        onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible}
         cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])}
         isFollowing
         onFollowToggle={onFollowToggle}
@@ -145,7 +159,7 @@ describe('NewsGroupCard', () => {
     const onFollowToggle = jest.fn();
     render(
       <NewsGroupCard
-        onStoryOpen={noopStoryOpen}
+        onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible}
         cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])}
         onFollowToggle={onFollowToggle}
       />,
@@ -158,7 +172,7 @@ describe('NewsGroupCard', () => {
   it('renders a story with its summary when present, and omits the paragraph when absent', () => {
     const withSummary = makeItem('a', '2026-05-03T00:00:00.000Z');
     const withoutSummary = makeItem('b', '2026-05-02T00:00:00.000Z', { summary: null });
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([withSummary, withoutSummary])} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([withSummary, withoutSummary])} />);
     expect(screen.getByText('Summary a')).toBeInTheDocument();
     expect(screen.queryByText('Summary b')).not.toBeInTheDocument();
   });
@@ -169,7 +183,7 @@ describe('NewsGroupCard', () => {
       makeItem('newest', '2026-05-03T00:00:00.000Z'),
       makeItem('middle', '2026-05-02T00:00:00.000Z'),
     ];
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith(items)} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith(items)} />);
     const headlines = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
     expect(headlines).toEqual(['Headline newest', 'Headline middle', 'Headline oldest']);
     expect(screen.queryByRole('button', { name: /view all/i })).not.toBeInTheDocument();
@@ -177,7 +191,7 @@ describe('NewsGroupCard', () => {
 
   it('shows an expander when there are more than 3 stories, and toggles the visible list', () => {
     const items = Array.from({ length: 5 }, (_, i) => makeItem(`s${i}`, `2026-05-0${i + 1}T00:00:00.000Z`));
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith(items)} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith(items)} />);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(3);
     const expander = screen.getByRole('button', { name: 'View all 5 updates from Acme' });
 
@@ -193,7 +207,7 @@ describe('NewsGroupCard', () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     const onStoryOpen = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
-    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} onStoryVisible={noopStoryVisible} />);
 
     fireEvent.click(screen.getByText('Headline a'));
     expect(onStoryOpen).toHaveBeenCalledWith(item);
@@ -205,7 +219,7 @@ describe('NewsGroupCard', () => {
   it('does NOT open the modal from the comment badge — it discloses the thread in place', () => {
     const onStoryOpen = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
-    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} onStoryVisible={noopStoryVisible} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
 
@@ -215,7 +229,7 @@ describe('NewsGroupCard', () => {
 
   it('renders the thread inline, collapsed by default, and toggles it closed again', () => {
     render(
-      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} />,
+      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} />,
     );
 
     // Mount = expanded, so nothing may be mounted before the first click.
@@ -236,7 +250,7 @@ describe('NewsGroupCard', () => {
   it('escalates the inline thread to the modal, flagged as such for analytics', () => {
     const onStoryOpen = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
-    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={clusterWith([item])} onStoryOpen={onStoryOpen} onStoryVisible={noopStoryVisible} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
     // "View all" is the only comment affordance that still reaches the modal.
@@ -249,7 +263,7 @@ describe('NewsGroupCard', () => {
     render(
       <NewsGroupCard
         cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z'), makeItem('b', '2026-05-02T00:00:00.000Z')])}
-        onStoryOpen={noopStoryOpen}
+        onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible}
       />,
     );
 
@@ -261,7 +275,7 @@ describe('NewsGroupCard', () => {
 
   it('refuses to collapse a thread holding an unsettled comment', () => {
     render(
-      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} />,
+      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Comments, show/ }));
@@ -276,7 +290,7 @@ describe('NewsGroupCard', () => {
 
   it('exposes rows as dialog-opening buttons with the title as accessible name', () => {
     render(
-      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={jest.fn()} />,
+      <NewsGroupCard cluster={clusterWith([makeItem('a', '2026-05-03T00:00:00.000Z')])} onStoryOpen={jest.fn()} onStoryVisible={noopStoryVisible} />,
     );
     const row = screen.getByRole('button', { name: 'Headline a' });
     expect(row).toHaveAttribute('aria-haspopup', 'dialog');
@@ -289,7 +303,7 @@ describe('NewsGroupCard', () => {
       makeItem('b', '2026-05-02T00:00:00.000Z'),
       makeItem('c', '2026-05-01T00:00:00.000Z'),
     ];
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith(items)} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith(items)} />);
     const positions = mockSourceList.mock.calls.map(([props]) => props.position);
     expect(positions).toEqual([0, 1, 2]);
   });
@@ -306,8 +320,8 @@ describe('NewsGroupCard', () => {
 
     render(
       <>
-        <NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterA} />
-        <NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterB} />
+        <NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterA} />
+        <NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterB} />
       </>,
     );
 
@@ -318,17 +332,17 @@ describe('NewsGroupCard', () => {
 
   it('resets to collapsed when remounted with a fresh key (simulating a filter change)', () => {
     const items = Array.from({ length: 5 }, (_, i) => makeItem(`s${i}`, `2026-05-0${i + 1}T00:00:00.000Z`));
-    const { rerender } = render(<NewsGroupCard onStoryOpen={noopStoryOpen} key="tab-a" cluster={clusterWith(items)} />);
+    const { rerender } = render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} key="tab-a" cluster={clusterWith(items)} />);
     fireEvent.click(screen.getByRole('button', { name: 'View all 5 updates from Acme' }));
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(5);
 
-    rerender(<NewsGroupCard onStoryOpen={noopStoryOpen} key="tab-b" cluster={clusterWith(items)} />);
+    rerender(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} key="tab-b" cluster={clusterWith(items)} />);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(3);
   });
 
   it("renders an Upvote button reflecting the story's upvote state", () => {
     const item = makeItem('a', '2026-05-03T00:00:00.000Z', { viewerHasUpvoted: true, upvoteCount: 5 });
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([item])} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([item])} />);
     expect(screen.getByRole('button', { name: 'Remove like (5)' })).toBeInTheDocument();
   });
 
@@ -336,7 +350,7 @@ describe('NewsGroupCard', () => {
     mockUseCurrentUserStore.mockReturnValue({ currentUser: null, isHydrated: true });
     const onUpvoteToggle = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([item])} onUpvoteToggle={onUpvoteToggle} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([item])} onUpvoteToggle={onUpvoteToggle} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Like (0)' }));
     expect(onUpvoteToggle).not.toHaveBeenCalled();
@@ -348,7 +362,7 @@ describe('NewsGroupCard', () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     const onUpvoteToggle = jest.fn();
     const item = makeItem('a', '2026-05-03T00:00:00.000Z');
-    render(<NewsGroupCard onStoryOpen={noopStoryOpen} cluster={clusterWith([item])} onUpvoteToggle={onUpvoteToggle} />);
+    render(<NewsGroupCard onStoryOpen={noopStoryOpen} onStoryVisible={noopStoryVisible} cluster={clusterWith([item])} onUpvoteToggle={onUpvoteToggle} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Like (0)' }));
     expect(onUpvoteToggle).toHaveBeenCalledWith(item);

--- a/__tests__/page/home/source-list.test.tsx
+++ b/__tests__/page/home/source-list.test.tsx
@@ -256,6 +256,17 @@ describe('NewsCard with a multi-source item', () => {
 });
 
 describe('NewsGroupCard with a multi-source story', () => {
+  beforeAll(() => {
+    // No global mock exists in jest.setup.js — story rows now call
+    // useCardVisibilityTracking.
+    class IO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IO;
+  });
+
   const story = makeItem('a', { sourceUrls: TWO_SOURCE_URLS, upvoteCount: 3 });
   const cluster: TeamCluster = {
     teamUid: 'team-1',
@@ -264,14 +275,15 @@ describe('NewsGroupCard with a multi-source story', () => {
     items: [story],
   };
   const onStoryOpen = jest.fn();
+  const onStoryVisible = jest.fn();
 
   it('shows the pill in the story row', () => {
-    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} onStoryVisible={onStoryVisible} />);
     expect(screen.getByRole('button', { name: /2 sources/i })).toBeInTheDocument();
   });
 
   it('does not open the story when the pill is activated by keyboard or click', () => {
-    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} onStoryVisible={onStoryVisible} />);
     const pill = screen.getByRole('button', { name: /2 sources/i });
 
     fireEvent.keyDown(pill, { key: 'Enter' });
@@ -282,7 +294,7 @@ describe('NewsGroupCard with a multi-source story', () => {
   });
 
   it('still opens the story on Enter pressed on the row itself', () => {
-    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} />);
+    render(<NewsGroupCard cluster={cluster} onStoryOpen={onStoryOpen} onStoryVisible={onStoryVisible} />);
     const row = document.querySelector('[data-story-uid="a"]') as HTMLElement;
     fireEvent.keyDown(row, { key: 'Enter' });
     expect(onStoryOpen).toHaveBeenCalledWith(story);

--- a/__tests__/page/home/team-news.test.tsx
+++ b/__tests__/page/home/team-news.test.tsx
@@ -213,6 +213,17 @@ const groups: ITeamNewsGroup[] = [
 ];
 
 describe('TeamNews', () => {
+  beforeAll(() => {
+    // No global mock exists in jest.setup.js — feed/band rows now call
+    // useCardVisibilityTracking (view-impression recording).
+    class IO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = IO;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSuggestedTeamsToFollow.mockReturnValue({ suggestions: [], isLoading: false });

--- a/__tests__/page/home/view-count.test.tsx
+++ b/__tests__/page/home/view-count.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { ViewCount } from '@/components/page/home/TeamNews/components/ViewCount/ViewCount';
+
+describe('ViewCount', () => {
+  it('shows "0 Views" when count is 0 (row shape stays stable, matching UpvoteButton)', () => {
+    render(<ViewCount count={0} />);
+    expect(screen.getByText('0 Views')).toBeInTheDocument();
+  });
+
+  it('treats an undefined count the same as 0', () => {
+    render(<ViewCount />);
+    expect(screen.getByText('0 Views')).toBeInTheDocument();
+  });
+
+  it('renders a compact count by default', () => {
+    render(<ViewCount count={1234} />);
+    expect(screen.getByText('1.2k Views')).toBeInTheDocument();
+  });
+
+  it('renders the exact count when exact is set', () => {
+    render(<ViewCount count={1234} exact />);
+    expect(screen.getByText('1,234 Views')).toBeInTheDocument();
+  });
+});

--- a/__tests__/services/team-news/team-news.service.test.ts
+++ b/__tests__/services/team-news/team-news.service.test.ts
@@ -1,4 +1,9 @@
-import { buildTeamNewsByTeamUrl, fetchTeamNewsByTeam } from '@/services/team-news/team-news.service';
+import {
+  buildTeamNewsByTeamUrl,
+  fetchTeamNewsByTeam,
+  recordTeamNewsImpressions,
+  sendTeamNewsImpressionsBeacon,
+} from '@/services/team-news/team-news.service';
 
 describe('buildTeamNewsByTeamUrl', () => {
   const originalEnv = process.env.DIRECTORY_API_URL;
@@ -85,5 +90,106 @@ describe('fetchTeamNewsByTeam', () => {
   it('returns null when fetch throws', async () => {
     fetchMock.mockRejectedValue(new Error('network'));
     await expect(fetchTeamNewsByTeam('team-1')).resolves.toBeNull();
+  });
+});
+
+describe('recordTeamNewsImpressions', () => {
+  const originalEnv = process.env.DIRECTORY_API_URL;
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    process.env.DIRECTORY_API_URL = 'https://api.example.com';
+    global.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    process.env.DIRECTORY_API_URL = originalEnv;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('POSTs the uid batch to the impressions endpoint, unauthenticated', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+
+    await recordTeamNewsImpressions(['n-1', 'n-2']);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/v1/team-news/impressions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newsItemUids: ['n-1', 'n-2'] }),
+      }),
+    );
+  });
+
+  it('splits a batch larger than the server’s 200-uid cap', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    const uids = Array.from({ length: 250 }, (_, i) => `n-${i}`);
+
+    await recordTeamNewsImpressions(uids);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const sentBatches = fetchMock.mock.calls.map(
+      (call) => (JSON.parse(call[1].body as string) as { newsItemUids: string[] }).newsItemUids.length,
+    );
+    expect(sentBatches).toEqual([200, 50]);
+  });
+
+  it('sends exactly one request at the cap boundary', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+
+    await recordTeamNewsImpressions(Array.from({ length: 200 }, (_, i) => `n-${i}`));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let one failed batch stop the others (allSettled, not all)', async () => {
+    const uids = Array.from({ length: 250 }, (_, i) => `n-${i}`);
+    fetchMock
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
+
+    await expect(recordTeamNewsImpressions(uids)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('sendTeamNewsImpressionsBeacon', () => {
+  const originalEnv = process.env.DIRECTORY_API_URL;
+  const sendBeaconMock = jest.fn();
+
+  beforeAll(() => {
+    process.env.DIRECTORY_API_URL = 'https://api.example.com';
+  });
+
+  afterAll(() => {
+    process.env.DIRECTORY_API_URL = originalEnv;
+  });
+
+  beforeEach(() => {
+    sendBeaconMock.mockReset();
+    (navigator as unknown as { sendBeacon: typeof sendBeaconMock }).sendBeacon = sendBeaconMock;
+  });
+
+  it('sends a beacon with the uid batch and returns true on success', () => {
+    sendBeaconMock.mockReturnValue(true);
+
+    const sent = sendTeamNewsImpressionsBeacon(['n-1', 'n-2']);
+
+    expect(sent).toBe(true);
+    expect(sendBeaconMock).toHaveBeenCalledWith('https://api.example.com/v1/team-news/impressions', expect.any(Blob));
+  });
+
+  it('returns false without sending when the queue is empty', () => {
+    expect(sendTeamNewsImpressionsBeacon([])).toBe(false);
+    expect(sendBeaconMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the browser has no sendBeacon support', () => {
+    (navigator as unknown as { sendBeacon: unknown }).sendBeacon = undefined;
+    expect(sendTeamNewsImpressionsBeacon(['n-1'])).toBe(false);
   });
 });

--- a/__tests__/services/team-news/use-team-news-impressions.test.ts
+++ b/__tests__/services/team-news/use-team-news-impressions.test.ts
@@ -1,0 +1,136 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useTeamNewsImpressions } from '@/services/team-news/hooks/useTeamNewsImpressions';
+import { recordTeamNewsImpressions, sendTeamNewsImpressionsBeacon } from '@/services/team-news/team-news.service';
+
+jest.mock('@/services/team-news/team-news.service', () => ({
+  recordTeamNewsImpressions: jest.fn(),
+  sendTeamNewsImpressionsBeacon: jest.fn(),
+}));
+
+const recordMock = recordTeamNewsImpressions as jest.Mock;
+const beaconMock = sendTeamNewsImpressionsBeacon as jest.Mock;
+
+describe('useTeamNewsImpressions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    recordMock.mockReset().mockResolvedValue(undefined);
+    beaconMock.mockReset().mockReturnValue(true);
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes a queued uid after the 1000ms window, batched', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+      result.current.recordVisible('n-2');
+    });
+    expect(recordMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    expect(recordMock).toHaveBeenCalledWith(['n-1', 'n-2']);
+  });
+
+  it('dedupes: the same uid reported twice only records once', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+      result.current.recordVisible('n-1');
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(recordMock).toHaveBeenCalledWith(['n-1']);
+  });
+
+  it('flushes immediately once the queue hits the size threshold, without waiting for the timer', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+    const uids = Array.from({ length: 50 }, (_, i) => `n-${i}`);
+
+    act(() => {
+      uids.forEach((uid) => result.current.recordVisible(uid));
+    });
+
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    expect(recordMock).toHaveBeenCalledWith(uids);
+  });
+
+  it('does not reset the flush timer on each new arrival — a burst within the window still flushes on schedule', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+    });
+    act(() => {
+      jest.advanceTimersByTime(600);
+      result.current.recordVisible('n-2'); // arrives before the window closes
+    });
+    act(() => {
+      jest.advanceTimersByTime(400); // window closes 1000ms after the first arrival, not the second
+    });
+
+    expect(recordMock).toHaveBeenCalledWith(['n-1', 'n-2']);
+  });
+
+  it('starts a fresh window after a flush — a later visible card is not silently dropped', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+      jest.advanceTimersByTime(1000);
+    });
+    expect(recordMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.recordVisible('n-2');
+      jest.advanceTimersByTime(1000);
+    });
+    expect(recordMock).toHaveBeenCalledTimes(2);
+    expect(recordMock).toHaveBeenLastCalledWith(['n-2']);
+  });
+
+  it('flushes via sendBeacon when the tab becomes hidden, and drops the queue on success', () => {
+    const { result } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+    });
+
+    act(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(beaconMock).toHaveBeenCalledWith(['n-1']);
+    // The regular timed flush must not also fire for the same uid.
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('flushes via sendBeacon on unmount as a last resort', () => {
+    const { result, unmount } = renderHook(() => useTeamNewsImpressions());
+
+    act(() => {
+      result.current.recordVisible('n-1');
+    });
+    unmount();
+
+    expect(beaconMock).toHaveBeenCalledWith(['n-1']);
+  });
+
+  it('does nothing on unmount when the queue is already empty', () => {
+    const { unmount } = renderHook(() => useTeamNewsImpressions());
+    unmount();
+    expect(beaconMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/page/home/TeamNews/TeamNews.tsx
+++ b/components/page/home/TeamNews/TeamNews.tsx
@@ -14,6 +14,7 @@ import { useFollowAnalytics, type FollowAnalyticsSource } from '@/analytics/foll
 import { useFollowTeam } from '@/services/follow/hooks/useFollowTeam';
 import { useSuggestedTeamsToFollow } from '@/services/follow/hooks/useSuggestedTeamsToFollow';
 import { useTeamNewsUpvoteToggle } from '@/services/team-news/hooks/useTeamNewsUpvoteToggle';
+import { useTeamNewsImpressions } from '@/services/team-news/hooks/useTeamNewsImpressions';
 import { useFeedForumPostLikeToggle } from '@/services/feed/hooks/useFeedForumPostLikeToggle';
 import { useFeedForumTopicLike } from '@/services/feed/hooks/useFeedComments';
 import { useCurrentUserStore } from '@/services/auth/store';
@@ -139,6 +140,10 @@ export const TeamNews = ({
   const { mutate: followMutate } = useFollowTeam();
   const { mutate: upvoteMutate } = useTeamNewsUpvoteToggle();
   const { mutate: postLikeMutate } = useFeedForumPostLikeToggle();
+  // One instance for the whole page: holds every rendered card's dedup/queue
+  // state, regardless of tab/category remounts below it (see the hook's own
+  // unmount-vs-page-load-scoped comments).
+  const { recordVisible } = useTeamNewsImpressions();
 
   // `groups` is an SSR prop, not a React Query cache — there's nothing here for a
   // useArticleLike-style setQueryData patch to act on. Upvote state is tracked the
@@ -871,6 +876,7 @@ export const TeamNews = ({
                 onFollowToggle={handleFollowToggle}
                 onUpvoteToggle={handleUpvoteToggle}
                 onStoryOpen={handleTopStoryOpen}
+                onStoryVisible={recordVisible}
               />
             </div>
           )}
@@ -932,6 +938,7 @@ export const TeamNews = ({
                           autoExpandStoryUid={
                             scrollTarget?.teamUid === entry.cluster.teamUid ? scrollTarget.storyUid : undefined
                           }
+                          onStoryVisible={recordVisible}
                         />
                       );
                     case 'forum':

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
@@ -351,7 +351,7 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
-  line-height: 18px; /* 150% */
+  //line-height: 18px; /* 150% */
   letter-spacing: -0.2px;
   // Equal-width digits: 0 → 1 → 2 all occupy the same space, so liking never
   // nudges the neighboring actions.
@@ -376,7 +376,7 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
-  line-height: 18px; /* 150% */
+  //line-height: 18px; /* 150% */
   letter-spacing: -0.2px;
   font-variant-numeric: tabular-nums;
 }

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.module.scss
@@ -365,3 +365,18 @@
 .upvoteActive {
   color: #156ff7;
 }
+
+// Read-only sibling to .upvote — same visual weight, no interactive states
+// (no hover/cursor), since view counts aren't clickable.
+.viewCount {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--foreground-neutral-secondary, #455468);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 18px; /* 150% */
+  letter-spacing: -0.2px;
+  font-variant-numeric: tabular-nums;
+}

--- a/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
+++ b/components/page/home/TeamNews/components/NewsCard/NewsCard.tsx
@@ -15,6 +15,7 @@ import { hasNewsSource } from '../../utils/getNewsSources';
 import { UpvoteButton } from './components/UpvoteButton/UpvoteButton';
 import { SourceList } from '../SourceList/SourceList';
 import { TruncatedSummary } from './TruncatedSummary';
+import { ViewCount } from '../ViewCount/ViewCount';
 
 import s from './NewsCard.module.scss';
 
@@ -161,6 +162,7 @@ export const NewsCard = ({
           <span className={s.time}>{formatTimeAgo(item.eventDate)}</span>
         </div>
         <span className={s.actions}>
+          <ViewCount count={item.viewCount} />
           {/* Gated on hydration (like FollowButton) so a pre-hydration click
               can't misread a signed-in viewer as a guest. */}
           {isHydrated && onUpvoteToggle && (

--- a/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
+++ b/components/page/home/TeamNews/components/NewsCard/components/CommentButton/CommentButton.module.scss
@@ -20,7 +20,7 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
-  line-height: 18px; /* 150% */
+  //line-height: 18px; /* 150% */
   letter-spacing: -0.2px;
   // Equal-width digits: a count bump never nudges the neighboring actions.
   font-variant-numeric: tabular-nums;

--- a/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.tsx
+++ b/components/page/home/TeamNews/components/NewsDetailModal/NewsDetailModal.tsx
@@ -18,6 +18,7 @@ import { getNewsSourcesWithPrimaryFallback } from '../../utils/getNewsSources';
 
 import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { NewsShareMenu } from '../NewsShareMenu';
+import { ViewCount } from '../ViewCount/ViewCount';
 import { FeedCommentsThread } from '../FeedCommentsThread/FeedCommentsThread';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
@@ -211,6 +212,7 @@ export function NewsDetailModal({
 
       <div className={s.footer}>
         <span className={s.footerActions}>
+          <ViewCount count={item.viewCount} exact />
           <NewsShareMenu item={item} source="news-modal" variant="button" side="top" onOpenChange={setShareOpen} />
           {/* Gated on hydration (like the feed rows) so a pre-hydration click on a
               deep-linked modal can't misread a signed-in viewer as a guest. */}

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 import { useRouter } from 'next/navigation';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { useCurrentUserStore } from '@/services/auth/store';
+import { useCardVisibilityTracking } from '@/hooks/useCardVisibilityTracking';
 import { FollowButton } from '@/components/ui/FollowButton';
 import type { ITeamNewsItem, TeamCluster } from '@/types/team-news.types';
 import {
@@ -46,6 +47,8 @@ interface NewsGroupCardProps {
    * this card that's beyond VISIBLE_STORIES — forces this card's own truncation
    * open. One-directional (never collapses); see the scroll-to-story plan. */
   autoExpandStoryUid?: string;
+  /** Fired once a story row scrolls into the viewport (view-impression recording). */
+  onStoryVisible: (uid: string) => void;
 }
 
 export function NewsGroupCard({
@@ -56,6 +59,7 @@ export function NewsGroupCard({
   onFollowToggle,
   onUpvoteToggle,
   autoExpandStoryUid,
+  onStoryVisible,
 }: NewsGroupCardProps) {
   const [expanded, toggleExpanded] = useToggle(false);
   const router = useRouter();
@@ -167,84 +171,132 @@ export function NewsGroupCard({
         )}
       </div>
 
-      {visibleStories.map((story, storyIndex) => {
-        const { label, dotClassName } = getEventTypeConfig(story.eventType);
-        return (
-          <div
-            key={story.uid}
-            data-story-uid={story.uid}
-            role="button"
-            aria-haspopup="dialog"
-            // Concise accessible name — without it the row's name is its entire
-            // text content (title + summary + meta), which is screen-reader noise
-            // and collides with other buttons in role queries.
-            aria-label={story.title}
-            tabIndex={0}
-            className={s.storyRow}
-            onClick={() => openStory(story)}
-            onKeyDown={(e) => {
-              // Only act on keys pressed on the row itself — Enter/Space on a
-              // nested control (Like/Share/SourceList) must not also open
-              // the modal. Same guard as NewsCard's handleKeyDown.
-              if (e.target !== e.currentTarget) return;
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                openStory(story);
-              }
-            }}
-          >
-            <h3 className={newsCardStyles.headline}>{story.title}</h3>
-            {story.summary && <p className={s.summary}>{story.summary}</p>}
-            <div className={newsCardStyles.metaLine}>
-              <div className={newsCardStyles.meta}>
-                <span className={newsCardStyles.eventType}>
-                  <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
-                  <span className={newsCardStyles.eventLabel}>{label}</span>
-                </span>
-                {hasNewsSource(story) && (
-                  <>
-                    <span className={newsCardStyles.sep} aria-hidden="true" />
-                    <SourceList item={story} position={storyIndex} analyticsSource={analyticsSource} />
-                  </>
-                )}
-                <span className={newsCardStyles.sep} aria-hidden="true" />
-                <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
-              </div>
-              <div className={newsCardStyles.actions}>
-                <ViewCount count={story.viewCount} />
-                <NewsShareMenu item={story} source={analyticsSource} />
-                <UpvoteButton
-                  count={story.upvoteCount ?? 0}
-                  voted={Boolean(story.viewerHasUpvoted)}
-                  onToggle={() => handleUpvoteClick(story)}
-                />
-                <CommentButton
-                  itemUid={story.uid}
-                  open={openThreadUids.has(story.uid)}
-                  onToggle={() => handleThreadToggle(story.uid)}
-                  controls={feedThreadDomId(story.uid)}
-                />
-              </div>
-            </div>
-            {/* Mount = expanded (the lazy comments query keys off it). */}
-            {openThreadUids.has(story.uid) && (
-              <FeedCommentsThread
-                itemUid={story.uid}
-                kind="news"
-                source={analyticsSource}
-                onViewAll={() => onStoryOpen(story, 'view-all-comments')}
-                onSignIn={() => handleThreadSignIn(story.uid)}
-                onBusyChange={(busy) => setThreadBusy(story.uid, busy)}
-              />
-            )}
-          </div>
-        );
-      })}
+      {visibleStories.map((story, storyIndex) => (
+        <StoryRow
+          key={story.uid}
+          story={story}
+          storyIndex={storyIndex}
+          analyticsSource={analyticsSource}
+          isThreadOpen={openThreadUids.has(story.uid)}
+          onOpen={() => openStory(story)}
+          onUpvoteClick={() => handleUpvoteClick(story)}
+          onThreadToggle={() => handleThreadToggle(story.uid)}
+          onThreadViewAll={() => onStoryOpen(story, 'view-all-comments')}
+          onThreadSignIn={() => handleThreadSignIn(story.uid)}
+          onThreadBusyChange={(busy) => setThreadBusy(story.uid, busy)}
+          onVisible={onStoryVisible}
+        />
+      ))}
 
       {hiddenCount > 0 && (
         <button type="button" className={s.expander} aria-expanded={expanded} onClick={toggleExpanded}>
           {expanded ? 'Show less' : `View all ${stories.length} updates from ${cluster.teamName}`}
         </button>
+      )}
+    </div>
+  );
+}
+
+interface StoryRowProps {
+  story: ITeamNewsItem;
+  storyIndex: number;
+  analyticsSource: TeamNewsAnalyticsSource;
+  isThreadOpen: boolean;
+  onOpen: () => void;
+  onUpvoteClick: () => void;
+  onThreadToggle: () => void;
+  onThreadViewAll: () => void;
+  onThreadSignIn: () => void;
+  onThreadBusyChange: (busy: boolean) => void;
+  onVisible: (uid: string) => void;
+}
+
+// Extracted so useCardVisibilityTracking has a legal, stable hook call site —
+// it can't be called directly inside the `visibleStories.map()` callback
+// above (rules of hooks). Same file as NewsGroupCard, not a new one; nothing
+// about this row is reused elsewhere. A row unmounts on collapse ("Show
+// less") or a tab/category change (composite-key remount) without losing any
+// already-queued impression — the queue lives one level up, in TeamNews.tsx's
+// useTeamNewsImpressions instance.
+function StoryRow({
+  story,
+  storyIndex,
+  analyticsSource,
+  isThreadOpen,
+  onOpen,
+  onUpvoteClick,
+  onThreadToggle,
+  onThreadViewAll,
+  onThreadSignIn,
+  onThreadBusyChange,
+  onVisible,
+}: StoryRowProps) {
+  const { label, dotClassName } = getEventTypeConfig(story.eventType);
+
+  // Memoized so this row's IntersectionObserver isn't torn down/rebuilt on
+  // every unrelated re-render of the card (e.g. a sibling row's thread
+  // toggling).
+  const handleVisible = useCallback(() => onVisible(story.uid), [onVisible, story.uid]);
+  const rowRef = useCardVisibilityTracking<HTMLDivElement>({ onVisible: handleVisible, threshold: 0.5, trackOnce: true });
+
+  return (
+    <div
+      ref={rowRef}
+      data-story-uid={story.uid}
+      role="button"
+      aria-haspopup="dialog"
+      // Concise accessible name — without it the row's name is its entire
+      // text content (title + summary + meta), which is screen-reader noise
+      // and collides with other buttons in role queries.
+      aria-label={story.title}
+      tabIndex={0}
+      className={s.storyRow}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        // Only act on keys pressed on the row itself — Enter/Space on a
+        // nested control (Like/Share/SourceList) must not also open
+        // the modal. Same guard as NewsCard's handleKeyDown.
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      <h3 className={newsCardStyles.headline}>{story.title}</h3>
+      {story.summary && <p className={s.summary}>{story.summary}</p>}
+      <div className={newsCardStyles.metaLine}>
+        <div className={newsCardStyles.meta}>
+          <span className={newsCardStyles.eventType}>
+            <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
+            <span className={newsCardStyles.eventLabel}>{label}</span>
+          </span>
+          {hasNewsSource(story) && (
+            <>
+              <span className={newsCardStyles.sep} aria-hidden="true" />
+              <SourceList item={story} position={storyIndex} analyticsSource={analyticsSource} />
+            </>
+          )}
+          <span className={newsCardStyles.sep} aria-hidden="true" />
+          <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
+        </div>
+        <div className={newsCardStyles.actions}>
+          <ViewCount count={story.viewCount} />
+          <NewsShareMenu item={story} source={analyticsSource} />
+          <UpvoteButton count={story.upvoteCount ?? 0} voted={Boolean(story.viewerHasUpvoted)} onToggle={onUpvoteClick} />
+          <CommentButton itemUid={story.uid} open={isThreadOpen} onToggle={onThreadToggle} controls={feedThreadDomId(story.uid)} />
+        </div>
+      </div>
+      {/* Mount = expanded (the lazy comments query keys off it). */}
+      {isThreadOpen && (
+        <FeedCommentsThread
+          itemUid={story.uid}
+          kind="news"
+          source={analyticsSource}
+          onViewAll={onThreadViewAll}
+          onSignIn={onThreadSignIn}
+          onBusyChange={onThreadBusyChange}
+        />
       )}
     </div>
   );

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -237,7 +237,11 @@ function StoryRow({
   // every unrelated re-render of the card (e.g. a sibling row's thread
   // toggling).
   const handleVisible = useCallback(() => onVisible(story.uid), [onVisible, story.uid]);
-  const rowRef = useCardVisibilityTracking<HTMLDivElement>({ onVisible: handleVisible, threshold: 0.5, trackOnce: true });
+  const rowRef = useCardVisibilityTracking<HTMLDivElement>({
+    onVisible: handleVisible,
+    threshold: 0.5,
+    trackOnce: true,
+  });
 
   return (
     <div
@@ -281,10 +285,19 @@ function StoryRow({
           <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
         </div>
         <div className={newsCardStyles.actions}>
-          <ViewCount count={story.viewCount} />
           <NewsShareMenu item={story} source={analyticsSource} />
-          <UpvoteButton count={story.upvoteCount ?? 0} voted={Boolean(story.viewerHasUpvoted)} onToggle={onUpvoteClick} />
-          <CommentButton itemUid={story.uid} open={isThreadOpen} onToggle={onThreadToggle} controls={feedThreadDomId(story.uid)} />
+          <ViewCount count={story.viewCount} />
+          <UpvoteButton
+            count={story.upvoteCount ?? 0}
+            voted={Boolean(story.viewerHasUpvoted)}
+            onToggle={onUpvoteClick}
+          />
+          <CommentButton
+            itemUid={story.uid}
+            open={isThreadOpen}
+            onToggle={onThreadToggle}
+            controls={feedThreadDomId(story.uid)}
+          />
         </div>
       </div>
       {/* Mount = expanded (the lazy comments query keys off it). */}

--- a/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
+++ b/components/page/home/TeamNews/components/NewsGroupCard/NewsGroupCard.tsx
@@ -20,6 +20,7 @@ import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { NewsShareMenu } from '../NewsShareMenu';
 import { SourceList } from '../SourceList/SourceList';
+import { ViewCount } from '../ViewCount/ViewCount';
 import { FeedCommentsThread, feedThreadDomId } from '../FeedCommentsThread/FeedCommentsThread';
 import { hasNewsSource } from '../../utils/getNewsSources';
 
@@ -210,6 +211,7 @@ export function NewsGroupCard({
                 <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
               </div>
               <div className={newsCardStyles.actions}>
+                <ViewCount count={story.viewCount} />
                 <NewsShareMenu item={story} source={analyticsSource} />
                 <UpvoteButton
                   count={story.upvoteCount ?? 0}

--- a/components/page/home/TeamNews/components/NewsShareMenu/NewsShareMenu.module.scss
+++ b/components/page/home/TeamNews/components/NewsShareMenu/NewsShareMenu.module.scss
@@ -33,7 +33,7 @@
   font-family: inherit;
   font-size: 12px;
   font-weight: 400;
-  line-height: 18px;
+  //line-height: 18px;
   letter-spacing: -0.2px;
   color: var(--foreground-neutral-secondary, #455468);
   cursor: pointer;

--- a/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { useCurrentUserStore } from '@/services/auth/store';
+import { useCardVisibilityTracking } from '@/hooks/useCardVisibilityTracking';
 import { FollowButton } from '@/components/ui/FollowButton';
 import { useTeamNewsAnalytics, type TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import type { ITeamNewsItem } from '@/types/team-news.types';
@@ -36,6 +37,8 @@ interface TopStoriesBlockProps {
    *  math: block items are not in `visibleEntries`, so the feed's findIndex
    *  would report -1 for every one of them. */
   onStoryOpen: (item: ITeamNewsItem, slot: TopStorySlot, position: number) => void;
+  /** Fired once a card (lead or row) scrolls into the viewport (view-impression recording). */
+  onStoryVisible: (uid: string) => void;
   analyticsSource?: TeamNewsAnalyticsSource;
 }
 
@@ -58,6 +61,7 @@ export function TopStoriesBlock({
   onFollowToggle,
   onUpvoteToggle,
   onStoryOpen,
+  onStoryVisible,
   analyticsSource = 'home',
 }: TopStoriesBlockProps) {
   const router = useRouter();
@@ -98,91 +102,118 @@ export function TopStoriesBlock({
         onFollowToggle={onFollowToggle}
         onUpvoteToggle={onUpvoteToggle}
         onOpen={(item) => onStoryOpen(item, 'lead', 0)}
+        onVisible={onStoryVisible}
         analyticsSource={analyticsSource}
       />
 
       {also.length > 0 && (
         <ul className={s.alsoList}>
-          {also.map((item, index) => {
-            const { label: eventTypeLabel, dotClassName } = getEventTypeConfig(item.eventType);
-            const isFollowing = followedTeamUids.has(item.teamUid);
-            return (
-              <li key={item.uid} className={s.alsoRow}>
-                <div className={newsCardStyles.head}>
-                  {item.teamLogoUrl ? (
-                    <img className={newsCardStyles.logo} src={item.teamLogoUrl} alt="" loading="lazy" />
-                  ) : (
-                    <div className={newsCardStyles.logoFallback}>{getTeamLogoFallback(item.teamName)}</div>
-                  )}
-                  <a
-                    href={`/teams/${item.teamUid}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={newsCardStyles.teamName}
-                  >
-                    {item.teamName}
-                  </a>
-                  {isHydrated && (
-                    <FollowButton
-                      following={isFollowing}
-                      onClick={handleFollowClick(item)}
-                      name={item.teamName}
-                      size="compact"
-                    />
-                  )}
-                </div>
-
-                {/* The headline is the click target, not the row: the row holds a
-                    Follow button and a team link, and a button can't nest inside
-                    a button (production hit exactly this in ReferRoleRow). */}
-                <button
-                  type="button"
-                  aria-haspopup="dialog"
-                  aria-label={item.title}
-                  className={s.alsoTitleBtn}
-                  onClick={() => onStoryOpen(item, 'row', index + 1)}
-                >
-                  <span className={s.alsoTitle}>{item.title}</span>
-                </button>
-
-                {item.summary && <p className={s.alsoSummary}>{item.summary}</p>}
-
-                <div className={newsCardStyles.metaLine}>
-                  <div className={newsCardStyles.meta}>
-                    <span className={newsCardStyles.eventType}>
-                      <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
-                      <span className={newsCardStyles.eventLabel}>{eventTypeLabel}</span>
-                    </span>
-                    {hasNewsSource(item) && (
-                      <>
-                        <span className={newsCardStyles.sep} aria-hidden="true" />
-                        <SourceList item={item} position={index + 1} analyticsSource={analyticsSource} />
-                      </>
-                    )}
-                    <span className={newsCardStyles.sep} aria-hidden="true" />
-                    <span className={newsCardStyles.time}>{formatTimeAgo(item.eventDate)}</span>
-                  </div>
-                  <div className={newsCardStyles.actions}>
-                    <ViewCount count={item.viewCount} />
-                    <NewsShareMenu item={item} source={analyticsSource} />
-                    <UpvoteButton
-                      count={item.upvoteCount ?? 0}
-                      voted={Boolean(item.viewerHasUpvoted)}
-                      onToggle={handleUpvoteClick(item)}
-                    />
-                    <CommentButton
-                      itemUid={item.uid}
-                      open={false}
-                      onToggle={() => onStoryOpen(item, 'row', index + 1)}
-                      opensDetail
-                    />
-                  </div>
-                </div>
-              </li>
-            );
-          })}
+          {also.map((item, index) => (
+            <AlsoRow
+              key={item.uid}
+              item={item}
+              index={index}
+              isFollowing={followedTeamUids.has(item.teamUid)}
+              isHydrated={isHydrated}
+              analyticsSource={analyticsSource}
+              onFollowClick={handleFollowClick(item)}
+              onUpvoteClick={handleUpvoteClick(item)}
+              onOpen={() => onStoryOpen(item, 'row', index + 1)}
+              onVisible={onStoryVisible}
+            />
+          ))}
         </ul>
       )}
     </section>
+  );
+}
+
+interface AlsoRowProps {
+  item: ITeamNewsItem;
+  index: number;
+  isFollowing: boolean;
+  isHydrated: boolean;
+  analyticsSource: TeamNewsAnalyticsSource;
+  onFollowClick: (e: React.MouseEvent) => void;
+  onUpvoteClick: () => void;
+  onOpen: () => void;
+  onVisible: (uid: string) => void;
+}
+
+// Extracted so useCardVisibilityTracking has a legal, stable hook call site —
+// it can't be called directly inside the `also.map()` callback above (rules
+// of hooks). Same file as TopStoriesBlock, not a new one; nothing about this
+// row is reused elsewhere.
+function AlsoRow({
+  item,
+  index,
+  isFollowing,
+  isHydrated,
+  analyticsSource,
+  onFollowClick,
+  onUpvoteClick,
+  onOpen,
+  onVisible,
+}: AlsoRowProps) {
+  const { label: eventTypeLabel, dotClassName } = getEventTypeConfig(item.eventType);
+
+  // Memoized so this row's IntersectionObserver isn't torn down/rebuilt on
+  // every unrelated re-render of the block.
+  const handleVisible = useCallback(() => onVisible(item.uid), [onVisible, item.uid]);
+  const rowRef = useCardVisibilityTracking<HTMLLIElement>({ onVisible: handleVisible, threshold: 0.5, trackOnce: true });
+
+  return (
+    <li ref={rowRef} className={s.alsoRow}>
+      <div className={newsCardStyles.head}>
+        {item.teamLogoUrl ? (
+          <img className={newsCardStyles.logo} src={item.teamLogoUrl} alt="" loading="lazy" />
+        ) : (
+          <div className={newsCardStyles.logoFallback}>{getTeamLogoFallback(item.teamName)}</div>
+        )}
+        <a
+          href={`/teams/${item.teamUid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={newsCardStyles.teamName}
+        >
+          {item.teamName}
+        </a>
+        {isHydrated && (
+          <FollowButton following={isFollowing} onClick={onFollowClick} name={item.teamName} size="compact" />
+        )}
+      </div>
+
+      {/* The headline is the click target, not the row: the row holds a
+          Follow button and a team link, and a button can't nest inside
+          a button (production hit exactly this in ReferRoleRow). */}
+      <button type="button" aria-haspopup="dialog" aria-label={item.title} className={s.alsoTitleBtn} onClick={onOpen}>
+        <span className={s.alsoTitle}>{item.title}</span>
+      </button>
+
+      {item.summary && <p className={s.alsoSummary}>{item.summary}</p>}
+
+      <div className={newsCardStyles.metaLine}>
+        <div className={newsCardStyles.meta}>
+          <span className={newsCardStyles.eventType}>
+            <span className={`${newsCardStyles.eventDot} ${dotClassName}`} aria-hidden="true" />
+            <span className={newsCardStyles.eventLabel}>{eventTypeLabel}</span>
+          </span>
+          {hasNewsSource(item) && (
+            <>
+              <span className={newsCardStyles.sep} aria-hidden="true" />
+              <SourceList item={item} position={index + 1} analyticsSource={analyticsSource} />
+            </>
+          )}
+          <span className={newsCardStyles.sep} aria-hidden="true" />
+          <span className={newsCardStyles.time}>{formatTimeAgo(item.eventDate)}</span>
+        </div>
+        <div className={newsCardStyles.actions}>
+          <ViewCount count={item.viewCount} />
+          <NewsShareMenu item={item} source={analyticsSource} />
+          <UpvoteButton count={item.upvoteCount ?? 0} voted={Boolean(item.viewerHasUpvoted)} onToggle={onUpvoteClick} />
+          <CommentButton itemUid={item.uid} open={false} onToggle={onOpen} opensDetail />
+        </div>
+      </div>
+    </li>
   );
 }

--- a/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoriesBlock.tsx
@@ -16,6 +16,7 @@ import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { NewsShareMenu } from '../NewsShareMenu';
 import { SourceList } from '../SourceList/SourceList';
+import { ViewCount } from '../ViewCount/ViewCount';
 import { TopStoryCard } from './TopStoryCard';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
@@ -162,6 +163,7 @@ export function TopStoriesBlock({
                     <span className={newsCardStyles.time}>{formatTimeAgo(item.eventDate)}</span>
                   </div>
                   <div className={newsCardStyles.actions}>
+                    <ViewCount count={item.viewCount} />
                     <NewsShareMenu item={item} source={analyticsSource} />
                     <UpvoteButton
                       count={item.upvoteCount ?? 0}

--- a/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { SVGProps } from 'react';
+import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { useCurrentUserStore } from '@/services/auth/store';
+import { useCardVisibilityTracking } from '@/hooks/useCardVisibilityTracking';
 import { FollowButton } from '@/components/ui/FollowButton';
 import type { TeamNewsAnalyticsSource } from '@/analytics/team-news.analytics';
 import type { ITeamNewsItem } from '@/types/team-news.types';
@@ -51,6 +53,8 @@ interface TopStoryCardProps {
   onFollowToggle: (teamUid: string, teamName: string, isCurrentlyFollowing: boolean) => void;
   onUpvoteToggle: (item: ITeamNewsItem) => void;
   onOpen: (item: ITeamNewsItem) => void;
+  /** Fired once this card scrolls into the viewport (view-impression recording). */
+  onVisible: (uid: string) => void;
   analyticsSource?: TeamNewsAnalyticsSource;
 }
 
@@ -74,11 +78,19 @@ export function TopStoryCard({
   onFollowToggle,
   onUpvoteToggle,
   onOpen,
+  onVisible,
   analyticsSource = 'home',
 }: TopStoryCardProps) {
   const router = useRouter();
   const { currentUser, isHydrated } = useCurrentUserStore();
   const { label: eventTypeLabel, dotClassName } = getEventTypeConfig(story.eventType);
+
+  // Memoized so this row's IntersectionObserver isn't torn down/rebuilt on
+  // every unrelated re-render — an inline arrow here would be a fresh
+  // reference every render, and useCardVisibilityTracking's effect depends
+  // on `onVisible`.
+  const handleVisible = useCallback(() => onVisible(story.uid), [onVisible, story.uid]);
+  const cardRef = useCardVisibilityTracking<HTMLElement>({ onVisible: handleVisible, threshold: 0.5, trackOnce: true });
 
   const requireSignIn = () => {
     router.push(`${window.location.pathname}${window.location.search}#login`, { scroll: false });
@@ -96,7 +108,7 @@ export function TopStoryCard({
   };
 
   return (
-    <article className={isOnly ? `${s.lead} ${s.leadOnly}` : s.lead}>
+    <article ref={cardRef} className={isOnly ? `${s.lead} ${s.leadOnly}` : s.lead}>
       <div className={s.eyebrow}>
         <span className={s.badge}>
           <PinFilledIcon className={s.badgeIcon} aria-hidden />

--- a/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
+++ b/components/page/home/TeamNews/components/TopStories/TopStoryCard.tsx
@@ -16,6 +16,7 @@ import { UpvoteButton } from '../NewsCard/components/UpvoteButton';
 import { CommentButton } from '../NewsCard/components/CommentButton/CommentButton';
 import { NewsShareMenu } from '../NewsShareMenu';
 import { SourceList } from '../SourceList/SourceList';
+import { ViewCount } from '../ViewCount/ViewCount';
 
 import newsCardStyles from '../NewsCard/NewsCard.module.scss';
 import s from './TopStories.module.scss';
@@ -155,6 +156,7 @@ export function TopStoryCard({
           <span className={newsCardStyles.time}>{formatTimeAgo(story.eventDate)}</span>
         </div>
         <div className={newsCardStyles.actions}>
+          <ViewCount count={story.viewCount} />
           <NewsShareMenu item={story} source={analyticsSource} />
           <UpvoteButton
             count={story.upvoteCount ?? 0}

--- a/components/page/home/TeamNews/components/ViewCount/ViewCount.tsx
+++ b/components/page/home/TeamNews/components/ViewCount/ViewCount.tsx
@@ -1,0 +1,25 @@
+import { EyeIcon } from '@/components/icons';
+import { formatNumber } from '@/utils/home.utils';
+
+import newsCardStyles from '../NewsCard/NewsCard.module.scss';
+
+interface ViewCountProps {
+  count?: number;
+  /** Exact (toLocaleString) instead of compact ("1.2k") — detail views only. */
+  exact?: boolean;
+}
+
+// Read-only, unlike the interactive Like/Comment controls beside it — no
+// button, no onClick. Always renders, including "0 Views": matches
+// UpvoteButton's own always-show-the-count behavior so the row's shape
+// doesn't shift as counts arrive.
+export function ViewCount({ count, exact = false }: ViewCountProps) {
+  const value = count ?? 0;
+  const label = exact ? value.toLocaleString() : formatNumber(value);
+  return (
+    <span className={newsCardStyles.viewCount}>
+      <EyeIcon width={16} height={13} />
+      {label} Views
+    </span>
+  );
+}

--- a/services/team-news/hooks/useTeamNewsImpressions.ts
+++ b/services/team-news/hooks/useTeamNewsImpressions.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { recordTeamNewsImpressions, sendTeamNewsImpressionsBeacon } from '../team-news.service';
+
+const FLUSH_DELAY_MS = 1000;
+const FLUSH_SIZE_THRESHOLD = 50;
+
+/**
+ * Owns view-impression recording for one page load: cards report visibility
+ * via `recordVisible(uid)`, which dedupes, queues, and flushes batched POSTs.
+ * In-memory only — never persisted — so a revisit/refresh can record fresh
+ * impressions (see the brainstorm's "rises on revisit" scenario).
+ */
+export function useTeamNewsImpressions() {
+  const recordedRef = useRef<Set<string>>(new Set());
+  const queueRef = useRef<string[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (queueRef.current.length === 0) return;
+    const uids = queueRef.current;
+    queueRef.current = [];
+    // Best-effort: no retry on failure. This is a "was it seen" signal, not
+    // a critical write — a dropped batch just under-counts, same tolerance
+    // the raw, non-deduplicated backend counter already accepts.
+    recordTeamNewsImpressions(uids).catch(() => {});
+  }, []);
+
+  const recordVisible = useCallback(
+    (uid: string) => {
+      // Dedup lives solely in recordedRef — once a uid is added here it's
+      // also pushed to queueRef in the same call, so there's no separate
+      // queue-membership check to make.
+      if (recordedRef.current.has(uid)) return;
+      recordedRef.current.add(uid);
+      queueRef.current.push(uid);
+
+      // Size-or-time flush: bounds payload growth during a fast scroll, not
+      // just latency.
+      if (queueRef.current.length >= FLUSH_SIZE_THRESHOLD) {
+        flush();
+        return;
+      }
+      // Fixed-delay batching window: the first visible card in a burst starts
+      // the timer; everything that becomes visible before it fires joins the
+      // same batch. Not reset per-arrival — a reset would let continuous
+      // scrolling postpone the flush indefinitely.
+      if (!timerRef.current) {
+        timerRef.current = setTimeout(flush, FLUSH_DELAY_MS);
+      }
+    },
+    [flush],
+  );
+
+  // Leave-flush: fires on an actual tab hide/close (visibilitychange), not
+  // just SPA-internal unmount, via sendBeacon — a plain fetch here can be
+  // aborted mid-flight when the tab really closes; sendBeacon is built to
+  // survive it.
+  useEffect(() => {
+    const flushViaBeacon = () => {
+      if (queueRef.current.length === 0) return;
+      const sent = sendTeamNewsImpressionsBeacon(queueRef.current);
+      if (sent) queueRef.current = [];
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushViaBeacon();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      flushViaBeacon(); // SPA-internal unmount: best-effort, same tolerance as above
+    };
+  }, []);
+
+  return { recordVisible };
+}

--- a/services/team-news/team-news.service.ts
+++ b/services/team-news/team-news.service.ts
@@ -112,3 +112,39 @@ export async function toggleTeamNewsUpvote(uid: string, upvoted: boolean): Promi
   if (!response?.ok) throw new Error('Failed to toggle team news upvote');
   return (await response.json()) as ITeamNewsUpvoteStatus;
 }
+
+// ── View impressions ─────────────────────────────────────────────────────────
+
+const IMPRESSIONS_BATCH_SIZE = 200;
+
+// Public endpoint (no auth needed/sent — signed-out visitors record views the
+// same as signed-in ones). Every occurrence of a uid increments viewCount by
+// 1 server-side; unknown uids are silently ignored.
+export async function recordTeamNewsImpressions(uids: string[]): Promise<void> {
+  const batches: string[][] = [];
+  for (let i = 0; i < uids.length; i += IMPRESSIONS_BATCH_SIZE) {
+    batches.push(uids.slice(i, i + IMPRESSIONS_BATCH_SIZE));
+  }
+  // allSettled, not all: each chunk is independently best-effort — one
+  // rejected batch shouldn't be entangled with the others' outcomes.
+  await Promise.allSettled(batches.map(postImpressionsBatch));
+}
+
+async function postImpressionsBatch(newsItemUids: string[]): Promise<void> {
+  const response = await fetch(`${process.env.DIRECTORY_API_URL}/v1/team-news/impressions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ newsItemUids }),
+  });
+  if (!response.ok) throw new Error('Failed to record team news impressions');
+}
+
+// Used only for the leave-flush (see useTeamNewsImpressions): sendBeacon
+// survives an actual tab-close/navigation, where a plain fetch can be
+// aborted mid-flight. Returns false (caller keeps its queue) if the browser
+// can't accept the beacon, so nothing is silently dropped.
+export function sendTeamNewsImpressionsBeacon(uids: string[]): boolean {
+  if (typeof navigator === 'undefined' || !navigator.sendBeacon || uids.length === 0) return false;
+  const blob = new Blob([JSON.stringify({ newsItemUids: uids })], { type: 'application/json' });
+  return navigator.sendBeacon(`${process.env.DIRECTORY_API_URL}/v1/team-news/impressions`, blob);
+}

--- a/types/team-news.types.ts
+++ b/types/team-news.types.ts
@@ -38,6 +38,9 @@ export interface ITeamNewsItem {
   upvoteCount?: number;
   /** 1 = Top Stories lead, 2–3 = runners-up; null/absent when not featured. */
   editorialRank?: number | null;
+  /** Raw feed-card impression count, not deduplicated by user/session/repeat
+   *  viewing. Incremented via POST /v1/team-news/impressions. */
+  viewCount?: number;
 }
 
 /** Returned by POST/DELETE /v1/team-news/:uid/upvote and carried on every news item. */


### PR DESCRIPTION
## Summary
- Display `viewCount` on Team News feed cards — compact ("1.2k Views") on cards, exact count in the detail modal — via a shared `ViewCount` component wired into `NewsCard`, `NewsGroupCard`, `TopStoryCard`, `TopStoriesBlock`, and `NewsDetailModal`.
- Record views via a new `useTeamNewsImpressions` hook: cards report visibility through the existing `useCardVisibilityTracking` (viewport-triggered, not on mount), deduped in-memory per page load, batched (size-or-time: 50 items / 1000ms) into `POST /v1/team-news/impressions`. Leave-flush uses `sendBeacon` on `visibilitychange`/unmount so an actual tab-close doesn't drop an in-flight request.
- Signed-in and signed-out users see identical behavior — no auth gating, matching the unauthenticated impressions endpoint.

## Backend dependency
Built against the confirmed contract on `feat/team-news-view-counts` (backend PR memser-spaceport/pln-directory-portal#3325): `TeamNewsItemSchema.viewCount` and `POST /v1/team-news/impressions`. **That backend PR is not yet merged to develop** — this FE PR will compile and pass its unit tests, but live view counts/impressions won't work against dev until it lands. Smoke-test after the backend merges.

## Key decisions
- `NewsGroupCard`/`TopStoriesBlock` each gained one same-file local row component (`StoryRow`/`AlsoRow`) so `useCardVisibilityTracking` has a legal per-row hook call site — can't call a hook inside a `.map()` callback.
- Each row's `onVisible` is wrapped in its own `useCallback` so the row's `IntersectionObserver` doesn't get torn down/rebuilt on unrelated re-renders.
- Dedup is in-memory only, not persisted — a revisit/refresh can record fresh impressions (per the accepted "rises on revisit" scenario, not live/optimistic).

Full design rationale: `docs/brainstorms/2026-08-10-team-news-view-counts-brainstorm.md` and `docs/plans/2026-08-10-feat-team-news-view-counts-plan.md` (both gitignored, local-only).

## Testing
- New tests: `recordTeamNewsImpressions`/`sendTeamNewsImpressionsBeacon` (batching, chunking, allSettled semantics), `useTeamNewsImpressions` (dedup, size-or-time flush, beacon leave-flush), `ViewCount` (zero/compact/exact formatting)
- Existing `NewsGroupCard`/`source-list`/`team-news` tests updated with the new required `onStoryVisible` prop and inline `IntersectionObserver` mocks
- Full suite: 1434 passing (1 pre-existing, unrelated date-boundary failure confirmed identical on a clean `develop` checkout)
- `npm run lint` and `tsc --noEmit` clean on all touched files

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)