### PR TITLE
fix(team-news): normalize Top Stories title font size

### DIFF
--- a/components/page/home/TeamNews/components/TopStories/TopStories.module.scss
+++ b/components/page/home/TeamNews/components/TopStories/TopStories.module.scss
@@ -1,5 +1,16 @@
 @import '../../../../../../styles/media';
 
+/* Shared by .leadTitle and .alsoTitle so both stay in sync — the lead used to
+   render larger, but multi-story cards read as inconsistent with two title
+   sizes in one card. Distinguishing the top story without font size is a
+   separate, upcoming design pass. */
+%storyTitle {
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+}
+
 /* One band holding a lead plus two rows. Without the shared border the rows read
    as feed items that happen to sit high, rather than as part of the pick.
 
@@ -112,19 +123,10 @@
 }
 
 .leadTitle {
+  @extend %storyTitle;
   margin: 0;
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 600;
-  letter-spacing: -0.6px;
   color: var(--foreground-neutral-primary, #0a0c11);
   transition: color 0.12s ease;
-
-  @include mobile-only {
-    font-size: 20px;
-    line-height: 28px;
-    letter-spacing: -0.4px;
-  }
 }
 
 .leadSummary {
@@ -188,10 +190,7 @@
 }
 
 .alsoTitle {
-  font-size: 15px;
-  line-height: 22px;
-  font-weight: 600;
-  letter-spacing: -0.2px;
+  @extend %storyTitle;
   color: var(--foreground-neutral-primary, #0a0c11);
   transition: color 0.12s ease;
 }


### PR DESCRIPTION
## Summary
- The lead story title in the Top Stories news feed card rendered larger (24px, 20px on mobile) than the runner-up story titles (15px) within the same card, making multi-story cards look visually inconsistent.
- Both `.leadTitle` and `.alsoTitle` now share a `%storyTitle` SCSS placeholder set to the runner-up size (15px / 22px / weight 600 / -0.2px letter-spacing), including removing the lead's separate mobile override.
- Visually distinguishing the Top 3 stories without relying on font size is explicitly out of scope here — Polina will provide specific card styling/highlighting direction separately, to follow in a later PR.

## Testing
- SCSS-only change; compiled the module standalone with `sass` to confirm no syntax/selector errors and that `@extend` merges the shared rule onto both `.leadTitle` and `.alsoTitle` as expected.
- Manually verified in the browser against the local dev server (`localhost:4200` → `/home`, public "Network updates" feed): a real multi-story card (EFF.org lead + Wyss Institute / ConsenSys runner-ups) now renders all three titles at the same size, at both desktop (1280px) and mobile (375px) widths. Hover states (`.leadBody:hover .leadTitle`, `.alsoRow:hover .alsoTitle`) still work; card border, gradient lead background, row dividers, and rounded corners are all unaffected.
- No existing automated tests/stories cover this component (confirmed during planning), so verification was manual/visual only.

## References
- Brainstorm: `docs/brainstorms/2026-08-12-top-stories-title-font-consistency-brainstorm.md`
- Plan: `docs/plans/2026-08-12-fix-top-stories-title-font-consistency-plan.md`
- Updated proto: https://pln-prototypes.vercel.app/prototypes/newsfeed

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)