### PR TITLE
feat(agent-sessions): add admin chat tab to the session detail page

### DIFF
--- a/__tests__/page/agent-sessions/agent-session-chat.test.tsx
+++ b/__tests__/page/agent-sessions/agent-session-chat.test.tsx
@@ -1,0 +1,192 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// react-markdown@9 is ESM-only and next/jest does not transform it. Stubbing it
+// keeps these tests focused on what this component owns: which messages render,
+// which side they land on, and when sending is allowed.
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+import { AgentSessionChat } from '@/components/page/agent-sessions/AgentSessionChat';
+import {
+  useAgentSessionMessages,
+  useSendAgentSessionMessage,
+} from '@/services/agent-sessions/hooks/useAgentSessionMessages';
+import type { AgentSession, AgentSessionMessage } from '@/services/agent-sessions/agent-sessions.service';
+
+jest.mock('@/services/agent-sessions/hooks/useAgentSessionMessages', () => ({
+  useAgentSessionMessages: jest.fn(),
+  useSendAgentSessionMessage: jest.fn(),
+}));
+
+const mockUseMessages = useAgentSessionMessages as jest.MockedFunction<typeof useAgentSessionMessages>;
+const mockUseSend = useSendAgentSessionMessage as jest.MockedFunction<typeof useSendAgentSessionMessage>;
+
+const mockMutateAsync = jest.fn();
+
+const message = (overrides: Partial<AgentSessionMessage> = {}): AgentSessionMessage => ({
+  id: '1',
+  task_id: 'task-1',
+  execution_id: null,
+  sender: 'agent',
+  message_type: 'reply',
+  body: 'body text',
+  created_at: '2026-08-11T08:00:00.000Z',
+  ...overrides,
+});
+
+const session = (overrides: Partial<AgentSession> = {}): AgentSession =>
+  ({
+    id: 'task-1',
+    status: 'running',
+    working_branch: 'agent/fix-task-1',
+    error_message: null,
+    ...overrides,
+  }) as AgentSession;
+
+function setMessages(items: AgentSessionMessage[]) {
+  mockUseMessages.mockReturnValue({
+    data: items,
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useAgentSessionMessages>);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMutateAsync.mockResolvedValue({});
+  mockUseSend.mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof useSendAgentSessionMessage>);
+  setMessages([]);
+});
+
+describe('AgentSessionChat thread', () => {
+  it('hides status narration but keeps the conversation', () => {
+    setMessages([
+      message({ id: '1', sender: 'admin', message_type: 'instruction', body: 'add a page' }),
+      message({ id: '2', message_type: 'status', body: 'Cloning repository' }),
+      message({ id: '3', message_type: 'reply', body: 'I added the page' }),
+    ]);
+
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('add a page')).toBeInTheDocument();
+    expect(screen.getByText('I added the page')).toBeInTheDocument();
+    expect(screen.queryByText('Cloning repository')).not.toBeInTheDocument();
+  });
+
+  // Guards the denylist against ever being rewritten as an allowlist: a message
+  // type nobody has seen yet must show up, not disappear.
+  it('renders an unknown message type rather than dropping it', () => {
+    setMessages([message({ id: '9', message_type: 'clarification', body: 'a brand new type' })]);
+
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('a brand new type')).toBeInTheDocument();
+  });
+
+  // An admin's follow-up arrives as `instruction` — the same type as the original
+  // prompt — so anything deriving alignment from message_type puts the admin's own
+  // words on the agent's side of the thread.
+  it('attributes an admin instruction to "You", not the agent', () => {
+    setMessages([message({ id: '1', sender: 'admin', message_type: 'instruction', body: 'do the thing' })]);
+
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument();
+  });
+
+  it('flags a question from the agent', () => {
+    setMessages([message({ id: '4', message_type: 'question', body: 'which page did you mean?' })]);
+
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('question')).toBeInTheDocument();
+  });
+
+  it('shows an empty thread as a normal state', () => {
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('No messages yet.')).toBeInTheDocument();
+  });
+
+  // A run can end with no closing agent message, so without the outcome footer the
+  // thread would simply trail off after "AI agent started".
+  it('shows the session outcome so a thread that stops still explains itself', () => {
+    setMessages([message({ id: '2', message_type: 'status', body: 'AI agent started' })]);
+
+    render(
+      <AgentSessionChat
+        sessionId="task-1"
+        session={session({ status: 'failed', error_message: 'Code-change Job failed with exit code 1' })}
+      />,
+    );
+
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('Code-change Job failed with exit code 1')).toBeInTheDocument();
+  });
+});
+
+describe('AgentSessionChat composer', () => {
+  it('blocks sending whitespace, which the orchestrator would reject anyway', () => {
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    const send = screen.getByRole('button', { name: 'Send' });
+    expect(send).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Message the agent'), { target: { value: '   ' } });
+    expect(send).toBeDisabled();
+  });
+
+  it('sends a trimmed message and clears the draft', async () => {
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    const textarea = screen.getByLabelText('Message the agent');
+    fireEvent.change(textarea, { target: { value: '  rename the heading  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledWith('rename the heading'));
+    await waitFor(() => expect(textarea).toHaveValue(''));
+  });
+
+  it('keeps the draft when the send fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('Forbidden resource'));
+
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    const textarea = screen.getByLabelText('Message the agent');
+    fireEvent.change(textarea, { target: { value: 'try again' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(await screen.findByText('Forbidden resource')).toBeInTheDocument();
+    expect(textarea).toHaveValue('try again');
+  });
+
+  // A message continues the agent from its existing branch, which is how you
+  // iterate on a finished session's PR — so a terminal status must not lock the
+  // composer.
+  it('stays usable on a terminal session', () => {
+    render(<AgentSessionChat sessionId="task-1" session={session({ status: 'ready' })} />);
+
+    fireEvent.change(screen.getByLabelText('Message the agent'), { target: { value: 'one more change' } });
+    expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled();
+  });
+
+  it('warns that sending starts a run on the working branch', () => {
+    render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+    expect(screen.getByText('Sending starts a new agent run on agent/fix-task-1.')).toBeInTheDocument();
+  });
+
+  it('calls out a session that is waiting on the admin', () => {
+    render(<AgentSessionChat sessionId="task-1" session={session({ status: 'waiting_for_input' })} />);
+
+    expect(screen.getByText('The agent is waiting for your answer.')).toBeInTheDocument();
+  });
+});

--- a/__tests__/page/agent-sessions/agent-session-chat.test.tsx
+++ b/__tests__/page/agent-sessions/agent-session-chat.test.tsx
@@ -155,6 +155,31 @@ describe('AgentSessionChat composer', () => {
     await waitFor(() => expect(textarea).toHaveValue(''));
   });
 
+  // Scrolling the thread is presentation. If it can throw into the send's catch
+  // block, a delivered message reports itself as failed — so this drops
+  // scrollIntoView (absent in older jsdom and in some embedded browsers) and
+  // asserts the send still reads as successful.
+  it('still reports success when scrollIntoView is unavailable', async () => {
+    const original = Element.prototype.scrollIntoView;
+    // @ts-expect-error — simulating an environment that lacks the API
+    delete Element.prototype.scrollIntoView;
+
+    try {
+      render(<AgentSessionChat sessionId="task-1" session={session()} />);
+
+      const textarea = screen.getByLabelText('Message the agent');
+      fireEvent.change(textarea, { target: { value: 'ship it' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledWith('ship it'));
+      await waitFor(() => expect(textarea).toHaveValue(''));
+      expect(screen.queryByText(/failed to send/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/is not a function/i)).not.toBeInTheDocument();
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
   it('keeps the draft when the send fails', async () => {
     mockMutateAsync.mockRejectedValue(new Error('Forbidden resource'));
 

--- a/__tests__/page/agent-sessions/agent-session-chat.test.tsx
+++ b/__tests__/page/agent-sessions/agent-session-chat.test.tsx
@@ -128,7 +128,7 @@ describe('AgentSessionChat thread', () => {
       />,
     );
 
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
     expect(screen.getByText('Code-change Job failed with exit code 1')).toBeInTheDocument();
   });
 });

--- a/__tests__/page/agent-sessions/session-status-badge.test.tsx
+++ b/__tests__/page/agent-sessions/session-status-badge.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { SessionStatusBadge, humanizeStatus } from '@/components/page/agent-sessions/shared/sessionStatus';
+
+describe('humanizeStatus', () => {
+  it.each([
+    ['waiting_for_input', 'Waiting for input'],
+    ['cleanup_failed', 'Cleanup failed'],
+    ['ready', 'Ready'],
+  ])('turns %s into %s', (input, expected) => {
+    expect(humanizeStatus(input)).toBe(expected);
+  });
+
+  it('leaves an empty status alone rather than returning an empty label', () => {
+    expect(humanizeStatus('')).toBe('');
+  });
+});
+
+describe('SessionStatusBadge', () => {
+  it.each([
+    ['waiting_for_input', 'Waiting for input'],
+    ['pr_created', 'PR created'],
+    ['in_progress', 'In progress'],
+    ['deleted', 'Deleted'],
+    ['ready', 'Ready'],
+  ])('renders %s as "%s"', (status, label) => {
+    render(<SessionStatusBadge status={status} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  // The orchestrator introduced `waiting_for_input` with no warning and the UI
+  // rendered it unstyled. The next unknown status must still read as English.
+  it('humanizes a status it has never seen', () => {
+    render(<SessionStatusBadge status="awaiting_review" />);
+    expect(screen.getByText('Awaiting review')).toBeInTheDocument();
+  });
+
+  it('does not crash on an empty status', () => {
+    const { container } = render(<SessionStatusBadge status="" />);
+    expect(container.querySelector('span')).toBeInTheDocument();
+  });
+
+  // Labels deliberately diverge from the wire format, so the raw value has to stay
+  // recoverable for anyone cross-checking against the orchestrator.
+  it('keeps the raw API value in the title attribute', () => {
+    render(<SessionStatusBadge status="waiting_for_input" />);
+    expect(screen.getByTitle('waiting_for_input')).toBeInTheDocument();
+  });
+
+  it('marks the icon decorative so the label is the only announced text', () => {
+    const { container } = render(<SessionStatusBadge status="running" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('animates a status where work is actively happening', () => {
+    const { container } = render(<SessionStatusBadge status="running" />);
+    expect(container.querySelector('svg')?.getAttribute('class')).toMatch(/spin/);
+  });
+
+  it('does not animate a settled status', () => {
+    const { container } = render(<SessionStatusBadge status="failed" />);
+    const className = container.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(className).not.toMatch(/spin/);
+    expect(className).not.toMatch(/pulse/);
+  });
+});

--- a/__tests__/services/agent-sessions/agent-sessions-messages.service.test.ts
+++ b/__tests__/services/agent-sessions/agent-sessions-messages.service.test.ts
@@ -1,0 +1,137 @@
+import { customFetch } from '@/utils/fetch-wrapper';
+import {
+  fetchAgentSessionMessages,
+  sendAgentSessionMessage,
+  isPermanentAgentSessionError,
+  AgentSessionRequestError,
+  AgentSessionMessage,
+} from '@/services/agent-sessions/agent-sessions.service';
+
+jest.mock('@/utils/fetch-wrapper', () => ({
+  customFetch: jest.fn(),
+}));
+
+const mockCustomFetch = customFetch as jest.MockedFunction<typeof customFetch>;
+
+const jsonResponse = (status: number, body: unknown = {}) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+const message = (overrides: Partial<AgentSessionMessage> = {}): AgentSessionMessage => ({
+  id: '1',
+  task_id: 'task-1',
+  execution_id: null,
+  sender: 'agent',
+  message_type: 'reply',
+  body: 'done',
+  created_at: '2026-08-11T08:00:00.000Z',
+  ...overrides,
+});
+
+describe('fetchAgentSessionMessages', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the thread as sent by the orchestrator', async () => {
+    const items = [message({ id: '1' }), message({ id: '2' })];
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { items }));
+
+    await expect(fetchAgentSessionMessages('task-1')).resolves.toEqual(items);
+  });
+
+  // A session that has never been messaged returns no `items` key at all — that is
+  // the common case, not an edge case, so it must not throw.
+  it('falls back to an empty thread when the payload has no items', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, {}));
+
+    await expect(fetchAgentSessionMessages('task-1')).resolves.toEqual([]);
+  });
+
+  it('encodes the session id into the messages path', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(200, { items: [] }));
+
+    await fetchAgentSessionMessages('a/b');
+
+    expect(mockCustomFetch).toHaveBeenCalledWith(expect.stringContaining('/a%2Fb/messages'), { method: 'GET' }, true);
+  });
+
+  it("surfaces the server's message when the request fails", async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(403, { message: 'Forbidden resource' }));
+
+    await expect(fetchAgentSessionMessages('task-1')).rejects.toThrow('Forbidden resource');
+  });
+});
+
+// A backend without the messages route answers 404 forever, so retrying only keeps
+// "Loading messages…" on screen. The status has to survive the throw for the query
+// to know that.
+describe('permanent vs transient failures', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('carries the HTTP status on the thrown error', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(404, { message: 'Cannot GET /v1/agent-sessions/x/messages' }));
+
+    await expect(fetchAgentSessionMessages('x')).rejects.toMatchObject({
+      status: 404,
+      message: 'Cannot GET /v1/agent-sessions/x/messages',
+    });
+  });
+
+  it.each([400, 403, 404, 422])('treats %i as permanent', (status) => {
+    expect(isPermanentAgentSessionError(new AgentSessionRequestError('nope', status))).toBe(true);
+  });
+
+  it.each([500, 502, 503])('treats %i as worth retrying', (status) => {
+    expect(isPermanentAgentSessionError(new AgentSessionRequestError('boom', status))).toBe(false);
+  });
+
+  // A dropped connection arrives as a plain Error with no status — that is exactly
+  // the case retrying exists for.
+  it('treats a network error as worth retrying', () => {
+    expect(isPermanentAgentSessionError(new Error('Network request failed'))).toBe(false);
+  });
+});
+
+describe('sendAgentSessionMessage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('posts the message as JSON', async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(202, { message: message({ sender: 'admin' }) }));
+
+    await sendAgentSessionMessage('task-1', 'rename the heading');
+
+    expect(mockCustomFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/task-1/messages'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ message: 'rename the heading' }),
+      }),
+      true,
+    );
+  });
+
+  // The 202 envelope carries the execution the message just started, which is how
+  // a caller could tell the admin a new agent run is underway.
+  it('returns the execution envelope', async () => {
+    const envelope = {
+      message: message({ id: '36', sender: 'admin', message_type: 'instruction' }),
+      executionId: 'exec-1',
+      executionNumber: 2,
+      executionStatus: 'starting',
+      kubernetesJobName: 'code-fix-e2',
+    };
+    mockCustomFetch.mockResolvedValue(jsonResponse(202, envelope));
+
+    await expect(sendAgentSessionMessage('task-1', 'go')).resolves.toEqual(envelope);
+  });
+
+  it("surfaces the server's message when the send is rejected", async () => {
+    mockCustomFetch.mockResolvedValue(jsonResponse(400, { message: ['message must contain at least 1 character(s)'] }));
+
+    await expect(sendAgentSessionMessage('task-1', ' ')).rejects.toThrow(
+      'message must contain at least 1 character(s)',
+    );
+  });
+});

