### PR TITLE
feat(gantry): connect "Build with AI" to Agent Sessions

### DIFF
--- a/__tests__/page/gantry/build-with-agents-button.test.tsx
+++ b/__tests__/page/gantry/build-with-agents-button.test.tsx
@@ -236,6 +236,38 @@ describe('BuildWithAgentsButton', () => {
     });
   });
 
+  describe('positioning', () => {
+    it('clamps the popover into the viewport instead of letting it spill', async () => {
+      const user = userEvent.setup();
+      // Trigger sits near the bottom-right corner, so an unclamped popover would
+      // hang off both edges.
+      jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        bottom: 740,
+        left: 1330,
+        top: 700,
+        right: 1400,
+        width: 70,
+        height: 40,
+        x: 1330,
+        y: 700,
+        toJSON: () => ({}),
+      } as DOMRect);
+      jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(300);
+      jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(320);
+      window.innerHeight = 768;
+      window.innerWidth = 1440;
+
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+
+      const dialog = screen.getByRole('dialog');
+      // 768 - 300 - 12 = 456, and 1440 - 320 - 12 = 1108.
+      expect(dialog).toHaveStyle({ top: '456px', left: '1108px' });
+
+      jest.restoreAllMocks();
+    });
+  });
+
   describe('accessibility', () => {
     it('exposes the picker as a labelled dialog', async () => {
       const user = userEvent.setup();

--- a/__tests__/page/gantry/build-with-agents-button.test.tsx
+++ b/__tests__/page/gantry/build-with-agents-button.test.tsx
@@ -96,9 +96,26 @@ describe('BuildWithAgentsButton', () => {
       const user = userEvent.setup();
       renderButton();
       await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      // The dropdown renders its options only once the menu is open.
+      await user.click(screen.getByLabelText('Repository'));
 
       expect(screen.getByRole('option', { name: 'Directory (directory)' })).toBeInTheDocument();
       expect(screen.queryByRole('option', { name: /Legacy/ })).not.toBeInTheDocument();
+    });
+
+    it('closes only the dropdown on the first Escape, then the popover', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByLabelText('Repository'));
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('creates a session with a prompt built from title and description, then navigates', async () => {

--- a/__tests__/page/gantry/build-with-agents-button.test.tsx
+++ b/__tests__/page/gantry/build-with-agents-button.test.tsx
@@ -161,6 +161,34 @@ describe('BuildWithAgentsButton', () => {
     });
   });
 
+  describe('single-flight', () => {
+    it('ignores Escape, backdrop and close while the session is being created', async () => {
+      const user = userEvent.setup();
+      let resolveCreate: (value: { id: string }) => void = () => undefined;
+      mockMutateAsync.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      // The request is in flight and cannot be recalled, so no dismissal path may
+      // hide the navigation that follows it.
+      await user.keyboard('{Escape}');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      resolveCreate({ id: 'session-42' });
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/pl-infra/agent-sessions/session-42'));
+    });
+  });
+
   describe('errors', () => {
     it('shows an inline error and keeps the picker open for retry', async () => {
       const user = userEvent.setup();

--- a/__tests__/page/gantry/build-with-agents-button.test.tsx
+++ b/__tests__/page/gantry/build-with-agents-button.test.tsx
@@ -1,0 +1,240 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BuildWithAgentsButton } from '@/components/page/gantry/shared/BuildWithAgentsButton';
+
+const mockPush = jest.fn();
+const mockMutateAsync = jest.fn();
+const mockTrackBuildButtonClick = jest.fn();
+const mockOnBuildButtonClicked = jest.fn();
+
+let permissionsResult = { permsSet: new Set<string>(), isLoading: false, isError: false };
+let mutationPending = false;
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/services/rbac/hooks/usePermissions', () => ({
+  usePermissions: () => permissionsResult,
+}));
+
+jest.mock('@/services/agent-sessions/hooks/useCreateAgentSession', () => ({
+  useCreateAgentSession: () => ({ mutateAsync: mockMutateAsync, isPending: mutationPending }),
+}));
+
+jest.mock('@/services/agent-sessions/hooks/useAgentSessionRepositories', () => ({
+  useAgentSessionRepositories: () => ({
+    data: [
+      { key: 'directory', displayName: 'Directory', defaultBranch: 'develop', enabled: true },
+      { key: 'legacy', displayName: 'Legacy', defaultBranch: 'main', enabled: false },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+jest.mock('@/services/gantry/gantry.service', () => ({
+  trackBuildButtonClick: (...args: unknown[]) => {
+    mockTrackBuildButtonClick(...args);
+    return Promise.resolve();
+  },
+}));
+
+jest.mock('@/analytics/gantry.analytics', () => ({
+  useGantryAnalytics: () => ({ onBuildButtonClicked: mockOnBuildButtonClicked }),
+}));
+
+const ADMIN = new Set(['code_agent_sessions.admin']);
+
+function renderButton(props: Partial<{ uid: string; title: string; description: string }> = {}) {
+  return render(
+    <BuildWithAgentsButton
+      uid={props.uid ?? 'item-1'}
+      title={props.title ?? 'Add dark mode'}
+      description={props.description ?? '<p>Users keep asking for it.</p>'}
+    />,
+  );
+}
+
+describe('BuildWithAgentsButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    permissionsResult = { permsSet: ADMIN, isLoading: false, isError: false };
+    mutationPending = false;
+    mockMutateAsync.mockResolvedValue({ id: 'session-42' });
+  });
+
+  describe('permission gating', () => {
+    it('renders the button for an agent-sessions admin', () => {
+      renderButton();
+      expect(screen.getByRole('button', { name: /build with ai/i })).toBeInTheDocument();
+    });
+
+    it('renders nothing without the admin permission', () => {
+      permissionsResult = { permsSet: new Set(['roadmap.view']), isLoading: false, isError: false };
+      const { container } = renderButton();
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing while permissions are loading', () => {
+      permissionsResult = { permsSet: new Set(), isLoading: true, isError: false };
+      const { container } = renderButton();
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when the permissions request errored', () => {
+      permissionsResult = { permsSet: new Set(), isLoading: false, isError: true };
+      const { container } = renderButton();
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('creation flow', () => {
+    it('lists only enabled repositories', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+
+      expect(screen.getByRole('option', { name: 'Directory (directory)' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Legacy/ })).not.toBeInTheDocument();
+    });
+
+    it('creates a session with a prompt built from title and description, then navigates', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        repository: 'directory',
+        prompt: 'Add dark mode\n\nUsers keep asking for it.',
+      });
+      expect(mockPush).toHaveBeenCalledWith('/pl-infra/agent-sessions/session-42');
+    });
+
+    it('fires both analytics channels only after the session exists', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+
+      expect(mockTrackBuildButtonClick).not.toHaveBeenCalled();
+      expect(mockOnBuildButtonClicked).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      await waitFor(() => expect(mockTrackBuildButtonClick).toHaveBeenCalledWith('item-1'));
+      expect(mockOnBuildButtonClicked).toHaveBeenCalledWith('item-1');
+    });
+
+    it('blocks creation when the item is too thin to describe', async () => {
+      const user = userEvent.setup();
+      renderButton({ title: 'ab', description: '<p><br></p>' });
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent(/longer title or description/i);
+    });
+
+    it('issues exactly one request when the create button is double-clicked', async () => {
+      const user = userEvent.setup();
+      let resolveCreate: (value: { id: string }) => void = () => undefined;
+      mockMutateAsync.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      const createBtn = screen.getByRole('button', { name: /create session/i });
+
+      await user.click(createBtn);
+      await user.click(createBtn);
+
+      expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+      resolveCreate({ id: 'session-42' });
+    });
+  });
+
+  describe('errors', () => {
+    it('shows an inline error and keeps the picker open for retry', async () => {
+      const user = userEvent.setup();
+      mockMutateAsync.mockRejectedValueOnce(new Error('Repository is not allowed'));
+
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('Repository is not allowed');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+
+      mockMutateAsync.mockResolvedValueOnce({ id: 'session-7' });
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/pl-infra/agent-sessions/session-7'));
+    });
+  });
+
+  describe('duplicate guard', () => {
+    it('offers the existing session instead of creating another', async () => {
+      const user = userEvent.setup();
+      window.localStorage.setItem('gantry-agent-sessions', JSON.stringify({ 'item-1': 'session-99' }));
+
+      renderButton();
+      const viewBtn = screen.getByRole('button', { name: /view session/i });
+      expect(screen.queryByRole('button', { name: /build with ai/i })).not.toBeInTheDocument();
+
+      await user.click(viewBtn);
+      expect(mockPush).toHaveBeenCalledWith('/pl-infra/agent-sessions/session-99');
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('remembers the session it just created', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      await user.click(screen.getByRole('button', { name: /create session/i }));
+
+      await waitFor(() => {
+        expect(JSON.parse(window.localStorage.getItem('gantry-agent-sessions') ?? '{}')).toEqual({
+          'item-1': 'session-42',
+        });
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes the picker as a labelled dialog', async () => {
+      const user = userEvent.setup();
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAccessibleName('Build with AI');
+      expect(screen.getByLabelText('Repository')).toHaveFocus();
+    });
+
+    it('closes only the picker on Escape, without bubbling to a host drawer', async () => {
+      const user = userEvent.setup();
+      const drawerEscape = jest.fn();
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') drawerEscape();
+      });
+
+      renderButton();
+      await user.click(screen.getByRole('button', { name: /build with ai/i }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(drawerEscape).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/utils/gantryAgentPrompt.test.ts
+++ b/__tests__/utils/gantryAgentPrompt.test.ts
@@ -1,0 +1,46 @@
+import {
+  buildAgentPrompt,
+  AGENT_PROMPT_MAX_LENGTH,
+} from '@/utils/gantryAgentPrompt';
+
+describe('buildAgentPrompt', () => {
+  it('joins the title and the stripped description', () => {
+    const result = buildAgentPrompt('Add dark mode', '<p>Users keep asking.</p><p>Follow the tokens.</p>');
+
+    expect(result.prompt).toBe('Add dark mode\n\nUsers keep asking.\n\nFollow the tokens.');
+    expect(result.isTruncated).toBe(false);
+    expect(result.isTooShort).toBe(false);
+  });
+
+  it('falls back to title-only when Quill reports an empty body', () => {
+    // Quill serialises an empty editor as <p><br></p>, which is truthy.
+    const result = buildAgentPrompt('Add dark mode', '<p><br></p>');
+
+    expect(result.prompt).toBe('Add dark mode');
+    expect(result.isTooShort).toBe(false);
+  });
+
+  it('handles a missing description', () => {
+    expect(buildAgentPrompt('Add dark mode', null).prompt).toBe('Add dark mode');
+    expect(buildAgentPrompt('Add dark mode', undefined).prompt).toBe('Add dark mode');
+  });
+
+  it('flags a prompt too short for the backend minimum', () => {
+    expect(buildAgentPrompt('ab', '<p><br></p>').isTooShort).toBe(true);
+    expect(buildAgentPrompt('', '').isTooShort).toBe(true);
+  });
+
+  it('truncates past the backend maximum at a word boundary', () => {
+    const longBody = `<p>${'word '.repeat(6000)}</p>`;
+    const result = buildAgentPrompt('Long item', longBody);
+
+    expect(result.isTruncated).toBe(true);
+    expect(result.prompt.length).toBeLessThanOrEqual(AGENT_PROMPT_MAX_LENGTH);
+    expect(result.prompt.endsWith('word')).toBe(true);
+  });
+
+  it('does not truncate a body that fits', () => {
+    const result = buildAgentPrompt('Item', `<p>${'a'.repeat(100)}</p>`);
+    expect(result.isTruncated).toBe(false);
+  });
+});

--- a/components/page/gantry/GantryDetailPage.module.scss
+++ b/components/page/gantry/GantryDetailPage.module.scss
@@ -142,6 +142,13 @@
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
+
+  /* Every action inside gates itself, so a viewer with none of them leaves this
+     wrapper empty — and an empty flex item still claims `.headerTop`'s 16px gap,
+     narrowing the title and wrapping it a word early. */
+  &:empty {
+    display: none;
+  }
 }
 
 .archiveAction {

--- a/components/page/gantry/shared/BuildWithAgentsButton.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsButton.tsx
@@ -36,6 +36,11 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
   const isSubmittingRef = useRef(false);
   const [pickerPos, setPickerPos] = useState<{ top: number; left: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /* Owned here rather than read off `createMutation.isPending`, so the in-flight
+     state has one source of truth that flips in the same commit as the ref
+     above. The mutation's own flag lands a render later — the same lag that let
+     a double-click through before. */
+  const [isCreating, setIsCreating] = useState(false);
 
   const canAdmin = canAdminAgentSessions(permsSet);
   const existingSessionId = useSyncExternalStore(
@@ -83,6 +88,7 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
     }
 
     isSubmittingRef.current = true;
+    setIsCreating(true);
     try {
       const session = await createMutation.mutateAsync({ repository, prompt });
       rememberGantryAgentSession(uid, session.id);
@@ -96,6 +102,7 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
       /* Only release the latch on failure. After a success we're navigating
          away, and staying latched covers the gap before the route changes. */
       isSubmittingRef.current = false;
+      setIsCreating(false);
       setError(err instanceof Error ? err.message : 'Failed to create session');
     }
   };
@@ -120,7 +127,7 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
 
   return (
     <div ref={triggerRef} className={s.buildAction}>
-      <HeaderActionBtn onClick={openPicker} disabled={createMutation.isPending}>
+      <HeaderActionBtn onClick={openPicker} disabled={isCreating}>
         <MagicSparklesIcon className={s.buildButtonIcon} />
         Build with AI
       </HeaderActionBtn>
@@ -128,7 +135,7 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
       {pickerPos && (
         <BuildWithAgentsRepoPicker
           pos={pickerPos}
-          isCreating={createMutation.isPending}
+          isCreating={isCreating}
           error={error}
           notice={
             isTruncated

--- a/components/page/gantry/shared/BuildWithAgentsButton.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState, useSyncExternalStore } from 'react';
 import { MagicSparklesIcon } from '@/components/icons/MagicSparklesIcon';
 import { HeaderActionBtn } from '@/components/common/profile/DetailsSection/components/DetailsSectionHeader';
 import { usePermissions } from '@/services/rbac/hooks/usePermissions';
@@ -10,7 +10,11 @@ import { useCreateAgentSession } from '@/services/agent-sessions/hooks/useCreate
 import { trackBuildButtonClick } from '@/services/gantry/gantry.service';
 import { useGantryAnalytics } from '@/analytics/gantry.analytics';
 import { buildAgentPrompt, AGENT_PROMPT_MAX_LENGTH } from '@/utils/gantryAgentPrompt';
-import { getGantryAgentSessionId, rememberGantryAgentSession } from '@/utils/gantryAgentSessionStorage';
+import {
+  getGantryAgentSessionId,
+  rememberGantryAgentSession,
+  subscribeGantryAgentSessions,
+} from '@/utils/gantryAgentSessionStorage';
 import { BuildWithAgentsRepoPicker } from './BuildWithAgentsRepoPicker';
 import s from './Shared.module.scss';
 
@@ -32,15 +36,23 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
   const isSubmittingRef = useRef(false);
   const [pickerPos, setPickerPos] = useState<{ top: number; left: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [existingSessionId, setExistingSessionId] = useState<string | null>(null);
 
   const canAdmin = canAdminAgentSessions(permsSet);
+  const existingSessionId = useSyncExternalStore(
+    subscribeGantryAgentSessions,
+    () => getGantryAgentSessionId(uid),
+    () => null,
+  );
 
-  useEffect(() => {
-    setExistingSessionId(getGantryAgentSessionId(uid));
+  /* The drawer keeps this component mounted while swapping items, so picker
+     state belongs to the uid that opened it. Adjusting during render (rather
+     than in an effect) drops the stale popover in the same commit. */
+  const [renderedUid, setRenderedUid] = useState(uid);
+  if (renderedUid !== uid) {
+    setRenderedUid(uid);
     setPickerPos(null);
     setError(null);
-  }, [uid]);
+  }
 
   const closePicker = () => {
     setPickerPos(null);

--- a/components/page/gantry/shared/BuildWithAgentsButton.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsButton.tsx
@@ -1,42 +1,133 @@
 'use client';
 
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 import { MagicSparklesIcon } from '@/components/icons/MagicSparklesIcon';
+import { HeaderActionBtn } from '@/components/common/profile/DetailsSection/components/DetailsSectionHeader';
+import { usePermissions } from '@/services/rbac/hooks/usePermissions';
+import { canAdminAgentSessions } from '@/services/rbac/utils/agentSessions/canAdminAgentSessions';
+import { useCreateAgentSession } from '@/services/agent-sessions/hooks/useCreateAgentSession';
 import { trackBuildButtonClick } from '@/services/gantry/gantry.service';
+import { useGantryAnalytics } from '@/analytics/gantry.analytics';
+import { buildAgentPrompt, AGENT_PROMPT_MAX_LENGTH } from '@/utils/gantryAgentPrompt';
+import { getGantryAgentSessionId, rememberGantryAgentSession } from '@/utils/gantryAgentSessionStorage';
+import { BuildWithAgentsRepoPicker } from './BuildWithAgentsRepoPicker';
 import s from './Shared.module.scss';
 
 interface Props {
   readonly uid: string;
-  readonly onTracked?: () => void;
+  readonly title: string;
+  readonly description?: string | null;
 }
 
-export function BuildWithAgentsButton({ uid, onTracked }: Props) {
-  const [isTracking, setIsTracking] = useState(false);
+export function BuildWithAgentsButton({ uid, title, description }: Props) {
+  const router = useRouter();
+  const analytics = useGantryAnalytics();
+  const { permsSet, isLoading: permsLoading, isError: permsError } = usePermissions();
+  const createMutation = useCreateAgentSession();
+  const triggerRef = useRef<HTMLDivElement>(null);
+  /* `createMutation.isPending` only turns true on the next render, so two fast
+     clicks can both pass a check against it and open two sessions — and the
+     endpoint has no idempotency key to save us. A ref flips synchronously. */
+  const isSubmittingRef = useRef(false);
+  const [pickerPos, setPickerPos] = useState<{ top: number; left: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [existingSessionId, setExistingSessionId] = useState<string | null>(null);
 
-  const handleClick = async () => {
-    if (isTracking) return;
-    setIsTracking(true);
+  const canAdmin = canAdminAgentSessions(permsSet);
+
+  useEffect(() => {
+    setExistingSessionId(getGantryAgentSessionId(uid));
+    setPickerPos(null);
+    setError(null);
+  }, [uid]);
+
+  const closePicker = () => {
+    setPickerPos(null);
+    setError(null);
+    /* Send focus back where it came from — the picker is a dialog, and a
+       dismissed dialog that drops focus to <body> strands keyboard users. */
+    triggerRef.current?.querySelector('button')?.focus();
+  };
+
+  const openPicker = () => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setError(null);
+    setPickerPos({
+      top: Math.min(rect.bottom + 8, window.innerHeight - 260),
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - 328)),
+    });
+  };
+
+  const handleCreate = async (repository: string) => {
+    if (isSubmittingRef.current) return;
+    setError(null);
+
+    const { prompt, isTooShort } = buildAgentPrompt(title, description);
+    if (isTooShort) {
+      setError('This item needs a longer title or description before an agent can work on it.');
+      return;
+    }
+
+    isSubmittingRef.current = true;
     try {
-      await trackBuildButtonClick(uid);
-      onTracked?.();
-    } catch {
-      // Fire-and-forget analytics click endpoint.
-    } finally {
-      setIsTracking(false);
+      const session = await createMutation.mutateAsync({ repository, prompt });
+      rememberGantryAgentSession(uid, session.id);
+      /* Fire once the session actually exists: the demand-era endpoint counted
+         intent, but a working button should count sessions. Both channels were
+         wired but never called — this is their first real signal. */
+      void trackBuildButtonClick(uid).catch(() => undefined);
+      analytics.onBuildButtonClicked(uid);
+      router.push(`/pl-infra/agent-sessions/${session.id}`);
+    } catch (err) {
+      /* Only release the latch on failure. After a success we're navigating
+         away, and staying latched covers the gap before the route changes. */
+      isSubmittingRef.current = false;
+      setError(err instanceof Error ? err.message : 'Failed to create session');
     }
   };
 
+  /* Nothing renders until permissions resolve. `usePermissions` retries twice
+     and then leaves permsSet empty, so an error is indistinguishable from "not
+     an admin" — both must stay silent rather than flash the button. */
+  if (permsLoading || permsError || !canAdmin) return null;
+
+  if (existingSessionId) {
+    return (
+      <div ref={triggerRef} className={s.buildAction}>
+        <HeaderActionBtn onClick={() => router.push(`/pl-infra/agent-sessions/${existingSessionId}`)}>
+          <MagicSparklesIcon className={s.buildButtonIcon} />
+          View session
+        </HeaderActionBtn>
+      </div>
+    );
+  }
+
+  const { isTruncated } = buildAgentPrompt(title, description);
+
   return (
-    <button
-      type="button"
-      className={s.buildButton}
-      aria-disabled="true"
-      onClick={handleClick}
-      disabled={isTracking}
-    >
-      <MagicSparklesIcon className={s.buildButtonIcon} />
-      <span>Build this with agents</span>
-      <span className={s.comingSoon}>Coming soon</span>
-    </button>
+    <div ref={triggerRef} className={s.buildAction}>
+      <HeaderActionBtn onClick={openPicker} disabled={createMutation.isPending}>
+        <MagicSparklesIcon className={s.buildButtonIcon} />
+        Build with AI
+      </HeaderActionBtn>
+
+      {pickerPos && (
+        <BuildWithAgentsRepoPicker
+          pos={pickerPos}
+          isCreating={createMutation.isPending}
+          error={error}
+          notice={
+            isTruncated
+              ? `This item is longer than the ${AGENT_PROMPT_MAX_LENGTH.toLocaleString()} character limit and will be shortened.`
+              : null
+          }
+          canSubmit
+          onCreate={handleCreate}
+          onDismiss={closePicker}
+        />
+      )}
+    </div>
   );
 }

--- a/components/page/gantry/shared/BuildWithAgentsButton.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsButton.tsx
@@ -49,14 +49,17 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
     () => null,
   );
 
-  /* The drawer keeps this component mounted while swapping items, so picker
-     state belongs to the uid that opened it. Adjusting during render (rather
-     than in an effect) drops the stale popover in the same commit. */
+  /* Picker state belongs to the uid that opened it. The drawer keys on itemId
+     so it remounts between items, but the page variant renders this same
+     component across /gantry/[uid] changes — so reset rather than depend on a
+     remount we don't own. Adjusting during render (rather than in an effect)
+     drops the stale popover in the same commit. */
   const [renderedUid, setRenderedUid] = useState(uid);
   if (renderedUid !== uid) {
     setRenderedUid(uid);
     setPickerPos(null);
     setError(null);
+    setIsCreating(false);
   }
 
   const closePicker = () => {
@@ -71,10 +74,13 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (!rect) return;
     setError(null);
-    setPickerPos({
-      top: Math.min(rect.bottom + 8, window.innerHeight - 260),
-      left: Math.max(8, Math.min(rect.left, window.innerWidth - 328)),
-    });
+    /* Cleared here rather than in the uid-change reset above, which runs during
+       render where refs are off limits. Opening the picker is the only route
+       back into a create, so this is the last moment it can matter. */
+    isSubmittingRef.current = false;
+    /* Just the anchor point — the picker measures itself and clamps into the
+       viewport, since its height depends on which notices it ends up showing. */
+    setPickerPos({ top: rect.bottom + 8, left: rect.left });
   };
 
   const handleCreate = async (repository: string) => {
@@ -142,7 +148,6 @@ export function BuildWithAgentsButton({ uid, title, description }: Props) {
               ? `This item is longer than the ${AGENT_PROMPT_MAX_LENGTH.toLocaleString()} character limit and will be shortened.`
               : null
           }
-          canSubmit
           onCreate={handleCreate}
           onDismiss={closePicker}
         />

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.module.scss
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.module.scss
@@ -72,21 +72,6 @@
   color: #374151;
 }
 
-.select {
-  width: 100%;
-  padding: 8px 10px;
-  border-radius: 8px;
-  border: 1px solid #e5e7eb;
-  background: #fff;
-  font-size: 0.8125rem;
-  color: #111827;
-
-  &:disabled {
-    background: #f9fafb;
-    color: #9ca3af;
-  }
-}
-
 .muted {
   font-size: 0.75rem;
   color: #9ca3af;

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.module.scss
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.module.scss
@@ -1,0 +1,150 @@
+/* Mirrors PinSwapPicker.module.scss — same anchored-popover shape and z-index
+   band, so the two gantry pickers stack and read identically. */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 299;
+}
+
+.popover {
+  position: fixed;
+  z-index: 300;
+  width: 320px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 14px 0;
+}
+
+.headerTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #9ca3af;
+  padding: 0;
+
+  &:hover {
+    background: #f3f4f6;
+    color: #374151;
+  }
+}
+
+.sub {
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin: 4px 14px 10px;
+  line-height: 1.4;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-top: 1px solid #f3f4f6;
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  font-size: 0.8125rem;
+  color: #111827;
+
+  &:disabled {
+    background: #f9fafb;
+    color: #9ca3af;
+  }
+}
+
+.muted {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  line-height: 1.4;
+}
+
+.error {
+  font-size: 0.75rem;
+  color: #dc2626;
+  line-height: 1.4;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid #f3f4f6;
+  background: #fafafa;
+}
+
+.secondaryBtn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: #f3f4f6;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.primaryBtn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  background: #1b4dff;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: #1740d6;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
@@ -32,15 +32,12 @@ export function BuildWithAgentsRepoPicker({
 }: Props) {
   const { data: repositories, isLoading, isError } = useAgentSessionRepositories();
   const selectRef = useRef<HTMLSelectElement>(null);
-  const [repository, setRepository] = useState('');
+  const [picked, setPicked] = useState<string | null>(null);
 
   const enabledRepos = useMemo(() => (repositories ?? []).filter((repo) => repo.enabled), [repositories]);
-
-  useEffect(() => {
-    if (!repository && enabledRepos.length > 0) {
-      setRepository(enabledRepos[0].key);
-    }
-  }, [enabledRepos, repository]);
+  /* Derived rather than synced into state: the default is simply "whatever the
+     list leads with" until the user chooses otherwise. */
+  const repository = picked ?? enabledRepos[0]?.key ?? '';
 
   useEffect(() => {
     selectRef.current?.focus();
@@ -103,7 +100,7 @@ export function BuildWithAgentsRepoPicker({
             className={s.select}
             value={repository}
             disabled={isLoading || isError || isRepoListEmpty || isCreating}
-            onChange={(event) => setRepository(event.target.value)}
+            onChange={(event) => setPicked(event.target.value)}
           >
             {enabledRepos.map((repo) => (
               <option key={repo.key} value={repo.key}>

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useAgentSessionRepositories } from '@/services/agent-sessions/hooks/useAgentSessionRepositories';
 import s from './BuildWithAgentsRepoPicker.module.scss';
 
 interface Props {
+  /** Anchor point under the trigger. The popover clamps itself into view from here. */
   readonly pos: { top: number; left: number };
   readonly isCreating: boolean;
   readonly error: string | null;
   readonly notice: string | null;
-  readonly canSubmit: boolean;
   readonly onCreate: (repository: string) => void;
   readonly onDismiss: () => void;
 }
+
+/** Breathing room kept between the popover and the viewport edges. */
+const VIEWPORT_MARGIN = 12;
 
 /* A Gantry item has no repository and none can be inferred from it, so this one
    field is the whole reason the flow isn't a bare button. Anchored popover
@@ -21,17 +24,10 @@ interface Props {
    Mounted only while open: `useAgentSessionRepositories` has no staleTime or
    `enabled`, so hoisting the hook into the button would fetch the repo list on
    every Gantry detail open, for every admin, whether or not they build. */
-export function BuildWithAgentsRepoPicker({
-  pos,
-  isCreating,
-  error,
-  notice,
-  canSubmit,
-  onCreate,
-  onDismiss,
-}: Props) {
+export function BuildWithAgentsRepoPicker({ pos, isCreating, error, notice, onCreate, onDismiss }: Props) {
   const { data: repositories, isLoading, isError } = useAgentSessionRepositories();
   const selectRef = useRef<HTMLSelectElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const [picked, setPicked] = useState<string | null>(null);
 
   const enabledRepos = useMemo(() => (repositories ?? []).filter((repo) => repo.enabled), [repositories]);
@@ -42,6 +38,24 @@ export function BuildWithAgentsRepoPicker({
   useEffect(() => {
     selectRef.current?.focus();
   }, [enabledRepos.length]);
+
+  /* Measure rather than guess, the way BoostImpactPopover does: this popover
+     grows after it opens — the loading line, a repo-load failure, the empty-repo
+     notice, the truncation notice and the inline create error each add a row —
+     and `.popover` is `overflow: hidden`, so anything spilling past the viewport
+     is clipped, not scrollable. A create failure growing the box must not push
+     the Create/Cancel footer off-screen. Runs before paint, so it never flickers. */
+  const [placement, setPlacement] = useState(pos);
+  useLayoutEffect(() => {
+    const el = popoverRef.current;
+    if (!el) return;
+    const maxTop = window.innerHeight - el.offsetHeight - VIEWPORT_MARGIN;
+    const maxLeft = window.innerWidth - el.offsetWidth - VIEWPORT_MARGIN;
+    setPlacement({
+      top: Math.max(VIEWPORT_MARGIN, Math.min(pos.top, maxTop)),
+      left: Math.max(VIEWPORT_MARGIN, Math.min(pos.left, maxLeft)),
+    });
+  }, [pos, isLoading, isError, enabledRepos.length, notice, error]);
 
   /* Single-flight, matching BoostImpactPopover: once the session request is out
      there is no way to recall it, so every dismissal path is a no-op until it
@@ -68,7 +82,7 @@ export function BuildWithAgentsRepoPicker({
   }, [dismiss]);
 
   const isRepoListEmpty = !isLoading && !isError && enabledRepos.length === 0;
-  const isBlocked = isLoading || isError || isRepoListEmpty || !repository || !canSubmit;
+  const isBlocked = isLoading || isError || isRepoListEmpty || !repository;
 
   return (
     <>
@@ -80,8 +94,9 @@ export function BuildWithAgentsRepoPicker({
         }}
       />
       <div
+        ref={popoverRef}
         className={s.popover}
-        style={{ top: pos.top, left: pos.left }}
+        style={{ top: placement.top, left: placement.left }}
         role="dialog"
         aria-modal="true"
         aria-labelledby="build-with-ai-title"

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgentSessionRepositories } from '@/services/agent-sessions/hooks/useAgentSessionRepositories';
 import s from './BuildWithAgentsRepoPicker.module.scss';
 
@@ -43,20 +43,29 @@ export function BuildWithAgentsRepoPicker({
     selectRef.current?.focus();
   }, [enabledRepos.length]);
 
+  /* Single-flight, matching BoostImpactPopover: once the session request is out
+     there is no way to recall it, so every dismissal path is a no-op until it
+     settles. Closing the popover wouldn't cancel anything — it would just hide
+     the pending navigation the caller performs on success. */
+  const dismiss = useCallback(() => {
+    if (!isCreating) onDismiss();
+  }, [isCreating, onDismiss]);
+
   /* Capture phase, so Escape closes this popover and stops there. The Drawer
      that may be hosting us listens for Escape on `document` in the bubble phase
      (Drawer.tsx) — without claiming the key first, dismissing the picker would
-     also tear down the whole drawer behind it. */
+     also tear down the whole drawer behind it. We swallow the key even while
+     creating, so a blocked dismissal doesn't fall through to the drawer. */
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.stopPropagation();
       event.preventDefault();
-      onDismiss();
+      dismiss();
     };
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [onDismiss]);
+  }, [dismiss]);
 
   const isRepoListEmpty = !isLoading && !isError && enabledRepos.length === 0;
   const isBlocked = isLoading || isError || isRepoListEmpty || !repository || !canSubmit;
@@ -67,7 +76,7 @@ export function BuildWithAgentsRepoPicker({
         className={s.backdrop}
         onClick={(event) => {
           event.stopPropagation();
-          onDismiss();
+          dismiss();
         }}
       />
       <div
@@ -82,7 +91,7 @@ export function BuildWithAgentsRepoPicker({
           <span className={s.headerTitle} id="build-with-ai-title">
             Build with AI
           </span>
-          <button type="button" className={s.closeBtn} onClick={onDismiss} aria-label="Close">
+          <button type="button" className={s.closeBtn} onClick={dismiss} disabled={isCreating} aria-label="Close">
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
               <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
             </svg>
@@ -121,7 +130,7 @@ export function BuildWithAgentsRepoPicker({
         </div>
 
         <div className={s.footer}>
-          <button type="button" className={s.secondaryBtn} onClick={onDismiss} disabled={isCreating}>
+          <button type="button" className={s.secondaryBtn} onClick={dismiss} disabled={isCreating}>
             Cancel
           </button>
           <button

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import Select, { type SelectInstance } from 'react-select';
+import { filterSelectStyles } from '@/components/common/filters/FilterSelect/filterSelectStyles';
+import type { Option } from '@/components/form/FormSelect/types';
 import { useAgentSessionRepositories } from '@/services/agent-sessions/hooks/useAgentSessionRepositories';
 import s from './BuildWithAgentsRepoPicker.module.scss';
 
@@ -17,6 +20,17 @@ interface Props {
 /** Breathing room kept between the popover and the viewport edges. */
 const VIEWPORT_MARGIN = 12;
 
+/* The house filter styling, with the menu lifted above this popover's own layer.
+   FilterSelect portals its menu to document.body at z-index 20, which sits under
+   our backdrop (299) — inside an overlay that renders the menu unclickable. The
+   rest of the look is shared, so the control still matches every other select in
+   the app. */
+const repoSelectStyles: typeof filterSelectStyles = {
+  ...filterSelectStyles,
+  menu: (base, props) => ({ ...filterSelectStyles.menu?.(base, props), zIndex: 320 }),
+  menuPortal: (base, props) => ({ ...filterSelectStyles.menuPortal?.(base, props), zIndex: 320 }),
+};
+
 /* A Gantry item has no repository and none can be inferred from it, so this one
    field is the whole reason the flow isn't a bare button. Anchored popover
    rather than a Modal to match PinSwapPicker, its neighbour in this directory.
@@ -26,14 +40,22 @@ const VIEWPORT_MARGIN = 12;
    every Gantry detail open, for every admin, whether or not they build. */
 export function BuildWithAgentsRepoPicker({ pos, isCreating, error, notice, onCreate, onDismiss }: Props) {
   const { data: repositories, isLoading, isError } = useAgentSessionRepositories();
-  const selectRef = useRef<HTMLSelectElement>(null);
+  const selectRef = useRef<SelectInstance<Option, false> | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [picked, setPicked] = useState<string | null>(null);
+  /* Controlled so Escape can close the menu without also closing the popover —
+     see the key handler below. */
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const enabledRepos = useMemo(() => (repositories ?? []).filter((repo) => repo.enabled), [repositories]);
+  const options = useMemo<Option[]>(
+    () => enabledRepos.map((repo) => ({ value: repo.key, label: `${repo.displayName} (${repo.key})` })),
+    [enabledRepos],
+  );
   /* Derived rather than synced into state: the default is simply "whatever the
      list leads with" until the user chooses otherwise. */
   const repository = picked ?? enabledRepos[0]?.key ?? '';
+  const selected = options.find((option) => option.value === repository) ?? null;
 
   useEffect(() => {
     selectRef.current?.focus();
@@ -69,17 +91,25 @@ export function BuildWithAgentsRepoPicker({ pos, isCreating, error, notice, onCr
      that may be hosting us listens for Escape on `document` in the bubble phase
      (Drawer.tsx) — without claiming the key first, dismissing the picker would
      also tear down the whole drawer behind it. We swallow the key even while
-     creating, so a blocked dismissal doesn't fall through to the drawer. */
+     creating, so a blocked dismissal doesn't fall through to the drawer.
+
+     Claiming it this early also takes it away from the repo dropdown, so an open
+     menu has to be unwound here: one Escape closes the menu, the next closes the
+     popover — what the dropdown would have done on its own. */
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.stopPropagation();
       event.preventDefault();
+      if (isMenuOpen) {
+        setIsMenuOpen(false);
+        return;
+      }
       dismiss();
     };
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [dismiss]);
+  }, [dismiss, isMenuOpen]);
 
   const isRepoListEmpty = !isLoading && !isError && enabledRepos.length === 0;
   const isBlocked = isLoading || isError || isRepoListEmpty || !repository;
@@ -118,22 +148,27 @@ export function BuildWithAgentsRepoPicker({ pos, isCreating, error, notice, onCr
           <label className={s.label} htmlFor="build-with-ai-repository">
             Repository
           </label>
-          <select
-            id="build-with-ai-repository"
+          <Select
             ref={selectRef}
-            className={s.select}
-            value={repository}
-            disabled={isLoading || isError || isRepoListEmpty || isCreating}
-            onChange={(event) => setPicked(event.target.value)}
-          >
-            {enabledRepos.map((repo) => (
-              <option key={repo.key} value={repo.key}>
-                {repo.displayName} ({repo.key})
-              </option>
-            ))}
-          </select>
+            inputId="build-with-ai-repository"
+            options={options}
+            value={selected}
+            onChange={(option) => setPicked(option?.value ?? null)}
+            isDisabled={isLoading || isError || isRepoListEmpty || isCreating}
+            isLoading={isLoading}
+            isSearchable={false}
+            placeholder={isLoading ? 'Loading repositories…' : 'Select a repository'}
+            styles={repoSelectStyles}
+            menuIsOpen={isMenuOpen}
+            onMenuOpen={() => setIsMenuOpen(true)}
+            onMenuClose={() => setIsMenuOpen(false)}
+            /* Escapes the popover's `overflow: hidden`, which would otherwise
+               clip the menu to the card. */
+            menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+            menuPosition="fixed"
+          />
 
-          {isLoading && <p className={s.muted}>Loading repositories…</p>}
+          {/* No loading line — the control carries its own spinner and placeholder. */}
           {isError && <p className={s.error}>Could not load repositories. Close and try again.</p>}
           {isRepoListEmpty && <p className={s.error}>No repositories are enabled for agent sessions.</p>}
           {notice && <p className={s.muted}>{notice}</p>}

--- a/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
+++ b/components/page/gantry/shared/BuildWithAgentsRepoPicker.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAgentSessionRepositories } from '@/services/agent-sessions/hooks/useAgentSessionRepositories';
+import s from './BuildWithAgentsRepoPicker.module.scss';
+
+interface Props {
+  readonly pos: { top: number; left: number };
+  readonly isCreating: boolean;
+  readonly error: string | null;
+  readonly notice: string | null;
+  readonly canSubmit: boolean;
+  readonly onCreate: (repository: string) => void;
+  readonly onDismiss: () => void;
+}
+
+/* A Gantry item has no repository and none can be inferred from it, so this one
+   field is the whole reason the flow isn't a bare button. Anchored popover
+   rather than a Modal to match PinSwapPicker, its neighbour in this directory.
+
+   Mounted only while open: `useAgentSessionRepositories` has no staleTime or
+   `enabled`, so hoisting the hook into the button would fetch the repo list on
+   every Gantry detail open, for every admin, whether or not they build. */
+export function BuildWithAgentsRepoPicker({
+  pos,
+  isCreating,
+  error,
+  notice,
+  canSubmit,
+  onCreate,
+  onDismiss,
+}: Props) {
+  const { data: repositories, isLoading, isError } = useAgentSessionRepositories();
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const [repository, setRepository] = useState('');
+
+  const enabledRepos = useMemo(() => (repositories ?? []).filter((repo) => repo.enabled), [repositories]);
+
+  useEffect(() => {
+    if (!repository && enabledRepos.length > 0) {
+      setRepository(enabledRepos[0].key);
+    }
+  }, [enabledRepos, repository]);
+
+  useEffect(() => {
+    selectRef.current?.focus();
+  }, [enabledRepos.length]);
+
+  /* Capture phase, so Escape closes this popover and stops there. The Drawer
+     that may be hosting us listens for Escape on `document` in the bubble phase
+     (Drawer.tsx) — without claiming the key first, dismissing the picker would
+     also tear down the whole drawer behind it. */
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.stopPropagation();
+      event.preventDefault();
+      onDismiss();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [onDismiss]);
+
+  const isRepoListEmpty = !isLoading && !isError && enabledRepos.length === 0;
+  const isBlocked = isLoading || isError || isRepoListEmpty || !repository || !canSubmit;
+
+  return (
+    <>
+      <div
+        className={s.backdrop}
+        onClick={(event) => {
+          event.stopPropagation();
+          onDismiss();
+        }}
+      />
+      <div
+        className={s.popover}
+        style={{ top: pos.top, left: pos.left }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="build-with-ai-title"
+        aria-busy={isCreating}
+      >
+        <div className={s.header}>
+          <span className={s.headerTitle} id="build-with-ai-title">
+            Build with AI
+          </span>
+          <button type="button" className={s.closeBtn} onClick={onDismiss} aria-label="Close">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+              <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+        <p className={s.sub}>Starts an agent session from this item&rsquo;s title and description.</p>
+
+        <div className={s.body}>
+          <label className={s.label} htmlFor="build-with-ai-repository">
+            Repository
+          </label>
+          <select
+            id="build-with-ai-repository"
+            ref={selectRef}
+            className={s.select}
+            value={repository}
+            disabled={isLoading || isError || isRepoListEmpty || isCreating}
+            onChange={(event) => setRepository(event.target.value)}
+          >
+            {enabledRepos.map((repo) => (
+              <option key={repo.key} value={repo.key}>
+                {repo.displayName} ({repo.key})
+              </option>
+            ))}
+          </select>
+
+          {isLoading && <p className={s.muted}>Loading repositories…</p>}
+          {isError && <p className={s.error}>Could not load repositories. Close and try again.</p>}
+          {isRepoListEmpty && <p className={s.error}>No repositories are enabled for agent sessions.</p>}
+          {notice && <p className={s.muted}>{notice}</p>}
+          {error && (
+            <p className={s.error} role="alert" aria-live="polite">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className={s.footer}>
+          <button type="button" className={s.secondaryBtn} onClick={onDismiss} disabled={isCreating}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={s.primaryBtn}
+            disabled={isBlocked || isCreating}
+            onClick={() => onCreate(repository)}
+          >
+            {isCreating ? 'Creating…' : 'Create session'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/page/gantry/shared/GantryItemDetailContent.tsx
+++ b/components/page/gantry/shared/GantryItemDetailContent.tsx
@@ -28,6 +28,7 @@ import { GantryItemAuthor } from './GantryItemAuthor';
 import { PinNotePopover } from './PinNotePopover';
 import { BoostImpactPopover } from './BoostImpactPopover';
 import { PinSwapPicker } from './PinSwapPicker';
+import { BuildWithAgentsButton } from './BuildWithAgentsButton';
 import { ImpactDetailSection } from './ImpactDetailSection';
 import { hasImpactData } from '@/services/gantry/impact';
 import { StageSelector } from './StageSelector';
@@ -181,19 +182,27 @@ export function GantryItemDetailContent({ uid, variant, onDismiss, headerStart }
         <div className={s.header}>
           <div className={s.headerTop}>
             <h1 className={clsx(s.title, variant === 'drawer' && s.drawerTitle)}>{item.title}</h1>
-            {canEdit && !isEditMode && (
+            {!isEditMode && (
               <div className={s.itemActions}>
-                <EditButton onClick={() => setIsEditMode(true)} />
-                {access.canCurate && (
-                  <HeaderActionBtn
-                    onClick={() => setIsArchiveModalOpen(true)}
-                    disabled={archiveMutation.isPending}
-                    className={s.archiveAction}
-                  >
-                    <ArchiveIcon />
-                    Archive
-                  </HeaderActionBtn>
+                {canEdit && (
+                  <>
+                    <EditButton onClick={() => setIsEditMode(true)} />
+                    {access.canCurate && (
+                      <HeaderActionBtn
+                        onClick={() => setIsArchiveModalOpen(true)}
+                        disabled={archiveMutation.isPending}
+                        className={s.archiveAction}
+                      >
+                        <ArchiveIcon />
+                        Archive
+                      </HeaderActionBtn>
+                    )}
+                  </>
                 )}
+                {/* Gates itself on agent-sessions admin — deliberately not on
+                    `canEdit`, which is stage-limited to IDEA/BACKLOG and would
+                    hide the button on exactly the items worth building. */}
+                <BuildWithAgentsButton uid={item.uid} title={item.title} description={item.description} />
               </div>
             )}
           </div>

--- a/components/page/gantry/shared/Shared.module.scss
+++ b/components/page/gantry/shared/Shared.module.scss
@@ -223,10 +223,11 @@
   flex-shrink: 0;
 }
 
-/* The trigger anchors its popover, so it needs to be a positioned box in the
-   header action row rather than a bare button. */
+/* Wraps the trigger so it sits as one item in the header action row and so the
+   dismissal handler has an element to restore focus into. No `position` here on
+   purpose: the popover is `position: fixed` against viewport coordinates, so a
+   containing block would do nothing. */
 .buildAction {
-  position: relative;
   display: inline-flex;
 }
 

--- a/components/page/gantry/shared/Shared.module.scss
+++ b/components/page/gantry/shared/Shared.module.scss
@@ -223,43 +223,13 @@
   flex-shrink: 0;
 }
 
-.buildButton {
+/* The trigger anchors its popover, so it needs to be a positioned box in the
+   header action row rather than a bare button. */
+.buildAction {
+  position: relative;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: fit-content;
-  max-width: 100%;
-  padding: 9px 16px;
-  border-radius: 8px;
-  border: 1px solid rgba(14, 15, 17, 0.12);
-  background: #f9fafb;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
-  letter-spacing: -0.2px;
-  color: #8897ae;
-  cursor: not-allowed;
-  margin-top: 8px;
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: wait;
-  }
 }
 
 .buildButtonIcon {
   flex-shrink: 0;
-}
-
-.comingSoon {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 16px;
-  border-radius: 999px;
-  border: 1px solid rgba(14, 15, 17, 0.12);
-  background: #fff;
-  padding: 2px 8px;
-  color: #8897ae;
 }

--- a/prototypes/entries/gantry-impact-rating/shared/ItemDrawer.module.scss
+++ b/prototypes/entries/gantry-impact-rating/shared/ItemDrawer.module.scss
@@ -182,3 +182,41 @@
   font-weight: 500;
   color: var(--foreground-neutral-tertiary, #8897ae);
 }
+
+// Frozen copy of production's old "Build this with agents / Coming soon" chrome.
+// Production replaced that disabled control with a live "Build with AI" button and
+// dropped these rules, so they no longer exist in Shared.module.scss to borrow —
+// this prototype keeps the pre-change look on its own. Sizes are production's
+// verbatim; only the color layer is translated to token pairs. The production
+// `:disabled` branch is omitted: this copy is inert (`aria-disabled`), never disabled.
+.buildButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 9px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--transparent-dark-12, rgba(14, 15, 17, 0.12));
+  background: var(--background-neutral-subtle, #f9fafb);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+  cursor: not-allowed;
+  margin-top: 8px;
+}
+
+.comingSoon {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  border-radius: 999px;
+  border: 1px solid var(--transparent-dark-12, rgba(14, 15, 17, 0.12));
+  background: var(--background-neutral-primary, #fff);
+  padding: 2px 8px;
+  color: var(--foreground-neutral-tertiary, #8897ae);
+}

--- a/prototypes/entries/gantry-impact-rating/shared/ItemDrawer.tsx
+++ b/prototypes/entries/gantry-impact-rating/shared/ItemDrawer.tsx
@@ -171,11 +171,13 @@ export function ItemDrawer({ item, viewer, goalMode, curatorView, onToggleBoost,
         </div>
 
         <div className={d.footerExtras}>
-          {/* Inert copy of production BuildWithAgentsButton (the real one fires a tracking API call). */}
-          <button type="button" className={shared.buildButton} aria-disabled="true">
+          {/* Frozen copy of the old production BuildWithAgentsButton. Production has since
+              replaced it with a live "Build with AI" button, so .buildButton/.comingSoon are
+              local now; only .buildButtonIcon still exists upstream to borrow. */}
+          <button type="button" className={s.buildButton} aria-disabled="true">
             <MagicSparklesIcon className={shared.buildButtonIcon} />
             <span>Build this with agents</span>
-            <span className={shared.comingSoon}>Coming soon</span>
+            <span className={s.comingSoon}>Coming soon</span>
           </button>
         </div>
       </div>

--- a/utils/gantryAgentPrompt.ts
+++ b/utils/gantryAgentPrompt.ts
@@ -1,0 +1,47 @@
+import { stripHtmlPreservingBreaks } from '@/utils/forum';
+
+/* The backend rejects anything outside these bounds (CreateAgentSessionDto), so
+   we clamp here instead of letting a Quill body that happens to be empty — or a
+   very long one — come back as an undebuggable 400. */
+export const AGENT_PROMPT_MIN_LENGTH = 3;
+export const AGENT_PROMPT_MAX_LENGTH = 20000;
+
+export interface BuiltAgentPrompt {
+  readonly prompt: string;
+  /** Body exceeded the backend limit and was cut short — the UI says so. */
+  readonly isTruncated: boolean;
+  /** Even the title is too thin to submit; the caller must block creation. */
+  readonly isTooShort: boolean;
+}
+
+/* Cut back to the last line or word boundary so the agent never receives a
+   prompt ending mid-word. Falls back to a hard slice when the tail is one
+   unbroken run of characters. */
+function truncateAtBoundary(text: string, limit: number): string {
+  const hardCut = text.slice(0, limit);
+  const boundary = Math.max(hardCut.lastIndexOf('\n'), hardCut.lastIndexOf(' '));
+  return (boundary > limit * 0.5 ? hardCut.slice(0, boundary) : hardCut).trimEnd();
+}
+
+/**
+ * Composes an agent-session prompt from a Gantry item.
+ *
+ * An agent session has no title field — the prompt is its only free text — so
+ * the item's title and description have to travel together in one string.
+ * `description` is Quill HTML, and an "empty" Quill body is `<p><br></p>`,
+ * which is truthy: stripping is what tells us whether there's really a body.
+ */
+export function buildAgentPrompt(title: string, description?: string | null): BuiltAgentPrompt {
+  const trimmedTitle = (title ?? '').trim();
+  const body = description ? stripHtmlPreservingBreaks(description) : '';
+
+  const composed = body ? `${trimmedTitle}\n\n${body}` : trimmedTitle;
+  const isTruncated = composed.length > AGENT_PROMPT_MAX_LENGTH;
+  const prompt = isTruncated ? truncateAtBoundary(composed, AGENT_PROMPT_MAX_LENGTH) : composed;
+
+  return {
+    prompt,
+    isTruncated,
+    isTooShort: prompt.length < AGENT_PROMPT_MIN_LENGTH,
+  };
+}

--- a/utils/gantryAgentSessionStorage.ts
+++ b/utils/gantryAgentSessionStorage.ts
@@ -27,6 +27,17 @@ export function getGantryAgentSessionId(itemUid: string): string | null {
   return readMap()[itemUid] ?? null;
 }
 
+/* Read through useSyncExternalStore rather than an effect, so the value is
+   available without a second render and the server snapshot stays null —
+   localStorage doesn't exist during SSR, and claiming otherwise would
+   hydrate "View session" over a server-rendered "Build with AI". */
+const listeners = new Set<() => void>();
+
+export function subscribeGantryAgentSessions(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
 export function rememberGantryAgentSession(itemUid: string, sessionId: string): void {
   if (typeof window === 'undefined') return;
   try {
@@ -34,4 +45,5 @@ export function rememberGantryAgentSession(itemUid: string, sessionId: string): 
   } catch {
     // Losing the guard only costs a duplicate session; never break the flow.
   }
+  listeners.forEach((listener) => listener());
 }

--- a/utils/gantryAgentSessionStorage.ts
+++ b/utils/gantryAgentSessionStorage.ts
@@ -1,0 +1,37 @@
+/* Nothing links an agent session back to the Gantry item that spawned it — the
+   create endpoint takes only a repository and a prompt, and has no idempotency
+   key. Without a record of what we already started, Back-then-click-again opens
+   a second session and a second PR against the same item.
+
+   This remembers the mapping client-side so the button can offer "View session"
+   instead. It is per-browser by design's absence, not by choice: a different
+   device, a cleared cache, or a second admin all see a fresh button. A durable
+   fix needs the session to carry its originating item on the backend. */
+const STORAGE_KEY = 'gantry-agent-sessions';
+
+type SessionMap = Record<string, string>;
+
+function readMap(): SessionMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' ? (parsed as SessionMap) : {};
+  } catch {
+    // Private mode, quota, or a hand-edited value — treat as "nothing recorded".
+    return {};
+  }
+}
+
+export function getGantryAgentSessionId(itemUid: string): string | null {
+  return readMap()[itemUid] ?? null;
+}
+
+export function rememberGantryAgentSession(itemUid: string, sessionId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...readMap(), [itemUid]: sessionId }));
+  } catch {
+    // Losing the guard only costs a duplicate session; never break the flow.
+  }
+}


### PR DESCRIPTION
## Summary

Wires the Gantry item detail view to the existing Agent Sessions creation flow. Users with `code_agent_sessions.admin` get a **Build with AI** button in the header action cluster; clicking it opens a one-field repository picker and creates a session whose prompt is composed from the item's title and description, then lands on `/pl-infra/agent-sessions/[id]`. Users without the permission render nothing.

Appears in both the `/gantry/[uid]` page and the `?itemId=` drawer, since both share `GantryItemDetailContent`.

### The ticket's premise was wrong — worth knowing

The ticket states Gantry "already ships a disabled 'Build this with agents' + 'Coming soon' control used to measure demand." It doesn't. `BuildWithAgentsButton.tsx` was **dead code, imported nowhere** — the only live copy was a frozen duplicate in `prototypes/`. The backend counter (`POST /v1/roadmap/{uid}/build-button-click`) and the PostHog event `gantry_build_button_clicked` both existed but **had never fired**. No demand signal was ever collected, so any decision resting on that data rested on an empty dataset. This PR is the first time either channel fires.

### Key decisions

- **Why a picker at all**, given "minimal extra UI": `CreateAgentSessionInput` requires `repository`, a `GantryItem` has no repository field, and none can be inferred. One dropdown is the smallest honest surface. `baseBranch` and `createFeatureEnvironment` are omitted and left to backend defaults.
- **Prompt composition**: an agent session has no title field, so title and description travel together in the single `prompt` string. Description is Quill HTML, and an empty Quill body is `<p><br></p>` (truthy) — stripping via `stripHtmlPreservingBreaks` is what reveals whether there's really a body. Blank falls back to title-only; under 3 chars is blocked with inline copy; over 20,000 is truncated at a word boundary with a notice, rather than letting an undebuggable 400 through.
- **Not gated on `canEdit`**: that's stage-limited to `IDEA`/`BACKLOG`, which would hide the button on exactly the items most worth building.
- **Escape handling**: the host `Drawer` listens for Escape on `document` in the bubble phase, so the picker claims the key in the capture phase — otherwise dismissing the popover would tear down the whole drawer behind it.
- **Single source of truth for in-flight state**: `createMutation.isPending` only flips on the next render, so guards reading it are a render behind — that lag let a double-click through in an early version. The component owns an `isCreating` state set in the same commit as a synchronous submit ref, and every guard reads that.
- **Duplicate guard**: Back-then-click-again would open a second session and a second PR, and the endpoint has no idempotency key. The created session id is remembered per item and the button becomes "View session". This is client-side only — per-browser, lost on cache clear, invisible to a second admin. A durable fix needs the session to carry its originating item on the backend.
- **Errors inline, no toasts** — matching both features' existing convention.

## Testing

- **23 tests** across `build-with-agents-button.test.tsx` and `gantryAgentPrompt.test.ts`: permission gating (admin / non-admin / loading / error all assert zero DOM), prompt derivation and truncation, single-POST-on-double-click, single-flight dismissal, viewport clamping, inline error + retry, the duplicate guard, and a11y (dialog role, accessible name, focus, Escape not reaching a host drawer).
- Full gantry suite green: **62 tests passing**. `eslint` and `tsc` clean on all changed files; both touched SCSS modules compile.
- **Manually verified** on the Gantry detail page and drawer by @VERZUOL1.

## Code review — all findings resolved

An automated review flagged two issues above the reporting threshold; both are fixed in `5e7a4a837`:

1. **Deleting `.buildButton`/`.comingSoon` broke a live prototype.** `prototypes/entries/gantry-impact-rating/shared/ItemDrawer.tsx` borrows those styles from the production module rather than defining its own, and it's a registered route. Production no longer has that control, so keeping the rules upstream would be orphaned CSS — the prototype now owns a frozen copy instead: production's literal sizes, colors translated to token pairs per `prototypes/CLAUDE.md`.
2. **Dismissing the picker mid-creation didn't stop the navigation.** Only Cancel was disabled; Escape, the backdrop and the header close still dismissed it, hiding — but not cancelling — the request, so the user landed in a session they thought they'd backed out of. All three now route through one guarded `dismiss()`, matching `BoostImpactPopover`'s documented single-flight convention.

Five lower-confidence findings are also fixed in `0de2cd4db`: the popover's hardcoded 260px height guess (it now measures and clamps both axes, since it grows as notices stack and `.popover` is `overflow: hidden`); a dead `canSubmit` prop; a no-op `position: relative` whose comment claimed it anchored the popover; an empty `.itemActions` wrapper consuming 16px of title width for viewers with no actions; and a uid-change reset justified by a comment claiming the drawer keeps this mounted, which `key={itemId}` contradicts.

## Follow-ups (not in this PR)

- The duplicate guard is localStorage-only. A durable fix needs a backend link from a session to its originating Gantry item.
- Should the button hide on `SHIPPED`/`DECLINED`/archived items? It currently shows on all stages.
- `acceptanceCriteria` is not included in the prompt (title + description only), though it may be valuable to the agent.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)