--- a/__tests__/services/agent-sessions/feature-env-actions.test.ts
+++ b/__tests__/services/agent-sessions/feature-env-actions.test.ts
@@ -1,0 +1,76 @@
+import { canDeleteFeatureEnv, canDeployFeatureEnv } from '@/services/agent-sessions/featureEnvActions';
+import type { AgentSession } from '@/services/agent-sessions/agent-sessions.service';
+
+const session = (overrides: Partial<AgentSession> = {}): AgentSession =>
+  ({
+    id: 'task-1',
+    pull_request_url: 'https://github.com/org/repo/pull/1',
+    working_branch: 'agent/fix-task-1',
+    feature_environment_status: null,
+    ...overrides,
+  }) as AgentSession;
+
+describe('canDeployFeatureEnv', () => {
+  it('needs a PR and a branch to deploy from', () => {
+    expect(canDeployFeatureEnv(session({ pull_request_url: null }))).toBe(false);
+    expect(canDeployFeatureEnv(session({ working_branch: null }))).toBe(false);
+  });
+
+  it.each([null, 'deleted', 'failed', 'cancelled', 'cleanup_failed'])(
+    'offers a fresh deploy when the env is absent or finished (%s)',
+    (status) => {
+      expect(canDeployFeatureEnv(session({ feature_environment_status: status }))).toBe(true);
+    },
+  );
+
+  it('offers a redeploy once the env is ready', () => {
+    expect(canDeployFeatureEnv(session({ feature_environment_status: 'ready' }))).toBe(true);
+  });
+
+  // Allowlist on purpose: deploying twice over an in-flight env is worse than
+  // withholding the button, so anything unrecognised is treated as in-flight.
+  it.each(['deploying', 'dispatched', 'deleting', 'some_future_state'])(
+    'withholds deploy while something is already happening (%s)',
+    (status) => {
+      expect(canDeployFeatureEnv(session({ feature_environment_status: status }))).toBe(false);
+    },
+  );
+});
+
+describe('canDeleteFeatureEnv', () => {
+  it('has nothing to delete when no env exists', () => {
+    expect(canDeleteFeatureEnv(session({ feature_environment_status: null }))).toBe(false);
+  });
+
+  it('has nothing to delete when the env is already gone', () => {
+    expect(canDeleteFeatureEnv(session({ feature_environment_status: 'deleted' }))).toBe(false);
+  });
+
+  // The bug this replaced: `dispatched` is what the orchestrator actually emits
+  // while a deploy is in flight, but the old allowlist spelled it `dispatching`,
+  // so the Delete button vanished for exactly those sessions.
+  it('offers delete for a dispatched env', () => {
+    expect(canDeleteFeatureEnv(session({ feature_environment_status: 'dispatched' }))).toBe(true);
+  });
+
+  it.each(['deploying', 'ready', 'deleting', 'failed', 'cancelled', 'cleanup_failed'])(
+    'offers delete for %s',
+    (status) => {
+      expect(canDeleteFeatureEnv(session({ feature_environment_status: status }))).toBe(true);
+    },
+  );
+
+  // Denylist on purpose: the backend rejects a delete it does not permit, so an
+  // unknown status must not silently hide the only way to clean up.
+  it('offers delete for a status nobody has seen yet', () => {
+    expect(canDeleteFeatureEnv(session({ feature_environment_status: 'quarantined' }))).toBe(true);
+  });
+
+  it('does not depend on the PR or branch, unlike deploy', () => {
+    expect(
+      canDeleteFeatureEnv(
+        session({ pull_request_url: null, working_branch: null, feature_environment_status: 'ready' }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
@@ -1,18 +1,19 @@
 @use 'styles/media';
 
-// Takes the leftover height of the page column so the panel ends where the
-// viewport does. `min-height: 0` is what lets it shrink below its content —
-// without it the panel grows to fit the whole thread, the page starts
-// scrolling, and the composer rides off the bottom of the screen.
+// Deliberately no height math and no `overflow: hidden`.
+//
+// Sizing the panel to the viewport cannot work here: the app header is
+// `position: sticky` with `min-height: var(--app-header-height)`, so it renders
+// taller than the variable claims, and any `calc(100vh - …)` lands the bottom of
+// the panel below the fold by that difference. Instead the page scrolls normally
+// and the composer sticks to the viewport — which needs a non-clipping ancestor,
+// hence no `overflow: hidden`.
 .root {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  min-height: 0;
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
-  overflow: hidden;
 }
 
 .waitingBanner {
@@ -24,17 +25,13 @@
   color: #78350f;
 }
 
-// The only scrolling region. `min-height: 0` again: a flex item defaults to
-// min-height auto, which refuses to shrink below its content and would push the
-// composer out of the panel instead of scrolling.
+// Grows with its content; the page is the single scroll region. A nested scroller
+// here would put two scrollbars on screen and trap the wheel over the thread.
 .thread {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
 }
 
 .messages {
@@ -187,14 +184,20 @@
   color: #b42318;
 }
 
-// Never shrinks and never scrolls away — the composer is the point of the tab.
+// Sticks to the bottom of the viewport for as long as the panel is on screen, so
+// however long the thread grows the composer stays reachable. Sticky elements keep
+// their place in flow, so nothing is permanently hidden behind it.
 .composer {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
   padding: 16px;
   border-top: 1px solid #e2e8f0;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
   background: #f8fafc;
 }
 

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
@@ -1,0 +1,254 @@
+@use 'styles/media';
+
+.root {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.waitingBanner {
+  padding: 12px 16px;
+  background: #fef3c7;
+  border-bottom: 1px solid #fde68a;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #78350f;
+}
+
+.thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  max-height: 55vh;
+  min-height: 220px;
+  overflow-y: auto;
+}
+
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+}
+
+.rowAdmin {
+  justify-content: flex-end;
+}
+
+.rowAgent {
+  justify-content: flex-start;
+}
+
+.bubble {
+  max-width: 80%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+
+  @include media.mobile-only {
+    max-width: 100%;
+  }
+}
+
+.bubbleAdmin {
+  background: #156ff7;
+  color: #fff;
+}
+
+.bubbleAgent {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  color: #0a0c11;
+}
+
+.bubbleQuestion {
+  background: #fffbeb;
+  border-color: #fcd34d;
+}
+
+.bubbleMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 11px;
+}
+
+.bubbleSender {
+  font-weight: 700;
+}
+
+.bubbleTime {
+  opacity: 0.7;
+}
+
+.questionTag {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #fcd34d;
+  color: #78350f;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.plainBody {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.markdownBody {
+  word-break: break-word;
+
+  p,
+  ul,
+  ol,
+  pre {
+    margin: 0 0 8px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  ul,
+  ol {
+    padding-left: 18px;
+  }
+
+  code {
+    padding: 1px 4px;
+    border-radius: 4px;
+    background: #e2e8f0;
+    font-size: 12px;
+  }
+
+  pre {
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: #0f172a;
+    color: #e2e8f0;
+    overflow-x: auto;
+
+    code {
+      padding: 0;
+      background: none;
+      color: inherit;
+    }
+  }
+
+  a {
+    color: #156ff7;
+    text-decoration: underline;
+  }
+}
+
+.outcome {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.outcomeError {
+  font-size: 12px;
+  color: #b42318;
+}
+
+.state {
+  margin: 0;
+  font-size: 14px;
+  color: #455468;
+}
+
+.error {
+  color: #b42318;
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-top: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.composerLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: #0a0c11;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 84px;
+  resize: vertical;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 14px;
+  color: #0a0c11;
+  background: #fff;
+
+  &:disabled {
+    opacity: 0.6;
+  }
+}
+
+.composerFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  @include media.mobile-only {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.composerHint {
+  font-size: 12px;
+  color: #64748b;
+  word-break: break-word;
+}
+
+.sendButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: none;
+  background: #156ff7;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    background: #0f5ed1;
+  }
+}

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
@@ -1,8 +1,14 @@
 @use 'styles/media';
 
+// Takes the leftover height of the page column so the panel ends where the
+// viewport does. `min-height: 0` is what lets it shrink below its content —
+// without it the panel grows to fit the whole thread, the page starts
+// scrolling, and the composer rides off the bottom of the screen.
 .root {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
@@ -18,13 +24,16 @@
   color: #78350f;
 }
 
+// The only scrolling region. `min-height: 0` again: a flex item defaults to
+// min-height auto, which refuses to shrink below its content and would push the
+// composer out of the panel instead of scrolling.
 .thread {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  max-height: 55vh;
-  min-height: 220px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -178,10 +187,12 @@
   color: #b42318;
 }
 
+// Never shrinks and never scrolls away — the composer is the point of the tab.
 .composer {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex-shrink: 0;
   padding: 16px;
   border-top: 1px solid #e2e8f0;
   background: #f8fafc;

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.module.scss
@@ -14,6 +14,19 @@
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
+
+  // Reserves room under the thread for the docked composer, which is out of flow
+  // and would otherwise cover the newest messages.
+  //
+  // Derived, not guessed — the textarea's max-height below caps the bar, so this is
+  // its worst case: 24 padding + 18 label + 8 + 160 textarea + 8 + 40 footer + 1
+  // border = 259. On mobile the footer stacks the hint above the button, adding
+  // ~40. Change the textarea's max-height and these move with it.
+  --chat-composer-space: 264px;
+
+  @include media.mobile-only {
+    --chat-composer-space: 304px;
+  }
 }
 
 .waitingBanner {
@@ -32,6 +45,7 @@
   flex-direction: column;
   gap: 12px;
   padding: 16px;
+  padding-bottom: var(--chat-composer-space);
 }
 
 .messages {
@@ -184,21 +198,32 @@
   color: #b42318;
 }
 
-// Sticks to the bottom of the viewport for as long as the panel is on screen, so
-// however long the thread grows the composer stays reachable. Sticky elements keep
-// their place in flow, so nothing is permanently hidden behind it.
+// Docked to the viewport, not to the panel. `position: sticky` still drifted at
+// the end of the scroll, because a sticky element is only pinned while its
+// containing block is on screen and the page has padding below the panel. Fixed
+// removes that last movement entirely.
+//
+// z-index stays under `.layout__header` (5) so the app header keeps winning.
 .composer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 4;
+  padding: 12px 16px;
+  border-top: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+// Keeps the docked bar's controls aligned with the page column above it, using
+// the same max-width and padding as `.content` in the shared stylesheet.
+.composerInner {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-  padding: 16px;
-  border-top: 1px solid #e2e8f0;
-  border-bottom-left-radius: 12px;
-  border-bottom-right-radius: 12px;
-  background: #f8fafc;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 24px;
 }
 
 .composerLabel {
@@ -207,9 +232,13 @@
   color: #0a0c11;
 }
 
+// The max-height is load-bearing: the bar is fixed, so an unbounded drag-resize
+// would grow it past the space reserved under the thread and cover the newest
+// messages. See --chat-composer-space.
 .textarea {
   width: 100%;
   min-height: 84px;
+  max-height: 160px;
   resize: vertical;
   border: 1px solid #cbd5e1;
   border-radius: 8px;

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEvent, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import {
@@ -11,9 +11,6 @@ import { HIDDEN_MESSAGE_TYPES, WAITING_FOR_INPUT_STATUS } from '@/services/agent
 import type { AgentSession, AgentSessionMessage } from '@/services/agent-sessions/agent-sessions.service';
 import { formatDate, SessionStatusBadge } from '../shared/sessionStatus';
 import s from './AgentSessionChat.module.scss';
-
-/** How close to the bottom counts as "following along" for autoscroll purposes. */
-const NEAR_BOTTOM_PX = 80;
 
 function MarkdownLink(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   return (
@@ -64,8 +61,7 @@ export function AgentSessionChat({ sessionId, session }: Props) {
   const sendMutation = useSendAgentSessionMessage(sessionId);
   const [draft, setDraft] = useState('');
   const [sendError, setSendError] = useState<string | null>(null);
-  const threadRef = useRef<HTMLDivElement | null>(null);
-  const wasNearBottomRef = useRef(true);
+  const threadEndRef = useRef<HTMLDivElement | null>(null);
 
   const messages = useMemo(
     () => (messagesQuery.data ?? []).filter((message) => !HIDDEN_MESSAGE_TYPES.has(message.message_type)),
@@ -73,21 +69,6 @@ export function AgentSessionChat({ sessionId, session }: Props) {
   );
 
   const isWaitingForInput = session?.status === WAITING_FOR_INPUT_STATUS;
-  const newestId = messages.length ? messages[messages.length - 1].id : null;
-
-  // Track the scroll position *before* the DOM updates, so a polling refresh never
-  // yanks an admin who scrolled up to read a long reply.
-  const handleScroll = () => {
-    const el = threadRef.current;
-    if (!el) return;
-    wasNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
-  };
-
-  useEffect(() => {
-    const el = threadRef.current;
-    if (!el || !wasNearBottomRef.current) return;
-    el.scrollTop = el.scrollHeight;
-  }, [newestId]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -97,11 +78,16 @@ export function AgentSessionChat({ sessionId, session }: Props) {
     setSendError(null);
     try {
       await sendMutation.mutateAsync(message);
-      setDraft('');
-      wasNearBottomRef.current = true;
     } catch (error) {
       setSendError(error instanceof Error ? error.message : 'Failed to send message');
+      return;
     }
+
+    setDraft('');
+    // Deliberately outside the try: scrolling is presentation, and a failure here
+    // must never be reported as a failed send. Only ever scrolls on the admin's own
+    // send — polling must not yank someone who scrolled up to read a long reply.
+    threadEndRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'end' });
   };
 
   return (
@@ -113,7 +99,7 @@ export function AgentSessionChat({ sessionId, session }: Props) {
         </div>
       ) : null}
 
-      <div className={s.thread} ref={threadRef} onScroll={handleScroll}>
+      <div className={s.thread}>
         {messagesQuery.isLoading ? <p className={s.state}>Loading messages…</p> : null}
 
         {messagesQuery.isError ? (
@@ -142,6 +128,8 @@ export function AgentSessionChat({ sessionId, session }: Props) {
             {session.error_message ? <span className={s.outcomeError}>{session.error_message}</span> : null}
           </div>
         ) : null}
+
+        <div ref={threadEndRef} />
       </div>
 
       <form className={s.composer} onSubmit={handleSubmit}>

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
@@ -133,36 +133,40 @@ export function AgentSessionChat({ sessionId, session }: Props) {
       </div>
 
       <form className={s.composer} onSubmit={handleSubmit}>
-        <label className={s.composerLabel} htmlFor="agent-session-message">
-          Message the agent
-        </label>
-        <textarea
-          id="agent-session-message"
-          className={s.textarea}
-          value={draft}
-          autoFocus={isWaitingForInput}
-          disabled={sendMutation.isPending}
-          placeholder="Describe the change you want — vague instructions cost a full agent run."
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-              void handleSubmit(event);
-            }
-          }}
-        />
-        <div className={s.composerFooter}>
-          {/* Sending is not a chat bubble — it launches a Kubernetes job that
-              continues the agent from this branch. Say so plainly. */}
-          <span className={s.composerHint}>
-            {session?.working_branch
-              ? `Sending starts a new agent run on ${session.working_branch}.`
-              : 'Sending starts a new agent run.'}
-          </span>
-          <button type="submit" className={s.sendButton} disabled={!draft.trim() || sendMutation.isPending}>
-            {sendMutation.isPending ? 'Sending…' : 'Send'}
-          </button>
+        {/* Inner wrapper keeps the controls aligned with the page column while the
+            bar itself spans the viewport. */}
+        <div className={s.composerInner}>
+          <label className={s.composerLabel} htmlFor="agent-session-message">
+            Message the agent
+          </label>
+          <textarea
+            id="agent-session-message"
+            className={s.textarea}
+            value={draft}
+            autoFocus={isWaitingForInput}
+            disabled={sendMutation.isPending}
+            placeholder="Describe the change you want — vague instructions cost a full agent run."
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                void handleSubmit(event);
+              }
+            }}
+          />
+          <div className={s.composerFooter}>
+            {/* Sending is not a chat bubble — it launches a Kubernetes job that
+                continues the agent from this branch. Say so plainly. */}
+            <span className={s.composerHint}>
+              {session?.working_branch
+                ? `Sending starts a new agent run on ${session.working_branch}.`
+                : 'Sending starts a new agent run.'}
+            </span>
+            <button type="submit" className={s.sendButton} disabled={!draft.trim() || sendMutation.isPending}>
+              {sendMutation.isPending ? 'Sending…' : 'Send'}
+            </button>
+          </div>
+          {sendError ? <p className={`${s.state} ${s.error}`}>{sendError}</p> : null}
         </div>
-        {sendError ? <p className={`${s.state} ${s.error}`}>{sendError}</p> : null}
       </form>
     </div>
   );

--- a/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
+++ b/components/page/agent-sessions/AgentSessionChat/AgentSessionChat.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import {
+  useAgentSessionMessages,
+  useSendAgentSessionMessage,
+} from '@/services/agent-sessions/hooks/useAgentSessionMessages';
+import { HIDDEN_MESSAGE_TYPES, WAITING_FOR_INPUT_STATUS } from '@/services/agent-sessions/constants';
+import type { AgentSession, AgentSessionMessage } from '@/services/agent-sessions/agent-sessions.service';
+import { formatDate, SessionStatusBadge } from '../shared/sessionStatus';
+import s from './AgentSessionChat.module.scss';
+
+/** How close to the bottom counts as "following along" for autoscroll purposes. */
+const NEAR_BOTTOM_PX = 80;
+
+function MarkdownLink(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a {...props} target="_blank" rel="noopener noreferrer">
+      {props.children}
+    </a>
+  );
+}
+
+/**
+ * Alignment keys off `sender`, never `message_type`: an admin's follow-up arrives
+ * as `instruction`, the same type as the original prompt, so typing off the type
+ * would put the admin's own messages on the agent's side.
+ */
+function MessageBubble({ message }: { message: AgentSessionMessage }) {
+  const isAdmin = message.sender === 'admin';
+  const isQuestion = message.message_type === 'question';
+
+  return (
+    <li className={`${s.row} ${isAdmin ? s.rowAdmin : s.rowAgent}`}>
+      <div className={`${s.bubble} ${isAdmin ? s.bubbleAdmin : s.bubbleAgent} ${isQuestion ? s.bubbleQuestion : ''}`}>
+        <div className={s.bubbleMeta}>
+          <span className={s.bubbleSender}>{isAdmin ? 'You' : 'Agent'}</span>
+          {isQuestion ? <span className={s.questionTag}>question</span> : null}
+          <span className={s.bubbleTime}>{formatDate(message.created_at)}</span>
+        </div>
+        {isAdmin ? (
+          <p className={s.plainBody}>{message.body}</p>
+        ) : (
+          // No rehype-raw: react-markdown escapes embedded HTML rather than
+          // executing it, so agent output cannot inject markup.
+          <div className={s.markdownBody}>
+            <ReactMarkdown components={{ a: MarkdownLink }}>{message.body}</ReactMarkdown>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+interface Props {
+  readonly sessionId: string;
+  readonly session: AgentSession | undefined;
+}
+
+export function AgentSessionChat({ sessionId, session }: Props) {
+  const messagesQuery = useAgentSessionMessages(sessionId, session?.status);
+  const sendMutation = useSendAgentSessionMessage(sessionId);
+  const [draft, setDraft] = useState('');
+  const [sendError, setSendError] = useState<string | null>(null);
+  const threadRef = useRef<HTMLDivElement | null>(null);
+  const wasNearBottomRef = useRef(true);
+
+  const messages = useMemo(
+    () => (messagesQuery.data ?? []).filter((message) => !HIDDEN_MESSAGE_TYPES.has(message.message_type)),
+    [messagesQuery.data],
+  );
+
+  const isWaitingForInput = session?.status === WAITING_FOR_INPUT_STATUS;
+  const newestId = messages.length ? messages[messages.length - 1].id : null;
+
+  // Track the scroll position *before* the DOM updates, so a polling refresh never
+  // yanks an admin who scrolled up to read a long reply.
+  const handleScroll = () => {
+    const el = threadRef.current;
+    if (!el) return;
+    wasNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
+  };
+
+  useEffect(() => {
+    const el = threadRef.current;
+    if (!el || !wasNearBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [newestId]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const message = draft.trim();
+    if (!message || sendMutation.isPending) return;
+
+    setSendError(null);
+    try {
+      await sendMutation.mutateAsync(message);
+      setDraft('');
+      wasNearBottomRef.current = true;
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : 'Failed to send message');
+    }
+  };
+
+  return (
+    <div className={s.root}>
+      {isWaitingForInput ? (
+        <div className={s.waitingBanner}>
+          <strong>The agent is waiting for your answer.</strong> It stopped to ask a question and will not continue
+          until you reply.
+        </div>
+      ) : null}
+
+      <div className={s.thread} ref={threadRef} onScroll={handleScroll}>
+        {messagesQuery.isLoading ? <p className={s.state}>Loading messages…</p> : null}
+
+        {messagesQuery.isError ? (
+          <p className={`${s.state} ${s.error}`}>
+            {messagesQuery.error instanceof Error ? messagesQuery.error.message : 'Failed to load messages'}
+          </p>
+        ) : null}
+
+        {!messagesQuery.isLoading && !messagesQuery.isError && !messages.length ? (
+          <p className={s.state}>No messages yet.</p>
+        ) : null}
+
+        {messages.length ? (
+          <ul className={s.messages}>
+            {messages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+          </ul>
+        ) : null}
+
+        {/* A run can end without a closing agent message — the outcome lives only on
+            the session. Without this the thread just trails off after "AI agent started". */}
+        {session ? (
+          <div className={s.outcome}>
+            <SessionStatusBadge status={session.status} />
+            {session.error_message ? <span className={s.outcomeError}>{session.error_message}</span> : null}
+          </div>
+        ) : null}
+      </div>
+
+      <form className={s.composer} onSubmit={handleSubmit}>
+        <label className={s.composerLabel} htmlFor="agent-session-message">
+          Message the agent
+        </label>
+        <textarea
+          id="agent-session-message"
+          className={s.textarea}
+          value={draft}
+          autoFocus={isWaitingForInput}
+          disabled={sendMutation.isPending}
+          placeholder="Describe the change you want — vague instructions cost a full agent run."
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+              void handleSubmit(event);
+            }
+          }}
+        />
+        <div className={s.composerFooter}>
+          {/* Sending is not a chat bubble — it launches a Kubernetes job that
+              continues the agent from this branch. Say so plainly. */}
+          <span className={s.composerHint}>
+            {session?.working_branch
+              ? `Sending starts a new agent run on ${session.working_branch}.`
+              : 'Sending starts a new agent run.'}
+          </span>
+          <button type="submit" className={s.sendButton} disabled={!draft.trim() || sendMutation.isPending}>
+            {sendMutation.isPending ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+        {sendError ? <p className={`${s.state} ${s.error}`}>{sendError}</p> : null}
+      </form>
+    </div>
+  );
+}

--- a/components/page/agent-sessions/AgentSessionChat/index.ts
+++ b/components/page/agent-sessions/AgentSessionChat/index.ts
@@ -1,0 +1,1 @@
+export { AgentSessionChat } from './AgentSessionChat';

--- a/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
+++ b/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
@@ -11,22 +11,12 @@ import {
   useDeployAgentSessionFeatureEnv,
 } from '@/services/agent-sessions/hooks/useAgentSessionFeatureEnv';
 import { deriveProgressSteps, type DerivedStepPhase } from '@/services/agent-sessions/deriveProgressSteps';
-import type { AgentSession } from '@/services/agent-sessions/agent-sessions.service';
+import { canDeleteFeatureEnv, canDeployFeatureEnv } from '@/services/agent-sessions/featureEnvActions';
 import { AgentSessionChat } from '../AgentSessionChat';
 import { formatDate, SessionStatusBadge } from '../shared/sessionStatus';
 import s from '../shared/AgentSessions.module.scss';
 
 type DetailTab = 'overview' | 'chat';
-
-const ACTIVE_FEATURE_ENV_STATUSES = new Set([
-  'queued',
-  'cleanup_pending',
-  'dispatching',
-  'in_progress',
-  'deploying',
-  'ready',
-  'deleting',
-]);
 
 const STEP_DOT_CLASS: Record<DerivedStepPhase, string> = {
   pending: '',
@@ -44,26 +34,6 @@ function featureEnvUrlFromProgress(progress: ReturnType<typeof useAgentSessionPr
   const readyUrls = readyStep?.metadata?.urls as Record<string, unknown> | undefined;
   if (readyUrls && typeof readyUrls.frontend === 'string') return readyUrls.frontend;
   return null;
-}
-
-function canDeployFeatureEnv(session: AgentSession) {
-  if (!session.pull_request_url || !session.working_branch) return false;
-  const status = session.feature_environment_status;
-  if (!status || status === 'deleted' || status === 'failed' || status === 'cancelled' || status === 'cleanup_failed') {
-    return true;
-  }
-  return status === 'ready';
-}
-
-function canDeleteFeatureEnv(session: AgentSession) {
-  const status = session.feature_environment_status;
-  if (!status || status === 'deleted') return false;
-  return (
-    ACTIVE_FEATURE_ENV_STATUSES.has(status) ||
-    status === 'failed' ||
-    status === 'cancelled' ||
-    status === 'cleanup_failed'
-  );
 }
 
 export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {

--- a/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
+++ b/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
@@ -15,8 +15,11 @@ import {
   type DerivedStepPhase,
 } from '@/services/agent-sessions/deriveProgressSteps';
 import type { AgentSession } from '@/services/agent-sessions/agent-sessions.service';
+import { AgentSessionChat } from '../AgentSessionChat';
 import { formatDate, SessionStatusBadge } from '../shared/sessionStatus';
 import s from '../shared/AgentSessions.module.scss';
+
+type DetailTab = 'overview' | 'chat';
 
 const ACTIVE_FEATURE_ENV_STATUSES = new Set([
   'queued',
@@ -69,6 +72,7 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
   const deployMutation = useDeployAgentSessionFeatureEnv(sessionId);
   const deleteMutation = useDeleteAgentSessionFeatureEnv(sessionId);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<DetailTab>('overview');
 
   const session = sessionQuery.data;
   const progress = progressQuery.data;
@@ -115,6 +119,31 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
           {session ? <SessionStatusBadge status={session.status} /> : null}
         </div>
 
+        {/* Chat is admin-only: a message starts a new agent run, so a VIEW-only
+            user gets no tab bar at all rather than a read-only thread. */}
+        {canAdmin ? (
+          <div className={s.tabs} role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'overview'}
+              className={`${s.tab} ${activeTab === 'overview' ? s.tabActive : ''}`}
+              onClick={() => setActiveTab('overview')}
+            >
+              Overview
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'chat'}
+              className={`${s.tab} ${activeTab === 'chat' ? s.tabActive : ''}`}
+              onClick={() => setActiveTab('chat')}
+            >
+              Chat
+            </button>
+          </div>
+        ) : null}
+
         {(sessionQuery.isLoading || progressQuery.isLoading) && !session ? (
           <div className={s.panel}>
             <p className={s.state}>Loading session…</p>
@@ -129,7 +158,11 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
           </div>
         ) : null}
 
-        {session ? (
+        {/* Mounted only while its tab is active, so the messages poll stops when
+            the admin is looking at Overview. */}
+        {canAdmin && activeTab === 'chat' ? <AgentSessionChat sessionId={sessionId} session={session} /> : null}
+
+        {session && activeTab === 'overview' ? (
           <>
             <div className={s.panel}>
               <h2 className={s.sectionTitle}>Overview</h2>

--- a/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
+++ b/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
@@ -107,42 +107,46 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
   return (
     <div className={s.pageFrame}>
       <div className={s.content}>
-        <Link href="/pl-infra/agent-sessions" className={s.backLink}>
-          ← Back to sessions
-        </Link>
+        {/* Back link, identity and tabs travel together: the tabs are page chrome,
+            and leaving them to scroll out from under a pinned title reads as broken. */}
+        <div className={s.stickyHeader}>
+          <Link href="/pl-infra/agent-sessions" className={s.backLink}>
+            ← Back to sessions
+          </Link>
 
-        <div className={s.header}>
-          <div className={s.titleBlock}>
-            <h1 className={s.title}>Agent Session</h1>
-            <p className={s.description}>{sessionId}</p>
+          <div className={s.header}>
+            <div className={s.titleBlock}>
+              <h1 className={s.title}>Agent Session</h1>
+              <p className={s.description}>{sessionId}</p>
+            </div>
+            {session ? <SessionStatusBadge status={session.status} /> : null}
           </div>
-          {session ? <SessionStatusBadge status={session.status} /> : null}
+
+          {/* Chat is admin-only: a message starts a new agent run, so a VIEW-only
+              user gets no tab bar at all rather than a read-only thread. */}
+          {canAdmin ? (
+            <div className={s.tabs} role="tablist">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'overview'}
+                className={`${s.tab} ${activeTab === 'overview' ? s.tabActive : ''}`}
+                onClick={() => setActiveTab('overview')}
+              >
+                Overview
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'chat'}
+                className={`${s.tab} ${activeTab === 'chat' ? s.tabActive : ''}`}
+                onClick={() => setActiveTab('chat')}
+              >
+                Chat
+              </button>
+            </div>
+          ) : null}
         </div>
-
-        {/* Chat is admin-only: a message starts a new agent run, so a VIEW-only
-            user gets no tab bar at all rather than a read-only thread. */}
-        {canAdmin ? (
-          <div className={s.tabs} role="tablist">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'overview'}
-              className={`${s.tab} ${activeTab === 'overview' ? s.tabActive : ''}`}
-              onClick={() => setActiveTab('overview')}
-            >
-              Overview
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'chat'}
-              className={`${s.tab} ${activeTab === 'chat' ? s.tabActive : ''}`}
-              onClick={() => setActiveTab('chat')}
-            >
-              Chat
-            </button>
-          </div>
-        ) : null}
 
         {(sessionQuery.isLoading || progressQuery.isLoading) && !session ? (
           <div className={s.panel}>

--- a/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
+++ b/components/page/agent-sessions/AgentSessionDetailPage/AgentSessionDetailPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { usePermissions } from '@/services/rbac/hooks/usePermissions';
 import { canAdminAgentSessions } from '@/services/rbac/utils/agentSessions/canAdminAgentSessions';
@@ -10,10 +10,7 @@ import {
   useDeleteAgentSessionFeatureEnv,
   useDeployAgentSessionFeatureEnv,
 } from '@/services/agent-sessions/hooks/useAgentSessionFeatureEnv';
-import {
-  deriveProgressSteps,
-  type DerivedStepPhase,
-} from '@/services/agent-sessions/deriveProgressSteps';
+import { deriveProgressSteps, type DerivedStepPhase } from '@/services/agent-sessions/deriveProgressSteps';
 import type { AgentSession } from '@/services/agent-sessions/agent-sessions.service';
 import { AgentSessionChat } from '../AgentSessionChat';
 import { formatDate, SessionStatusBadge } from '../shared/sessionStatus';
@@ -61,7 +58,12 @@ function canDeployFeatureEnv(session: AgentSession) {
 function canDeleteFeatureEnv(session: AgentSession) {
   const status = session.feature_environment_status;
   if (!status || status === 'deleted') return false;
-  return ACTIVE_FEATURE_ENV_STATUSES.has(status) || status === 'failed' || status === 'cancelled' || status === 'cleanup_failed';
+  return (
+    ACTIVE_FEATURE_ENV_STATUSES.has(status) ||
+    status === 'failed' ||
+    status === 'cancelled' ||
+    status === 'cleanup_failed'
+  );
 }
 
 export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
@@ -111,7 +113,7 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
             and leaving them to scroll out from under a pinned title reads as broken. */}
         <div className={s.stickyHeader}>
           <Link href="/pl-infra/agent-sessions" className={s.backLink}>
-            ← Back to sessions
+            <ChevronLeftIcon /> Back to sessions
           </Link>
 
           <div className={s.header}>
@@ -214,8 +216,12 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
                       <a className={s.externalLink} href={featureEnvUrl} target="_blank" rel="noreferrer">
                         {featureEnvUrl}
                       </a>
+                    ) : session.feature_environment_status ? (
+                      // Same vocabulary as the session status, so it gets the same
+                      // treatment rather than a bare `dispatched` string.
+                      <SessionStatusBadge status={session.feature_environment_status} />
                     ) : (
-                      session.feature_environment_status || '—'
+                      '—'
                     )}
                   </span>
                 </div>
@@ -238,12 +244,7 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
                     </button>
                   ) : null}
                   {canDeleteFeatureEnv(session) ? (
-                    <button
-                      type="button"
-                      className={s.dangerButton}
-                      disabled={busy}
-                      onClick={handleDelete}
-                    >
+                    <button type="button" className={s.dangerButton} disabled={busy} onClick={handleDelete}>
                       {deleteMutation.isPending ? 'Deleting…' : 'Delete feature env'}
                     </button>
                   ) : null}
@@ -292,3 +293,9 @@ export function AgentSessionDetailPage({ sessionId }: { sessionId: string }) {
     </div>
   );
 }
+
+const ChevronLeftIcon = () => (
+  <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M11 14.5L5 8.5L11 2.5" stroke="#156FF7" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/components/page/agent-sessions/shared/AgentSessions.module.scss
+++ b/components/page/agent-sessions/shared/AgentSessions.module.scss
@@ -182,6 +182,22 @@
   color: #1d4ed8;
 }
 
+// Keeps the session's identity and the tab switcher in view while a long chat
+// thread scrolls underneath. `top: var(--app-header-height)` is the app-wide
+// convention for sitting below the sticky `.layout__header` (see the forum feed,
+// members page and demo-day headers); the background matches `.pageFrame` so
+// content passing underneath is hidden rather than showing through.
+.stickyHeader {
+  position: sticky;
+  top: var(--app-header-height);
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 0 0;
+  background: #f1f5f9;
+}
+
 .tabs {
   display: flex;
   gap: 4px;

--- a/components/page/agent-sessions/shared/AgentSessions.module.scss
+++ b/components/page/agent-sessions/shared/AgentSessions.module.scss
@@ -140,46 +140,87 @@
   color: #64748b;
 }
 
+// No `text-transform` any more: labels are authored properly cased in
+// sessionStatus.tsx rather than being raw API values dressed down.
 .status {
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
+  gap: 6px;
+  padding: 3px 10px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 600;
   background: #e2e8f0;
   color: #334155;
-  text-transform: lowercase;
+  white-space: nowrap;
 }
 
-// The agent has stopped to ask something and needs an admin reply — amber rather
-// than the in-flight blue, because nothing is progressing until someone answers.
-.statusWaiting_for_input {
+.statusIcon {
+  flex-shrink: 0;
+}
+
+// Tones, not per-status colours: statuses are grouped by what they mean for the
+// reader, so a new orchestrator state only needs a tone rather than a stylesheet
+// edit. Icons inherit these via `currentColor`.
+.toneProgress {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.toneWaiting {
   background: #fef3c7;
   color: #78350f;
 }
 
-.statusReady {
+.toneSuccess {
   background: #dcfce7;
   color: #166534;
 }
 
-.statusFailed,
-.statusCancelled {
+.toneDanger {
   background: #fee4e2;
   color: #b42318;
 }
 
-.statusRunning,
-.statusDeploying,
-.statusStarting,
-.statusCloning,
-.statusTesting,
-.statusPushing,
-.statusPr_created,
-.statusQueued {
-  background: #dbeafe;
-  color: #1d4ed8;
+.toneInfo {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.toneNeutral {
+  background: #e2e8f0;
+  color: #334155;
+}
+
+@keyframes agentStatusSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes agentStatusPulse {
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.spin {
+  animation: agentStatusSpin 0.9s linear infinite;
+  transform-origin: center;
+}
+
+.pulse {
+  animation: agentStatusPulse 1.6s ease-in-out infinite;
+}
+
+// These badges sit on a page that polls every 5s; a permanently spinning icon is
+// exactly the kind of motion that triggers vestibular discomfort, so honour the
+// system setting rather than animating unconditionally.
+@media (prefers-reduced-motion: reduce) {
+  .spin,
+  .pulse {
+    animation: none;
+  }
 }
 
 // Keeps the session's identity and the tab switcher in view while a long chat
@@ -227,7 +268,7 @@
 .backLink {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   color: #455468;
   text-decoration: none;
   font-size: 13px;

--- a/components/page/agent-sessions/shared/AgentSessions.module.scss
+++ b/components/page/agent-sessions/shared/AgentSessions.module.scss
@@ -152,6 +152,13 @@
   text-transform: lowercase;
 }
 
+// The agent has stopped to ask something and needs an admin reply — amber rather
+// than the in-flight blue, because nothing is progressing until someone answers.
+.statusWaiting_for_input {
+  background: #fef3c7;
+  color: #78350f;
+}
+
 .statusReady {
   background: #dcfce7;
   color: #166534;
@@ -173,6 +180,32 @@
 .statusQueued {
   background: #dbeafe;
   color: #1d4ed8;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.tab {
+  padding: 10px 16px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+
+  &:hover {
+    color: #0a0c11;
+  }
+}
+
+.tabActive {
+  color: #156ff7;
+  border-bottom-color: #156ff7;
 }
 
 .backLink {

--- a/components/page/agent-sessions/shared/sessionStatus.tsx
+++ b/components/page/agent-sessions/shared/sessionStatus.tsx
@@ -1,23 +1,100 @@
+import type { ComponentType } from 'react';
+import {
+  AlertIcon,
+  CheckIcon,
+  ClockIcon,
+  MergeIcon,
+  PullRequestIcon,
+  QuestionIcon,
+  SlashIcon,
+  SpinnerIcon,
+  TrashIcon,
+} from './statusIcons';
 import s from './AgentSessions.module.scss';
 
-const STATUS_CLASS: Record<string, string> = {
-  ready: s.statusReady,
-  failed: s.statusFailed,
-  cancelled: s.statusCancelled,
-  deploying: s.statusDeploying,
-  running: s.statusRunning,
-  starting: s.statusStarting,
-  cloning: s.statusCloning,
-  testing: s.statusTesting,
-  pushing: s.statusPushing,
-  pr_created: s.statusPr_created,
-  queued: s.statusQueued,
-  waiting_for_input: s.statusWaiting_for_input,
+type StatusTone = 'progress' | 'waiting' | 'success' | 'danger' | 'info' | 'neutral';
+
+interface StatusMeta {
+  label: string;
+  tone: StatusTone;
+  Icon: ComponentType<{ className?: string }>;
+  /** Continuously animated — reserved for states where work is actually happening. */
+  spin?: boolean;
+  /** Gently pulsed — draws the eye to a state that is blocked on a human. */
+  pulse?: boolean;
+}
+
+const TONE_CLASS: Record<StatusTone, string> = {
+  progress: s.toneProgress,
+  waiting: s.toneWaiting,
+  success: s.toneSuccess,
+  danger: s.toneDanger,
+  info: s.toneInfo,
+  neutral: s.toneNeutral,
 };
 
+/**
+ * Covers both `status` on a session and `feature_environment_status`, which share
+ * most of their vocabulary.
+ *
+ * Anything missing here still renders — see `humanizeStatus`. The orchestrator adds
+ * states without warning (`waiting_for_input` appeared this way), so an unknown
+ * value must degrade to a readable badge rather than a blank or a crash.
+ */
+const STATUS_META: Record<string, StatusMeta> = {
+  queued: { label: 'Queued', tone: 'neutral', Icon: ClockIcon },
+  cleanup_pending: { label: 'Cleanup pending', tone: 'neutral', Icon: ClockIcon },
+
+  starting: { label: 'Starting', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  cloning: { label: 'Cloning', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  running: { label: 'Running', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  testing: { label: 'Testing', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  pushing: { label: 'Pushing', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  deploying: { label: 'Deploying', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  in_progress: { label: 'In progress', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  dispatching: { label: 'Dispatching', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  dispatched: { label: 'Dispatched', tone: 'progress', Icon: SpinnerIcon, spin: true },
+  deleting: { label: 'Deleting', tone: 'neutral', Icon: SpinnerIcon, spin: true },
+
+  // The only state that needs a person. Amber and pulsing so it stands out in a
+  // list where every other row is self-driving.
+  waiting_for_input: { label: 'Waiting for input', tone: 'waiting', Icon: QuestionIcon, pulse: true },
+
+  pr_created: { label: 'PR created', tone: 'info', Icon: PullRequestIcon },
+  merged: { label: 'Merged', tone: 'info', Icon: MergeIcon },
+  ready: { label: 'Ready', tone: 'success', Icon: CheckIcon },
+
+  failed: { label: 'Failed', tone: 'danger', Icon: AlertIcon },
+  cleanup_failed: { label: 'Cleanup failed', tone: 'danger', Icon: AlertIcon },
+
+  cancelled: { label: 'Cancelled', tone: 'neutral', Icon: SlashIcon },
+  closed: { label: 'Closed', tone: 'neutral', Icon: SlashIcon },
+  deleted: { label: 'Deleted', tone: 'neutral', Icon: TrashIcon },
+};
+
+/** `some_new_state` → `Some new state`. */
+export function humanizeStatus(status: string): string {
+  const spaced = status.replace(/_/g, ' ').trim();
+  if (!spaced) return status;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
 export function SessionStatusBadge({ status }: { status: string }) {
-  const className = STATUS_CLASS[status] ?? '';
-  return <span className={`${s.status} ${className}`}>{status}</span>;
+  const meta = STATUS_META[status];
+  const label = meta ? meta.label : humanizeStatus(status);
+  const tone = meta ? meta.tone : 'neutral';
+  const Icon = meta?.Icon;
+  const motion = meta?.spin ? s.spin : meta?.pulse ? s.pulse : '';
+
+  return (
+    // `title` keeps the raw API value one hover away. The labels intentionally no
+    // longer match the wire format, and admins debugging against the orchestrator
+    // still need to know which value they are looking at.
+    <span className={`${s.status} ${TONE_CLASS[tone]}`} title={status}>
+      {Icon ? <Icon className={`${s.statusIcon} ${motion}`} /> : null}
+      {label}
+    </span>
+  );
 }
 
 export function formatDate(value: string | null | undefined) {

--- a/components/page/agent-sessions/shared/sessionStatus.tsx
+++ b/components/page/agent-sessions/shared/sessionStatus.tsx
@@ -12,6 +12,7 @@ const STATUS_CLASS: Record<string, string> = {
   pushing: s.statusPushing,
   pr_created: s.statusPr_created,
   queued: s.statusQueued,
+  waiting_for_input: s.statusWaiting_for_input,
 };
 
 export function SessionStatusBadge({ status }: { status: string }) {

--- a/components/page/agent-sessions/shared/statusIcons.tsx
+++ b/components/page/agent-sessions/shared/statusIcons.tsx
@@ -1,0 +1,116 @@
+/**
+ * Hand-rolled inline SVGs, matching how the rest of this codebase does icons —
+ * there is no icon package installed. All stroke `currentColor`, so a badge's tone
+ * class colours the icon along with its text.
+ */
+import type { SVGProps } from 'react';
+
+interface IconProps {
+  readonly className?: string;
+}
+
+// Annotated rather than inferred: without it `focusable` widens to `string` and
+// `strokeLinecap` to `string`, neither of which satisfies SVGProps.
+const BASE: SVGProps<SVGSVGElement> = {
+  width: 12,
+  height: 12,
+  viewBox: '0 0 16 16',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.75,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  'aria-hidden': true,
+  focusable: 'false',
+};
+
+/** Open arc — reads as motion once the spin class is applied. */
+export function SpinnerIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <path d="M8 1.5a6.5 6.5 0 1 0 6.5 6.5" />
+    </svg>
+  );
+}
+
+export function ClockIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M8 4.5V8l2.5 1.5" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M5 8.25 7.25 10.5 11 6" />
+    </svg>
+  );
+}
+
+export function AlertIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M8 4.75V8.5" />
+      <path d="M8 11.25h.01" />
+    </svg>
+  );
+}
+
+export function SlashIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M3.75 3.75l8.5 8.5" />
+    </svg>
+  );
+}
+
+export function QuestionIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M6.25 6.25a1.75 1.75 0 1 1 2.4 1.63c-.4.16-.65.55-.65.98v.24" />
+      <path d="M8 11.5h.01" />
+    </svg>
+  );
+}
+
+export function PullRequestIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="4.5" cy="4" r="1.75" />
+      <circle cx="4.5" cy="12" r="1.75" />
+      <path d="M4.5 5.75v4.5" />
+      <circle cx="11.5" cy="12" r="1.75" />
+      <path d="M11.5 10.25V6.5a2 2 0 0 0-2-2H7.5" />
+      <path d="M9 2.75 7.25 4.5 9 6.25" />
+    </svg>
+  );
+}
+
+export function MergeIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <circle cx="4.5" cy="3.5" r="1.75" />
+      <circle cx="4.5" cy="12.5" r="1.75" />
+      <circle cx="11.5" cy="8" r="1.75" />
+      <path d="M4.5 5.25v5.5" />
+      <path d="M6.25 8h3.5" />
+    </svg>
+  );
+}
+
+export function TrashIcon({ className }: IconProps) {
+  return (
+    <svg {...BASE} className={className}>
+      <path d="M2.75 4.25h10.5" />
+      <path d="M6.25 4.25V3a.75.75 0 0 1 .75-.75h2a.75.75 0 0 1 .75.75v1.25" />
+      <path d="M4.25 4.25v8.5a.75.75 0 0 0 .75.75h6a.75.75 0 0 0 .75-.75v-8.5" />
+    </svg>
+  );
+}

--- a/services/agent-sessions/agent-sessions.service.ts
+++ b/services/agent-sessions/agent-sessions.service.ts
@@ -59,11 +59,55 @@ export interface AgentSessionProgress {
   steps: AgentSessionProgressStep[];
 }
 
+export interface AgentSessionMessage {
+  id: string;
+  task_id: string;
+  execution_id: string | null;
+  sender: 'admin' | 'agent';
+  /**
+   * Widened to `string` on purpose. The orchestrator emits `instruction`, `status`,
+   * `reply` and `question` today and is free to add more — an unknown type must
+   * render as an ordinary bubble, never disappear or break parsing.
+   */
+  message_type: string;
+  body: string;
+  created_at: string;
+}
+
+/** 202 envelope returned when a message resumes the agent. */
+export interface SendAgentSessionMessageResult {
+  message: AgentSessionMessage;
+  executionId: string;
+  executionNumber: number;
+  executionStatus: string;
+  kubernetesJobName: string;
+}
+
 export interface CreateAgentSessionInput {
   repository: string;
   baseBranch?: string;
   prompt: string;
   createFeatureEnvironment?: boolean;
+}
+
+/**
+ * Carries the HTTP status alongside the message so callers can tell a permanent
+ * failure (404 route missing, 403 not an admin) from a transient one and skip
+ * pointless retries.
+ */
+export class AgentSessionRequestError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'AgentSessionRequestError';
+    this.status = status;
+  }
+}
+
+/** 4xx means the request itself is wrong — retrying cannot fix it. */
+export function isPermanentAgentSessionError(error: unknown): boolean {
+  return error instanceof AgentSessionRequestError && error.status >= 400 && error.status < 500;
 }
 
 function extractErrorMessage(body: unknown, fallbackMessage: string): string {
@@ -87,7 +131,7 @@ async function parseJson<T>(response: Response | undefined, fallbackMessage: str
     } catch {
       // ignore parse errors
     }
-    throw new Error(detail);
+    throw new AgentSessionRequestError(detail, response.status);
   }
   return response.json() as Promise<T>;
 }
@@ -110,6 +154,33 @@ export async function fetchAgentSessionProgress(id: string): Promise<AgentSessio
     true,
   );
   return parseJson<AgentSessionProgress>(response, 'Failed to load session progress');
+}
+
+export async function fetchAgentSessionMessages(id: string): Promise<AgentSessionMessage[]> {
+  const response = await customFetch(
+    `${AGENT_SESSIONS_API_URL}/${encodeURIComponent(id)}/messages`,
+    { method: 'GET' },
+    true,
+  );
+  const data = await parseJson<{ items: AgentSessionMessage[] }>(response, 'Failed to load messages');
+  return data.items ?? [];
+}
+
+/**
+ * Sending resumes the agent from the session's existing branch — this starts a
+ * real run, it does not just append text.
+ */
+export async function sendAgentSessionMessage(id: string, message: string): Promise<SendAgentSessionMessageResult> {
+  const response = await customFetch(
+    `${AGENT_SESSIONS_API_URL}/${encodeURIComponent(id)}/messages`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    },
+    true,
+  );
+  return parseJson<SendAgentSessionMessageResult>(response, 'Failed to send message');
 }
 
 export async function fetchAgentSessionRepositories(): Promise<AgentSessionRepository[]> {

--- a/services/agent-sessions/constants.ts
+++ b/services/agent-sessions/constants.ts
@@ -3,6 +3,21 @@ export enum AgentSessionsQueryKeys {
   DETAIL = 'agent-session-detail',
   PROGRESS = 'agent-session-progress',
   REPOSITORIES = 'agent-session-repositories',
+  MESSAGES = 'agent-session-messages',
 }
 
 export const TERMINAL_SESSION_STATUSES = new Set(['ready', 'failed', 'cancelled', 'merged', 'closed', 'deleted']);
+
+/** The agent has asked something and will not proceed until an admin answers. */
+export const WAITING_FOR_INPUT_STATUS = 'waiting_for_input';
+
+/**
+ * A denylist, deliberately — not an allowlist.
+ *
+ * `status` messages are step narration ("Cloning repository", "Running: git diff
+ * --check") that already renders in the Progress panel, so the chat hides them.
+ * Everything else renders, including message types that don't exist yet: the safe
+ * failure mode is an unexpected bubble appearing, never an agent message silently
+ * vanishing from the conversation.
+ */
+export const HIDDEN_MESSAGE_TYPES = new Set(['status']);

--- a/services/agent-sessions/featureEnvActions.ts
+++ b/services/agent-sessions/featureEnvActions.ts
@@ -1,0 +1,40 @@
+import type { AgentSession } from '@/services/agent-sessions/agent-sessions.service';
+
+/**
+ * Whether the Deploy button should be offered.
+ *
+ * Deliberately an allowlist: deploying is a *create* action, and offering it while
+ * an environment is mid-flight risks a double deploy. An unrecognised status is
+ * therefore treated as "something is happening, stay out of the way".
+ */
+export function canDeployFeatureEnv(session: AgentSession): boolean {
+  if (!session.pull_request_url || !session.working_branch) return false;
+
+  const status = session.feature_environment_status;
+  if (!status || status === 'deleted' || status === 'failed' || status === 'cancelled' || status === 'cleanup_failed') {
+    return true;
+  }
+
+  // `ready` means an environment exists and this is a redeploy.
+  return status === 'ready';
+}
+
+/**
+ * Whether the Delete button should be offered.
+ *
+ * Deliberately a denylist, and the inverse of the rule above. There are only two
+ * reasons deletion cannot apply: there is no environment, or it is already gone.
+ * Every other state — including a failed or half-deleted one — is something an
+ * admin may legitimately want to tear down.
+ *
+ * This used to be an allowlist of statuses, which silently hid the button for any
+ * state nobody had thought of. It listed `dispatching`, `in_progress`, `queued` and
+ * `cleanup_pending` (none of which the orchestrator emits) while missing
+ * `dispatched` (which it does), so a dispatched environment could not be deleted
+ * from the UI at all. The backend is the real authority here and rejects a delete
+ * it does not permit, so guessing the vocabulary bought nothing.
+ */
+export function canDeleteFeatureEnv(session: AgentSession): boolean {
+  const status = session.feature_environment_status;
+  return Boolean(status) && status !== 'deleted';
+}

--- a/services/agent-sessions/hooks/useAgentSessionFeatureEnv.ts
+++ b/services/agent-sessions/hooks/useAgentSessionFeatureEnv.ts
@@ -1,19 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AgentSessionsQueryKeys } from '@/services/agent-sessions/constants';
 import {
   deleteAgentSessionFeatureEnv,
   deployAgentSessionFeatureEnv,
 } from '@/services/agent-sessions/agent-sessions.service';
+import { invalidateAgentSession } from '@/services/agent-sessions/invalidateAgentSession';
 
 type FeatureEnvActionInput = {
   force?: boolean;
 };
-
-function invalidateSession(queryClient: ReturnType<typeof useQueryClient>, id: string) {
-  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.DETAIL, id] });
-  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.PROGRESS, id] });
-  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.LIST] });
-}
 
 export function useDeployAgentSessionFeatureEnv(sessionId: string) {
   const queryClient = useQueryClient();
@@ -21,7 +15,7 @@ export function useDeployAgentSessionFeatureEnv(sessionId: string) {
   return useMutation({
     mutationFn: ({ force = false }: FeatureEnvActionInput = {}) =>
       deployAgentSessionFeatureEnv(sessionId, force),
-    onSuccess: () => invalidateSession(queryClient, sessionId),
+    onSuccess: () => invalidateAgentSession(queryClient, sessionId),
   });
 }
 
@@ -31,6 +25,6 @@ export function useDeleteAgentSessionFeatureEnv(sessionId: string) {
   return useMutation({
     mutationFn: ({ force = false }: FeatureEnvActionInput = {}) =>
       deleteAgentSessionFeatureEnv(sessionId, force),
-    onSuccess: () => invalidateSession(queryClient, sessionId),
+    onSuccess: () => invalidateAgentSession(queryClient, sessionId),
   });
 }

--- a/services/agent-sessions/hooks/useAgentSessionMessages.ts
+++ b/services/agent-sessions/hooks/useAgentSessionMessages.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AgentSessionsQueryKeys, TERMINAL_SESSION_STATUSES } from '@/services/agent-sessions/constants';
+import {
+  fetchAgentSessionMessages,
+  isPermanentAgentSessionError,
+  sendAgentSessionMessage,
+} from '@/services/agent-sessions/agent-sessions.service';
+import { invalidateAgentSession } from '@/services/agent-sessions/invalidateAgentSession';
+
+/**
+ * `sessionStatus` must come from the live session query rather than a value captured
+ * at mount: sending a message on a finished session starts a new execution, and
+ * polling has to resume when the status leaves the terminal set.
+ */
+export function useAgentSessionMessages(id: string, sessionStatus?: string) {
+  return useQuery({
+    queryKey: [AgentSessionsQueryKeys.MESSAGES, id],
+    queryFn: () => fetchAgentSessionMessages(id),
+    enabled: Boolean(id),
+    // A 404 (backend without the messages route) or 403 (not an admin) will never
+    // succeed on retry — surface it immediately instead of leaving "Loading
+    // messages…" on screen through three backed-off attempts.
+    retry: (failureCount, error) => !isPermanentAgentSessionError(error) && failureCount < 3,
+    refetchInterval: () => {
+      if (!sessionStatus || TERMINAL_SESSION_STATUSES.has(sessionStatus)) return false;
+      return 5000;
+    },
+  });
+}
+
+export function useSendAgentSessionMessage(sessionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (message: string) => sendAgentSessionMessage(sessionId, message),
+    onSuccess: () => invalidateAgentSession(queryClient, sessionId),
+  });
+}

--- a/services/agent-sessions/invalidateAgentSession.ts
+++ b/services/agent-sessions/invalidateAgentSession.ts
@@ -1,0 +1,16 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { AgentSessionsQueryKeys } from '@/services/agent-sessions/constants';
+
+/**
+ * Anything that acts on a session — deploying a feature env, sending a message —
+ * can move its status, its progress steps and its thread at once, so they are
+ * invalidated together. Sending a message is the sharpest case: it starts a new
+ * agent execution, and refreshing only the thread would leave a stale "failed" or
+ * "ready" badge beside a session that is running again.
+ */
+export function invalidateAgentSession(queryClient: QueryClient, id: string) {
+  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.DETAIL, id] });
+  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.PROGRESS, id] });
+  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.MESSAGES, id] });
+  void queryClient.invalidateQueries({ queryKey: [AgentSessionsQueryKeys.LIST] });
+}


### PR DESCRIPTION
Adds a `Chat` tab to `/pl-infra/agent-sessions/[id]` where an admin can read the agent's messages and send follow-ups.

> ⛔️ **Blocked on** memser-spaceport/pln-directory-portal#3331. Until those routes reach the dev API this tab 404s — that is expected, not a bug in this PR.

```
← Back to sessions
Agent Session                                  [waiting_for_input]

 ┌──────────┬────────┐
 │ Overview │  Chat  │     ← admin-only; VIEW users see today's page unchanged
 └──────────┴────────┘
```

## Behaviour

- Thread polls on the same 5s / stop-on-terminal contract as the progress panel, and mounts **only while its tab is active** — the Overview tab costs nothing extra
- Agent bodies render as Markdown via `react-markdown` (already a dependency; same pattern as `PrdContent`). No `rehype-raw`, no sanitizer needed — react-markdown escapes embedded HTML rather than executing it, so LLM-authored output cannot inject markup
- Sending clears the draft on success and keeps it on failure

## Decisions worth reviewing

Each of these came from probing the live orchestrator, and each would look arbitrary without the reason:

**Alignment keys off `sender`, never `message_type`.** An admin follow-up arrives as `instruction` — the same type as the original prompt — so typing off the type would put the admin's own words on the agent's side. There's a regression test for exactly this.

**`HIDDEN_MESSAGE_TYPES` is a denylist, not an allowlist.** `status` messages are step narration that already renders in Progress. Everything else shows, *including types that don't exist yet*. An unexpected bubble is a far better failure mode than an agent message silently vanishing — also regression-tested.

**The composer stays enabled on terminal sessions.** A message continues the agent from its existing branch, so messaging a finished session is how you iterate on its PR. Disabling it would block the feature's best use.

**Sending is labelled as the heavyweight action it is.** It launches a Kubernetes job, so the composer reads *"Sending starts a new agent run on `{branch}`."* and success invalidates status/progress/list as well as the thread — otherwise a stale `failed` badge sits beside a session that is running again.

**The thread shows the session's status and error at its foot.** A run can end with no closing agent message; without this the conversation just trails off after "AI agent started".

**4xx is not retried.** A backend without these routes answers 404 forever, and React Query's default 3 retries only prolong a "Loading messages…" spinner.

## Drive-by fix

`waiting_for_input` — emitted when the agent stops to ask a question — was unstyled everywhere, because it appeared nowhere in the codebase. Now registered in the status badge map, which fixes the **sessions list** too, independent of this feature.

## Testing

- 28 new tests (13 service, 15 component), all passing
- Full suite: 1453 pass. One failure in `plaa-round.utils.test.ts` is pre-existing — verified failing identically on clean `develop` via a temp worktree
- `tsc --noEmit`: no errors in agent-sessions (23 pre-existing in unrelated test files)
- ESLint: no new problems
- **Not** verified against a running backend — see the blocker above

## Out of scope

Streaming, unread badge on the tab, `?tab=chat` deep-linking, `execution_id` run-grouping, cancelling an in-flight execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)